### PR TITLE
Improve imports for criterions

### DIFF
--- a/classy_vision/criterions/__init__.py
+++ b/classy_vision/criterions/__init__.py
@@ -69,3 +69,22 @@ def register_criterion(name):
 
 # automatically import any Python files in the criterion/ directory
 import_all_modules(FILE_ROOT, "classy_vision.criterions")
+
+
+from .barron_loss import BarronLoss  # isort:skip
+from .label_smoothing_criterion import LabelSmoothingCrossEntropyLoss  # isort:skip
+from .multi_output_sum_loss import MultiOutputSumLoss  # isort:skip
+from .soft_target_cross_entropy_loss import SoftTargetCrossEntropyLoss  # isort:skip
+from .sum_arbitrary_loss import SumArbitraryLoss  # isort:skip
+
+
+__all__ = [
+    "BarronLoss",
+    "ClassyCriterion",
+    "LabelSmoothingCrossEntropyLoss",
+    "MultiOutputSumLoss",
+    "SoftTargetCrossEntropyLoss",
+    "SumArbitraryLoss",
+    "build_criterion",
+    "register_criterion",
+]

--- a/classy_vision/criterions/label_smoothing_criterion.py
+++ b/classy_vision/criterions/label_smoothing_criterion.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import numpy as np
-import torch
 from classy_vision.criterions import ClassyCriterion, register_criterion
 from classy_vision.criterions.soft_target_cross_entropy_loss import (
     _SoftTargetCrossEntropyLoss,

--- a/test/criterions_barron_loss_test.py
+++ b/test/criterions_barron_loss_test.py
@@ -8,8 +8,7 @@ import copy
 import unittest
 
 import torch
-from classy_vision.criterions import build_criterion
-from classy_vision.criterions.barron_loss import BarronLoss
+from classy_vision.criterions import BarronLoss, build_criterion
 
 
 class TestBarronLoss(unittest.TestCase):

--- a/test/criterions_label_smoothing_cross_entropy_loss_test.py
+++ b/test/criterions_label_smoothing_cross_entropy_loss_test.py
@@ -8,10 +8,7 @@ import copy
 import unittest
 
 import torch
-from classy_vision.criterions import build_criterion
-from classy_vision.criterions.label_smoothing_criterion import (
-    LabelSmoothingCrossEntropyLoss,
-)
+from classy_vision.criterions import LabelSmoothingCrossEntropyLoss, build_criterion
 
 
 class TestLabelSmoothingCrossEntropyLoss(unittest.TestCase):

--- a/test/criterions_multi_output_sum_loss_test.py
+++ b/test/criterions_multi_output_sum_loss_test.py
@@ -9,10 +9,10 @@ import unittest
 import torch
 from classy_vision.criterions import (
     ClassyCriterion,
+    MultiOutputSumLoss,
     build_criterion,
     register_criterion,
 )
-from classy_vision.criterions.multi_output_sum_loss import MultiOutputSumLoss
 
 
 @register_criterion("mock_1")

--- a/test/criterions_soft_target_cross_entropy_loss_test.py
+++ b/test/criterions_soft_target_cross_entropy_loss_test.py
@@ -8,10 +8,7 @@ import copy
 import unittest
 
 import torch
-from classy_vision.criterions import build_criterion
-from classy_vision.criterions.soft_target_cross_entropy_loss import (
-    SoftTargetCrossEntropyLoss,
-)
+from classy_vision.criterions import SoftTargetCrossEntropyLoss, build_criterion
 
 
 class TestSoftTargetCrossEntropyLoss(unittest.TestCase):

--- a/test/criterions_sum_arbitrary_loss_test.py
+++ b/test/criterions_sum_arbitrary_loss_test.py
@@ -10,10 +10,10 @@ import unittest
 import torch
 from classy_vision.criterions import (
     ClassyCriterion,
+    SumArbitraryLoss,
     build_criterion,
     register_criterion,
 )
-from classy_vision.criterions.sum_arbitrary_loss import SumArbitraryLoss
 
 
 @register_criterion("mock_a")


### PR DESCRIPTION
Summary:
Import all the criterions in `__init__.py` and add them to `__all__`

Removed `import_all_modules` since it is not needed anyway and can cause people to forget importing future modules.

Differential Revision: D17632979

