### PR TITLE
Stop storing configs in datasets

### DIFF
--- a/classy_vision/dataset/classy_cifar.py
+++ b/classy_vision/dataset/classy_cifar.py
@@ -58,7 +58,7 @@ class CifarDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         default_transform = (
             _cifar_augment_transform()
             if self._split == "train"

--- a/classy_vision/dataset/classy_coco.py
+++ b/classy_vision/dataset/classy_coco.py
@@ -65,7 +65,7 @@ class CocoDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_cub2011.py
+++ b/classy_vision/dataset/classy_cub2011.py
@@ -36,7 +36,7 @@ class Cub2011Dataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -32,7 +32,6 @@ class ClassyDataset(Dataset):
         Classy Dataloader constructor.
         """
         # Assignments:
-        self._config = config
         self._split = config["split"] if "split" in config else None
         self.dataset = None
 
@@ -130,7 +129,6 @@ class ClassyDataset(Dataset):
     def get_classy_state(self):
         """Get state for object (e.g. shuffle)"""
         return {
-            "config": self._config,
             "split": self._split,
             "state": {"dataset_type": type(self)},
             "wrapped_state": self.dataset.get_classy_state()
@@ -144,7 +142,6 @@ class ClassyDataset(Dataset):
             "Type of saved state does not match current object. "
             "If intentional, use non-strict flag"
         )
-        self._config = state["config"]
         self._split = state["split"]
         if self.dataset is not None:
             self.dataset.set_classy_state(state["wrapped_state"])

--- a/classy_vision/dataset/classy_imagenet.py
+++ b/classy_vision/dataset/classy_imagenet.py
@@ -42,7 +42,7 @@ class ImagenetDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_omniglot.py
+++ b/classy_vision/dataset/classy_omniglot.py
@@ -65,7 +65,7 @@ class OmniglotDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_oxford_flowers.py
+++ b/classy_vision/dataset/classy_oxford_flowers.py
@@ -133,7 +133,7 @@ class OxfordFlowersDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_pascal.py
+++ b/classy_vision/dataset/classy_pascal.py
@@ -105,7 +105,7 @@ class PascalDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_places365.py
+++ b/classy_vision/dataset/classy_places365.py
@@ -42,7 +42,7 @@ class Places365Dataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_sun397.py
+++ b/classy_vision/dataset/classy_sun397.py
@@ -31,7 +31,7 @@ class Sun397Dataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_svhn.py
+++ b/classy_vision/dataset/classy_svhn.py
@@ -30,7 +30,7 @@ class SVHNDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         transform = build_field_transform_default_imagenet(
             transform_config, split=self._split
         )

--- a/classy_vision/dataset/classy_synthetic_image.py
+++ b/classy_vision/dataset/classy_synthetic_image.py
@@ -28,7 +28,7 @@ class SyntheticImageClassificationDataset(ClassyDataset):
             batchsize_per_replica,
             shuffle,
             num_samples,
-        ) = self.parse_config(self._config)
+        ) = self.parse_config(config)
         default_transform = transforms.Compose(
             [
                 transforms.ToTensor(),

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -110,12 +110,11 @@ class TestClassyDataset(unittest.TestCase):
 
     def test_get_set_classy_state(self):
         state = self.dataset1.get_classy_state()
-        self.assertEqual(state["config"], DUMMY_CONFIG)
         self.assertEqual(
             state["wrapped_state"], self.dataset1.dataset.get_classy_state()
         )
 
-        new_config = state["config"]
+        new_config = DUMMY_CONFIG.copy()
         new_config["dummy2"] = 2
         state["config"] = new_config
         self.dataset1.set_classy_state(state)


### PR DESCRIPTION
Summary:
In preparation to switch datasets to a .from_config constructor, make sure no
datasets store the config itself as a member of the class. This makes things
easier later.

Differential Revision: D17578858

