### PR TITLE
Remove num_workers and pin_memory from ClassyTask constructor

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -101,7 +101,7 @@ def main(args):
     if args.visdom_server != "":
         hooks.append(VisdomHook(args.visdom_server, args.visdom_port))
 
-    trainer = ClassyTrainer(hooks, args.device == "gpu")
+    trainer = ClassyTrainer(hooks, args.device == "gpu", num_workers=args.num_workers)
     trainer.train(task)
 
 

--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -12,19 +12,23 @@ from classy_vision.state.classy_state import ClassyState
 
 
 class ClassyTrainer:
-    def __init__(self, hooks, use_gpu):
+    def __init__(self, hooks, use_gpu, num_workers=0):
         assert isinstance(hooks, list)
         assert all(isinstance(hook, ClassyHook) for hook in hooks)
 
         self.hooks = hooks
         self.use_gpu = use_gpu
+        self.num_workers = num_workers
 
     def train(self, task):
         """
         Runs training phases, phases are generated from the config.
         """
 
-        state = task.build_initial_state()
+        pin_memory = self.use_gpu and torch.cuda.device_count() > 1
+        state = task.build_initial_state(
+            num_workers=self.num_workers, pin_memory=pin_memory
+        )
         assert isinstance(state, ClassyState)
 
         if self.use_gpu:

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -72,8 +72,6 @@ class TestParamSchedulerIntegration(unittest.TestCase):
             optimizer_config=config["optimizer"],
             meter_config=config["meters"],
             test_only=False,
-            num_workers=0,
-            pin_memory=False,
         ).set_criterion(build_criterion(config["criterion"]))
 
         self.assertTrue(task is not None)

--- a/test/tasks_classy_vision_task_test.py
+++ b/test/tasks_classy_vision_task_test.py
@@ -30,13 +30,11 @@ class TestClassyVisionTask(unittest.TestCase):
             optimizer_config=config["optimizer"],
             meter_config={},
             test_only=False,
-            num_workers=1,
-            pin_memory=False,
         ).set_criterion(criterion)
 
-        state = task.build_initial_state()
+        state = task.build_initial_state(num_workers=1, pin_memory=False)
         self.assertTrue(state is not None)
 
         args = get_test_args()
         task = setup_task(config, args)
-        state = task.build_initial_state()
+        state = task.build_initial_state(num_workers=1, pin_memory=False)

--- a/test/trainer_test.py
+++ b/test/trainer_test.py
@@ -70,8 +70,6 @@ class TestClassyTrainer(unittest.TestCase):
             optimizer_config=config["optimizer"],
             meter_config=config["meters"],
             test_only=False,
-            num_workers=0,
-            pin_memory=False,
         ).set_criterion(build_criterion(config["criterion"]))
         self.assertTrue(task is not None)
 


### PR DESCRIPTION
Summary:
pin_memory is a setting that only makes sense when training on GPUs. So move
that to build_initial_state which happens to get called whenever a Trainer is
instantiated.

Differential Revision: D17658720

