### PR TITLE
Switch transforms to .from_config idiom

### DIFF
--- a/classy_vision/dataset/core/transform_dataset.py
+++ b/classy_vision/dataset/core/transform_dataset.py
@@ -27,10 +27,7 @@ class TransformDataset(Dataset):
         assert idx >= 0 and idx < len(self.dataset)
         sample = self.dataset[idx]
         for transform in self._transform:
-            try:  # transform may not implement `idx` as secondary input
-                sample = transform(sample, idx)
-            except TypeError:
-                sample = transform(sample)
+            sample = transform(sample)
         return sample
 
     def __len__(self):

--- a/classy_vision/dataset/transforms/__init__.py
+++ b/classy_vision/dataset/transforms/__init__.py
@@ -11,6 +11,8 @@ from typing import Any, Callable, Dict, List, Union
 import torchvision.transforms as transforms
 from classy_vision.generic.registry_utils import import_all_modules
 
+from .classy_transform import ClassyTransform
+
 
 FILE_ROOT = Path(__file__).parent
 
@@ -30,7 +32,7 @@ def build_transform(transform_config: Dict[str, Any]) -> Callable:
     transform_args = transform_config.copy()
     del transform_args["name"]
     if name in TRANSFORM_REGISTRY:
-        return TRANSFORM_REGISTRY[name](**transform_args)
+        return TRANSFORM_REGISTRY[name].from_config(transform_args)
     # the name should be available in torchvision.transforms
     assert hasattr(transforms, name), (
         f"{name} isn't a registered tranform"
@@ -85,3 +87,10 @@ def register_transform(name: str):
 
 # automatically import any Python files in the transforms/ directory
 import_all_modules(FILE_ROOT, "classy_vision.dataset.transforms")
+
+__all__ = [
+    "ClassyTransform",
+    "LightingTransform",
+    "register_transform",
+    "build_transform",
+]

--- a/classy_vision/dataset/transforms/classy_transform.py
+++ b/classy_vision/dataset/transforms/classy_transform.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class ClassyTransform(ABC):
+    @abstractmethod
+    def __call__(self, image):
+        pass
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]):
+        return cls(**config)

--- a/classy_vision/dataset/transforms/lighting_transform.py
+++ b/classy_vision/dataset/transforms/lighting_transform.py
@@ -7,6 +7,7 @@
 import torch
 
 from . import register_transform
+from .classy_transform import ClassyTransform
 
 
 _IMAGENET_EIGEN_VAL = [0.2175, 0.0188, 0.0045]
@@ -20,7 +21,7 @@ _DEFAULT_COLOR_LIGHTING_STD = 0.1
 
 
 @register_transform("lighting")
-class LightingTransform:
+class LightingTransform(ClassyTransform):
     """
     Lighting noise(AlexNet - style PCA - based noise).
     This trick was originally used in AlexNet paper

--- a/classy_vision/dataset/transforms/util.py
+++ b/classy_vision/dataset/transforms/util.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import torchvision.transforms as transforms
 
-from . import build_transforms, register_transform
+from . import ClassyTransform, build_transforms, register_transform
 
 
 class ImagenetConstants:
@@ -38,36 +38,46 @@ class FieldTransform:
 
 
 @register_transform("imagenet_augment")
-def imagenet_augment_transform(
-    crop_size: int = ImagenetConstants.CROP_SIZE,
-    mean: List[float] = ImagenetConstants.MEAN,
-    std: List[float] = ImagenetConstants.STD,
-) -> Callable:
-    return transforms.Compose(
-        [
-            transforms.RandomResizedCrop(crop_size),
-            transforms.RandomHorizontalFlip(),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=mean, std=std),
-        ]
-    )
+class imagenet_augment_transform(ClassyTransform):
+    def __init__(
+        self,
+        crop_size: int = ImagenetConstants.CROP_SIZE,
+        mean: List[float] = ImagenetConstants.MEAN,
+        std: List[float] = ImagenetConstants.STD,
+    ):
+        self.transform = transforms.Compose(
+            [
+                transforms.RandomResizedCrop(crop_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=mean, std=std),
+            ]
+        )
+
+    def __call__(self, img):
+        return self.transform(img)
 
 
 @register_transform("imagenet_no_augment")
-def imagenet_no_augment_transform(
-    resize: int = ImagenetConstants.RESIZE,
-    crop_size: int = ImagenetConstants.CROP_SIZE,
-    mean: List[float] = ImagenetConstants.MEAN,
-    std: List[float] = ImagenetConstants.STD,
-) -> Callable:
-    return transforms.Compose(
-        [
-            transforms.Resize(resize),
-            transforms.CenterCrop(crop_size),
-            transforms.ToTensor(),
-            transforms.Normalize(mean=mean, std=std),
-        ]
-    )
+class imagenet_no_augment_transform(ClassyTransform):
+    def __init__(
+        self,
+        resize: int = ImagenetConstants.RESIZE,
+        crop_size: int = ImagenetConstants.CROP_SIZE,
+        mean: List[float] = ImagenetConstants.MEAN,
+        std: List[float] = ImagenetConstants.STD,
+    ):
+        self.transform = transforms.Compose(
+            [
+                transforms.Resize(resize),
+                transforms.CenterCrop(crop_size),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=mean, std=std),
+            ]
+        )
+
+    def __call__(self, img):
+        return self.transform(img)
 
 
 def build_field_transform_default_imagenet(

--- a/test/dataset_transforms_test.py
+++ b/test/dataset_transforms_test.py
@@ -8,18 +8,30 @@ import unittest
 
 import torch
 import torchvision.transforms as transforms
-from classy_vision.dataset.transforms import build_transforms, register_transform
+from classy_vision.dataset.transforms import (
+    ClassyTransform,
+    build_transforms,
+    register_transform,
+)
 from classy_vision.dataset.transforms.util import imagenet_no_augment_transform
 
 
 @register_transform("resize")
-def resize(size: int):
-    return transforms.Resize(size=size)
+class resize(ClassyTransform):
+    def __init__(self, size: int):
+        self.transform = transforms.Resize(size=size)
+
+    def __call__(self, img):
+        return self.transform(img)
 
 
 @register_transform("center_crop")
-def center_crop(size: int):
-    return transforms.CenterCrop(size=size)
+class center_crop(ClassyTransform):
+    def __init__(self, size: int):
+        self.transform = transforms.CenterCrop(size=size)
+
+    def __call__(self, img):
+        return self.transform(img)
 
 
 class DatasetTransformsTest(unittest.TestCase):


### PR DESCRIPTION
Summary:
I was originally against a ClassyTransform abstraction, but I've come around.
All other Classy things implement a from_config method, so we need a
ClassyTransform as well. That gives us the flexibility of implementing
transforms where the dictionary can't be mapped directly to arguments in the
constructor.

Differential Revision: D17578366

