### PR TITLE
Make Everstore match existing dataset API

### DIFF
--- a/classy_vision/dataset/core/batch_dataset.py
+++ b/classy_vision/dataset/core/batch_dataset.py
@@ -51,10 +51,11 @@ class BatchDataset(Dataset):
             sample = self.dataset[n]
             if not self.filter_func(sample):
                 continue
-            if torch.is_tensor(sample):
-                sample = sample
             batch.append(sample)
         # batch data:
+        if len(batch) == 0:
+            return None
+
         batch = default_collate(batch)
         return batch
 

--- a/classy_vision/dataset/transforms/util.py
+++ b/classy_vision/dataset/transforms/util.py
@@ -30,6 +30,9 @@ class FieldTransform:
 
     def __call__(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Updates sample by applying a transform and to the appropriate key."""
+        if sample is None:
+            return sample
+
         assert isinstance(sample, dict) and self.key in sample, (
             "This transform only supports dicts with key '%s'" % self.key
         )

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -97,6 +97,23 @@ def is_on_gpu(model):
     return has_params and on_gpu
 
 
+def is_not_none(sample):
+    """
+    Returns True if sample is not None and constituents are not none.
+    """
+    if sample is None:
+        return False
+
+    if isinstance(sample, (list, tuple)):
+        if any(s is None for s in sample):
+            return False
+
+    if isinstance(sample, dict):
+        if any(s is None for s in sample.values()):
+            return False
+    return True
+
+
 def copy_model_to_gpu(model, criterion=None):
     """
     Copies a model and (optional) criterion to GPU and enables cudnn benchmarking.


### PR DESCRIPTION
Summary:
As I tried to work on the downstream diffs some of the internal datasets which have sample fetch failures had a different API and this was causing me headaches. This migrates the API for those datasets to fetch single samples and instead prefetch the data to avoid complications around batching, etc.

This involved:

1. Making sure that we can ignore Nones in the batching and transforms so I had to add some extra parameters to the transforms for ignoring Nones if desired (this is what needs to be synced with github).
2. Modifying all downstream datasets
3. Adding prefetching to the Everstore dataset.
4. Found some small UI changes to the internal benchmark to make it easier to use.

I then verified that performance was fine. The performance turned out to be faster than I measured on the previous benchmark, I'm still not sure why this is, but I added functionality to the benchmark to print out a tensor for visual inspection and the data appears to be fine.

As a note, I was trying to figure out if we can switch to spawn here and ran into a host of problems which was what was blocking this work, so I will save that for a later diff.

Differential Revision: D17266435

