### PR TITLE
Switch datasets to .from_config idiom

### DIFF
--- a/classy_vision/dataset/__init__.py
+++ b/classy_vision/dataset/__init__.py
@@ -18,7 +18,7 @@ DATASET_CLASS_NAMES = set()
 
 
 def build_dataset(config, *args, **kwargs):
-    return DATASET_REGISTRY[config["name"]](config, *args, **kwargs)
+    return DATASET_REGISTRY[config["name"]].from_config(config, *args, **kwargs)
 
 
 def get_available_splits(dataset_name):

--- a/classy_vision/dataset/classy_cifar.py
+++ b/classy_vision/dataset/classy_cifar.py
@@ -75,6 +75,10 @@ class CifarDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # set up CIFAR dataset:
         set_proxies()

--- a/classy_vision/dataset/classy_coco.py
+++ b/classy_vision/dataset/classy_coco.py
@@ -77,6 +77,10 @@ class CocoDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         annot_suffix = _get_annot_suffix(self._split)
         annot_file = os.path.join(

--- a/classy_vision/dataset/classy_cub2011.py
+++ b/classy_vision/dataset/classy_cub2011.py
@@ -48,6 +48,10 @@ class Cub2011Dataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # find location of images:
         img_dir = None

--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -35,6 +35,10 @@ class ClassyDataset(Dataset):
         self._split = config["split"] if "split" in config else None
         self.dataset = None
 
+    @classmethod
+    def from_config(cls, config):
+        raise NotImplementedError()
+
     def parse_config(self, config):
         """
         This function parses out common config options. Those options are

--- a/classy_vision/dataset/classy_imagenet.py
+++ b/classy_vision/dataset/classy_imagenet.py
@@ -54,6 +54,10 @@ class ImagenetDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # find location of images
         img_dir = None

--- a/classy_vision/dataset/classy_omniglot.py
+++ b/classy_vision/dataset/classy_omniglot.py
@@ -77,6 +77,10 @@ class OmniglotDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # monkey-patch ImageFolder:
         orig_find_classes = datasets.folder.DatasetFolder._find_classes

--- a/classy_vision/dataset/classy_oxford_flowers.py
+++ b/classy_vision/dataset/classy_oxford_flowers.py
@@ -145,6 +145,10 @@ class OxfordFlowersDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # find location of images:
         img_dir = None

--- a/classy_vision/dataset/classy_pascal.py
+++ b/classy_vision/dataset/classy_pascal.py
@@ -117,6 +117,10 @@ class PascalDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # assertions:
         assert self._pascal_version in ["voc2007", "voc2012"]

--- a/classy_vision/dataset/classy_places365.py
+++ b/classy_vision/dataset/classy_places365.py
@@ -54,6 +54,10 @@ class Places365Dataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # find location of images:
         img_dir = None

--- a/classy_vision/dataset/classy_sun397.py
+++ b/classy_vision/dataset/classy_sun397.py
@@ -43,6 +43,10 @@ class Sun397Dataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         # TODO(aadcock): allow access to predefined train / test splits
         # SUN397 defines 10 different train/test splits,

--- a/classy_vision/dataset/classy_svhn.py
+++ b/classy_vision/dataset/classy_svhn.py
@@ -42,6 +42,10 @@ class SVHNDataset(ClassyDataset):
             subsample=num_samples,
         )
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
     def _load_dataset(self):
         set_proxies()
         dataset = datasets.SVHN(DATA_PATH, split=self._split, download=True)

--- a/classy_vision/dataset/classy_synthetic_image.py
+++ b/classy_vision/dataset/classy_synthetic_image.py
@@ -47,3 +47,7 @@ class SyntheticImageClassificationDataset(ClassyDataset):
             shuffle=shuffle,
             subsample=num_samples,
         )
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -39,6 +39,10 @@ class TestDataset(ClassyDataset):
         target_tensors = [sample["target"] for sample in samples]
         self.dataset = ListDataset(input_tensors, target_tensors, loader=lambda x: x)
 
+    @classmethod
+    def from_config(cls, config, *args, **kwargs):
+        return cls(config, *args, **kwargs)
+
 
 @register_dataset("other_test_dataset")
 class OtherTestDataset(ClassyDataset):
@@ -57,6 +61,10 @@ class OtherTestDataset(ClassyDataset):
         input_tensors = [sample["input"] for sample in self.samples]
         target_tensors = [sample["target"] for sample in self.samples]
         self.dataset = ListDataset(input_tensors, target_tensors, loader=lambda x: x)
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
 
 
 class TestRegistryFunctions(unittest.TestCase):


### PR DESCRIPTION
Summary:
Datasets are not for the faint of heart. Unlike the other
abstractions, I cannot do the migration to .from_config with a single diff.
Instead, I'm adding a .from_config method that passes the config to the
constructor. That way each class can be migrated on its own.

Differential Revision: D17689190

