### PR TITLE
Set small_input attribute in Densenet

### DIFF
--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -136,8 +136,8 @@ class DenseNet(ClassyVisionModel):
 
         # initial convolutional block:
         self.num_blocks = config["num_blocks"]
-        small_input = config["small_input"]
-        if small_input:
+        self.small_input = config["small_input"]
+        if self.small_input:
             self.initial_block = nn.Sequential(
                 nn.Conv2d(
                     3,


### PR DESCRIPTION
Summary: `DenseNet.input_shape` calls `self.small_input`, which isn't defined currently.

Differential Revision: D17628854

