### PR TITLE
Create an image dataset to load local data

### DIFF
--- a/classy_vision/dataset/image_path_dataset.py
+++ b/classy_vision/dataset/image_path_dataset.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os.path
+
+import torchvision.datasets as datasets
+
+from .classy_dataset import ClassyDataset
+from .core import ListDataset, WrapDataset
+from .transforms.util import build_field_transform_default_imagenet
+
+
+def _transform_sample(sample):
+    return {"input": sample["input"][0], "target": sample["input"][1]}
+
+
+class ImagePathDataset(ClassyDataset):
+    """
+    A ClassyDataset class which reads images from image paths.
+
+    image_paths: Can be
+        - A single directory location, in which case the data is expected to be
+            arranged in a format similar to torchvision.datasets.ImageFolder.
+            The targets will be inferred from the directory structure.
+        - A list of paths, in which case the list will contain the paths to all the
+            images. In this situation, the targets can be specified by the targets
+            argument.
+    targets (optional): A list containing the target classes for each image
+    default_transform (optional): Transform to apply if one isn't specified in the
+        config. If left as None, the dataset's split is used to determine the
+        imagenet transform to apply.
+    split (optional): The dataset's split
+    """
+
+    def __init__(
+        self,
+        config,
+        image_paths=None,
+        targets=None,
+        default_transform=None,
+        split="train",
+    ):
+        # TODO(@mannatsingh): we should be able to call build_dataset() to create
+        # datasets from this class.
+        assert image_paths is not None, "image_paths needs to be provided"
+        assert targets is None or isinstance(image_paths, list), (
+            "targets cannot be specified when image_paths is a directory containing "
+            "the targets in the directory structure"
+        )
+        assert (
+            config.setdefault("split", split) == split
+        ), "Passed conflicting splits in config and arg"
+        super().__init__(config)
+
+        dataset = self._load_dataset(image_paths, targets)
+        (
+            transform_config,
+            batchsize_per_replica,
+            shuffle,
+            num_samples,
+        ) = self.parse_config(config)
+        transform = build_field_transform_default_imagenet(
+            transform_config, default_transform=default_transform, split=self._split
+        )
+        self.dataset = self.wrap_dataset(
+            dataset,
+            transform,
+            batchsize_per_replica=batchsize_per_replica,
+            shuffle=shuffle,
+            subsample=num_samples,
+        )
+
+    def _load_dataset(self, image_paths, targets):
+        if isinstance(image_paths, str):
+            assert os.path.isdir(
+                image_paths
+            ), "Expect image_paths to be a dir when it is a string"
+            dataset = datasets.ImageFolder(image_paths)
+            dataset = WrapDataset(dataset)
+            # Wrap dataset places whole sample in input field by default
+            # Remap this to input / targets since default wrapper does not
+            # know which tensors are targets vs inputs
+            dataset = dataset.transform(_transform_sample)
+        else:
+            dataset = ListDataset(image_paths, targets)
+        return dataset

--- a/test/dataset_image_path_dataset_test.py
+++ b/test/dataset_image_path_dataset_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+import torch
+from classy_vision.dataset import ClassyDataset, build_dataset
+from classy_vision.dataset.image_path_dataset import ImagePathDataset
+from torchvision import transforms
+
+
+class TestImageDataset(unittest.TestCase):
+    def get_test_image_dataset(self):
+        config = {
+            "name": "synthetic_image",
+            "crop_size": 224,
+            "num_channels": 3,
+            "seed": 0,
+            "class_ratio": 0.5,
+            "num_samples": 100,
+            "batchsize_per_replica": 1,
+            "use_shuffle": False,
+            "transforms": [{"name": "ToTensor"}],
+        }
+        dataset = build_dataset(config)
+        return dataset
+
+    def setUp(self):
+        # create a base directory to write image files to
+        self.base_dir = tempfile.mkdtemp()
+        os.mkdir(f"{self.base_dir}/0")
+        os.mkdir(f"{self.base_dir}/1")
+
+    def tearDown(self):
+        # delete all the temporary data created
+        shutil.rmtree(self.base_dir)
+
+    def get_dataset_config(self):
+        return {
+            "batchsize_per_replica": 1,
+            "use_shuffle": False,
+            "num_samples": None,
+            "transforms": [{"name": "ToTensor"}],
+        }
+
+    @unittest.skip(
+        "Skipping test since build_dataset doesn't "
+        "work right now for ImagePathDataset"
+    )
+    def test_build_dataset(self):
+        config = self.get_dataset_config()
+        dataset = build_dataset(config)
+        self.assertIsInstance(dataset, ClassyDataset)
+
+    def test_image_dataset(self):
+        image_paths = []
+        inputs = []
+        targets = []
+        dataloader = self.get_test_image_dataset().iterator()
+        for i, sample in enumerate(dataloader):
+            input = sample["input"]
+            target = sample["target"]
+            image = transforms.ToPILImage()(input.squeeze())
+            path = f"{self.base_dir}/{target.item()}/{i}.png"
+            # save the image in a lossless format (png)
+            image.save(path)
+            image_paths.append(path)
+            inputs.append(input)
+            targets.append(target)
+
+        # config for the image dataset
+        config = self.get_dataset_config()
+
+        # create an image dataset from the list of images
+        dataset = ImagePathDataset(config, image_paths=image_paths, targets=targets)
+        dataloader = dataset.iterator()
+        # the samples should be in the same order
+        for sample, expected_input, expected_target in zip(dataloader, inputs, targets):
+            self.assertTrue(torch.allclose(sample["input"], expected_input))
+            self.assertEqual(sample["target"], expected_target)
+
+        # test the dataset works without targets as well
+        dataset = ImagePathDataset(config, image_paths=image_paths)
+        dataloader = dataset.iterator()
+        # the samples should be in the same order
+        for sample, expected_input in zip(dataloader, inputs):
+            self.assertTrue(torch.allclose(sample["input"], expected_input))
+
+        # create an image dataset from the root dir
+        dataset = ImagePathDataset(config, image_paths=self.base_dir)
+        dataloader = dataset.iterator()
+        # test that we get the same class distribution
+        # we don't test the actual samples since the ordering isn't defined
+        counts = [0, 0]
+        for sample in dataloader:
+            counts[sample["target"].item()] += 1
+        expected_counts = [0, 0]
+        for target in targets:
+            expected_counts[target.item()] += 1
+        self.assertEqual(counts, expected_counts)


### PR DESCRIPTION
Summary:
Implemented an `ImageDataset` in `dataset/generic` and added an `__init__.py` file. The dataset creates a classy dataset using images from local paths. Look at the docstring for more information. This will be used by the torchhub interface in the following diff.

Ideally, there should have been a class/function which returned a class object, and the returned class would expect the config as an input. But that would mean the class wouldn't be serializable. This is a bit of a compromise - the class takes all the args along with the config in `__init__`. The non-config args are named so that we can apply partial to them in the future - the returned object would just then take the config as an argument.

Please let me know if you have any suggestions to improve the interface!

Differential Revision: D17728549

