### PR TITLE
Add model tensorboard hook to fblearner

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -17,11 +17,13 @@ from classy_vision.hooks import (
     ModelTensorboardHook,
     ProfilerHook,
     ProgressBarHook,
+    TensorboardPlotHook,
     TimeMetricsHook,
     VisdomHook,
 )
 from classy_vision.tasks import build_task
 from classy_vision.trainer import DistributedTrainer
+from tensorboardX import SummaryWriter
 
 
 # run all the things:
@@ -40,7 +42,9 @@ def main(args):
 
     hooks = [LossLrMeterLoggingHook(), ModelComplexityHook(), TimeMetricsHook()]
     if not args.skip_tensorboard:
-        hooks.append(ModelTensorboardHook())
+        tb_writer = SummaryWriter(log_dir="/tmp/tensorboard")
+        hooks.append(TensorboardPlotHook(tb_writer))
+        hooks.append(ModelTensorboardHook(tb_writer))
     if args.checkpoint_folder != "":
         hooks.append(
             CheckpointHook(

--- a/test/manual/hooks_model_tensorboard_hook_test.py
+++ b/test/manual/hooks_model_tensorboard_hook_test.py
@@ -15,20 +15,12 @@ from tensorboardX import SummaryWriter
 
 class TestModelTensorboardHook(unittest.TestCase):
     @mock.patch("classy_vision.hooks.model_tensorboard_hook.is_master")
-    @mock.patch("classy_vision.generic.visualize.SummaryWriter", autospec=True)
-    def test_writer(
-        self,
-        mock_summary_writer_cls: mock.MagicMock,
-        mock_is_master_func: mock.MagicMock,
-    ) -> None:
+    def test_writer(self, mock_is_master_func: mock.MagicMock) -> None:
         """
         Tests that the tensorboard writer calls SummaryWriter with the model
         iff is_master() is True.
         """
-        # TODO (mannatsingh): get rid of pyfakefs
-        # needed to mock out SummaryWriter since it doesn't work with pyfakefs
         mock_summary_writer = mock.create_autospec(SummaryWriter, instance=True)
-        mock_summary_writer_cls.return_value = mock_summary_writer
 
         task = get_test_classy_task()
         state = task.build_initial_state()
@@ -43,19 +35,13 @@ class TestModelTensorboardHook(unittest.TestCase):
                 state.base_model = model
 
                 # create a model tensorboard hook
-                model_tensorboard_hook = ModelTensorboardHook()
+                model_tensorboard_hook = ModelTensorboardHook(mock_summary_writer)
 
                 with self.assertLogs():
                     model_tensorboard_hook.on_start(state, local_variables)
 
                 if master:
                     # SummaryWriter should have been init-ed with the correct
-                    # log_dir kwarg
-                    mock_summary_writer_cls.assert_called_once()
-                    self.assertEqual(
-                        mock_summary_writer_cls.call_args[1]["log_dir"],
-                        model_tensorboard_hook.tensorboard_dir,
-                    )
                     # add_graph should be called once with model as the first arg
                     mock_summary_writer.add_graph.assert_called_once()
                     self.assertEqual(
@@ -64,5 +50,4 @@ class TestModelTensorboardHook(unittest.TestCase):
                 else:
                     # add_graph shouldn't be called since is_master() is False
                     mock_summary_writer.add_graph.assert_not_called()
-                mock_summary_writer_cls.reset_mock()
                 mock_summary_writer.reset_mock()


### PR DESCRIPTION
Summary: Changed the ModelTensorboardHook API to be the same as TensorboardPlotHook (they take summary writers as inputs). Plugged ModelTensorboardHook into the fblearner workflows. Since I was making the change anyway, added TensorboardPlotHook to all the local runs which I changed as well. Also, pyfakefs isn't a dependency anymore.

Differential Revision: D17743822

