### PR TITLE
Remove meters from ClassyTask constructor

### DIFF
--- a/classy_vision/meters/__init__.py
+++ b/classy_vision/meters/__init__.py
@@ -18,7 +18,14 @@ METER_REGISTRY = {}
 
 
 def build_meter(config):
-    return METER_REGISTRY[config["name"]].from_config(config)
+    instance = METER_REGISTRY[config["name"]].from_config(config)
+    instance._config_DO_NOT_USE = config
+    return instance
+
+
+def build_meters(config):
+    configs = [{"name": name, **args} for name, args in config.items()]
+    return [build_meter(config) for config in configs]
 
 
 def register_meter(name):

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -69,7 +69,6 @@ class TestParamSchedulerIntegration(unittest.TestCase):
             dataset_config=config["dataset"],
             model_config=config["model"],
             optimizer_config=config["optimizer"],
-            meter_config=config["meters"],
         ).set_criterion(build_criterion(config["criterion"]))
 
         self.assertTrue(task is not None)

--- a/test/tasks_classy_vision_task_test.py
+++ b/test/tasks_classy_vision_task_test.py
@@ -27,7 +27,6 @@ class TestClassyVisionTask(unittest.TestCase):
             dataset_config=config["dataset"],
             model_config=config["model"],
             optimizer_config=config["optimizer"],
-            meter_config={},
         ).set_criterion(criterion)
 
         state = task.build_initial_state(num_workers=1, pin_memory=False)

--- a/test/trainer_test.py
+++ b/test/trainer_test.py
@@ -7,6 +7,7 @@
 import unittest
 
 from classy_vision.criterions import build_criterion
+from classy_vision.meters.accuracy_meter import AccuracyMeter
 from classy_vision.tasks.classy_vision_task import ClassyVisionTask
 from classy_vision.trainer import ClassyTrainer
 
@@ -62,13 +63,16 @@ class TestClassyTrainer(unittest.TestCase):
     def test_cpu_training(self):
         """Checks we can train a small MLP model on a CPU."""
         config = self._get_config()
-        task = ClassyVisionTask(
-            num_phases=10,
-            dataset_config=config["dataset"],
-            model_config=config["model"],
-            optimizer_config=config["optimizer"],
-            meter_config=config["meters"],
-        ).set_criterion(build_criterion(config["criterion"]))
+        task = (
+            ClassyVisionTask(
+                num_phases=10,
+                dataset_config=config["dataset"],
+                model_config=config["model"],
+                optimizer_config=config["optimizer"],
+            )
+            .set_criterion(build_criterion(config["criterion"]))
+            .set_meters([AccuracyMeter(topk=[1])])
+        )
         self.assertTrue(task is not None)
 
         trainer = ClassyTrainer(hooks=[], use_gpu=False)


### PR DESCRIPTION
Summary:
Instead of taking the meters config in the constructor, store the meter
instances themselves in ClassyTask. Meters can be added with an `add_meter`
method.

Differential Revision: D17659504

