### PR TITLE
Make Everstore match existing dataset API (#16)

### DIFF
--- a/classy_vision/dataset/core/batch_dataset.py
+++ b/classy_vision/dataset/core/batch_dataset.py
@@ -51,10 +51,11 @@ class BatchDataset(Dataset):
             sample = self.dataset[n]
             if not self.filter_func(sample):
                 continue
-            if torch.is_tensor(sample):
-                sample = sample
             batch.append(sample)
         # batch data:
+        if len(batch) == 0:
+            return None
+
         batch = default_collate(batch)
         return batch
 

--- a/classy_vision/dataset/transforms/util.py
+++ b/classy_vision/dataset/transforms/util.py
@@ -30,6 +30,9 @@ class FieldTransform:
 
     def __call__(self, sample: Dict[str, Any]) -> Dict[str, Any]:
         """Updates sample by applying a transform and to the appropriate key."""
+        if sample is None:
+            return sample
+
         assert isinstance(sample, dict) and self.key in sample, (
             "This transform only supports dicts with key '%s'" % self.key
         )

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -97,6 +97,23 @@ def is_on_gpu(model):
     return has_params and on_gpu
 
 
+def is_not_none(sample):
+    """
+    Returns True if sample is not None and constituents are not none.
+    """
+    if sample is None:
+        return False
+
+    if isinstance(sample, (list, tuple)):
+        if any(s is None for s in sample):
+            return False
+
+    if isinstance(sample, dict):
+        if any(s is None for s in sample.values()):
+            return False
+    return True
+
+
 def copy_model_to_gpu(model, criterion=None):
     """
     Copies a model and (optional) criterion to GPU and enables cudnn benchmarking.


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/ClassyVision/pull/16

Pull Request resolved: https://github.com/fairinternal/ClassyVision/pull/2

As I tried to work on the downstream diffs some of the internal datasets which have sample fetch failures had a different API and this was causing me headaches. In particular, most of the dataset API is reimplemented for the everstore dataset (particularly the batching and transformation logic). This made the downstream work to refactor and ultimately delete this logic twice as complicated since I effectively had to do it twice (one for canonical datasets and once for the everstore datasets).

This diff migrates the API for those datasets to fetch single samples and use the dataset wrappers like all of the other Classy datasets (so future migrations happen only once). This has performance implications since the original goal of separate batching logic was to issue multiple everstore requests simultaneously, so I also had to make a change to prefetch the upcoming samples to make sure performance was still good.

This involved:

1. Everstore batching / transformation logic dealt with missing samples (None's), so I had to move some of that logic to the "is_not_none" filter function and add a ignore none's option to the transforms.
2. Modifying all downstream datasets (e.g. the visual relevance team's datasets, also made max_samples -> num_samples to match all other datasets)
3. Adding prefetching to the Everstore dataset for performance.
4. Found some small CLI changes to the internal benchmark to make it easier to use by displaying samples when needed.

I then verified that performance was fine. The performance turned out to be faster than I measured on the previous benchmark, I'm still not sure why this is, but I added functionality to the benchmark to print out a tensor for visual inspection and the data appears to be fine.

As a note, I was trying to figure out if we can switch to spawn here and ran into a host of problems which was what was blocking this work, so I will save that for a later diff.

Differential Revision: D17266435

