### PR TITLE
Plot meters to tensorboard

### DIFF
--- a/classy_vision/hooks/__init__.py
+++ b/classy_vision/hooks/__init__.py
@@ -11,11 +11,11 @@ from classy_vision.generic.registry_utils import import_all_modules
 from .checkpoint_hook import CheckpointHook
 from .classy_hook import ClassyHook, ClassyHookFunctions
 from .loss_lr_meter_logging_hook import LossLrMeterLoggingHook
-from .loss_lr_tensorboard_hook import LossLrTensorboardHook
 from .model_complexity_hook import ModelComplexityHook
 from .model_tensorboard_hook import ModelTensorboardHook
 from .profiler_hook import ProfilerHook
 from .progress_bar_hook import ProgressBarHook
+from .tensorboard_plot_hook import TensorboardPlotHook
 from .time_metrics_hook import TimeMetricsHook
 from .visdom_hook import VisdomHook
 
@@ -25,7 +25,7 @@ __all__ = [
     "ClassyHook",
     "ClassyHookFunctions",
     "LossLrMeterLoggingHook",
-    "LossLrTensorboardHook",
+    "TensorboardPlotHook",
     "ModelComplexityHook",
     "ModelTensorboardHook",
     "ProfilerHook",


### PR DESCRIPTION
Summary: Renamed `LossLrTensorboardHook` to `TensorboardPlotHook` and plot the meters to tensorboard as well (apart from the loss and lr).

Reviewed By: vreis

Differential Revision: D17646340

