### PR TITLE
support dict input in Classy module and head

### DIFF
--- a/classy_vision/heads/classy_vision_head.py
+++ b/classy_vision/heads/classy_vision_head.py
@@ -27,3 +27,9 @@ class ClassyVisionHead(nn.Module):
 
     def forward(self, x):
         raise NotImplementedError
+
+    def requires_dict_input(self):
+        """
+        Override this function if the head expects dict input
+        """
+        return False

--- a/classy_vision/models/classy_vision_model.py
+++ b/classy_vision/models/classy_vision_model.py
@@ -9,7 +9,7 @@ import logging
 
 import torch.nn as nn
 
-from .classy_module import ClassyModule
+from .classy_module import ClassyModule, ClassyModuleWithDictInput
 
 
 class ClassyVisionModel(nn.Module):
@@ -78,13 +78,23 @@ class ClassyVisionModel(nn.Module):
     def summarize(self):
         raise NotImplementedError
 
+    def requires_dict_input(self):
+        """
+        Override this function if the model input is dict and the dict is
+        expected to be used in heads
+        """
+        return False
+
     def build_attachable_block(self, name, module):
         """
         Add a wrapper to the module to allow to attach heads to the module.
         """
         if name in self._attachable_blocks:
             raise ValueError("Found duplicated block name {}".format(name))
-        block = ClassyModule(name, module)
+        if not self.requires_dict_input():
+            block = ClassyModule(name, module)
+        else:
+            block = ClassyModuleWithDictInput(name, module)
         self._attachable_blocks[name] = block
         return block
 


### PR DESCRIPTION
Summary:
We have one head that needs extra feature input in addition to image tensor. The extra input is generated from the image.
Right now, in head execution, we assume each head only takes output of the forked layer as input, which makes it hard to pass in extra input. In more general cases, we may want to pass in metadata of image to the head, so supporting dict as input can allows us to encapsulate more input data.

Differential Revision: D17585529

