### PR TITLE
Move heads to .from_config idiom

### DIFF
--- a/classy_vision/heads/__init__.py
+++ b/classy_vision/heads/__init__.py
@@ -59,12 +59,14 @@ def register_head(name):
     return register_head_cls
 
 
-def build_head(head_config):
-    assert "name" in head_config, "Expect name in config"
-    assert "unique_id" in head_config, "Expect a global unique id in config"
-    assert "fork_block" in head_config, "Expect fork_block in config"
-    assert head_config["name"] in HEAD_REGISTRY, "unknown head"
-    return HEAD_REGISTRY[head_config["name"]](head_config)
+def build_head(config):
+    assert "name" in config, "Expect name in config"
+    assert "unique_id" in config, "Expect a global unique id in config"
+    assert config["name"] in HEAD_REGISTRY, "unknown head"
+    name = config["name"]
+    head_config = config.copy()
+    del head_config["name"]
+    return HEAD_REGISTRY[name].from_config(head_config)
 
 
 # automatically import any Python files in the heads/ directory

--- a/classy_vision/heads/classy_vision_head.py
+++ b/classy_vision/heads/classy_vision_head.py
@@ -4,26 +4,23 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Optional
+
 import torch.nn as nn
 
 
 class ClassyVisionHead(nn.Module):
-    def __init__(self, head_config):
+    def __init__(self, unique_id: Optional[str] = None):
         """
-        Classy Head constructor. This stores the head config for future access.
-        This is also the place to build and initialize the layers.
+        Classy Head constructor.
+        This is the place to build and initialize the layers.
         """
-        assert "name" in head_config
-        assert "unique_id" in head_config
         super().__init__()
-        self._config = head_config
+        self.unique_id = unique_id or self.__class__.__name__
 
-    @property
-    def unique_id(self):
-        """
-        return a global unique identifier for the head.
-        """
-        return self._config["unique_id"]
+    @classmethod
+    def from_config(cls, config):
+        raise NotImplementedError
 
     def forward(self, x):
         raise NotImplementedError

--- a/classy_vision/heads/identity_head.py
+++ b/classy_vision/heads/identity_head.py
@@ -9,8 +9,9 @@ from classy_vision.heads import ClassyVisionHead, register_head
 
 @register_head("identity")
 class IdentityHead(ClassyVisionHead):
-    def __init__(self, head_config):
-        super().__init__(head_config)
-
     def forward(self, x):
         return x
+
+    @classmethod
+    def from_config(cls, config):
+        return cls()

--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -72,8 +72,13 @@ def build_model(model_config):
         ), "Expect freeze_trunk to be specified in config when there is head"
         heads = defaultdict(dict)
         for head_config in model_config["heads"]:
-            head = build_head(head_config)
-            heads[head_config["fork_block"]][head.unique_id] = head
+            assert "fork_block" in head_config, "Expect fork_block in config"
+            fork_block = head_config["fork_block"]
+            updated_config = head_config.copy()
+            del updated_config["fork_block"]
+
+            head = build_head(updated_config)
+            heads[fork_block][head.unique_id] = head
         model.set_heads(heads, model_config["freeze_trunk"])
     return model
 

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -192,22 +192,19 @@ class BottleneckLayer(GenericLayer):
 
 @register_head("resnext_fc")
 class FullyConnectedLayer(ClassyVisionHead):
-    def __init__(self, config):
-        super().__init__(config)
-        config = self.parse_config(config)
-        num_classes = config["num_classes"]
-        in_plane = config["in_plane"]
-        assert num_classes is None or is_pos_int(num_classes)
-        assert is_pos_int(in_plane)
+    def __init__(self, num_classes, in_plane):
+        super().__init__()
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = None if num_classes is None else nn.Linear(in_plane, num_classes)
 
-    def parse_config(self, config):
-        assert "in_plane" in config
-        return {
-            "num_classes": config["num_classes"] if "num_classes" in config else None,
-            "in_plane": config["in_plane"],
-        }
+    @classmethod
+    def from_config(cls, config):
+        num_classes = config.get("num_classes", None)
+        in_plane = config["in_plane"]
+        assert num_classes is None or is_pos_int(num_classes)
+        assert is_pos_int(in_plane)
+
+        return cls(num_classes=num_classes, in_plane=in_plane)
 
     def forward(self, x):
         # perform average pooling:

--- a/test/classy_module_test.py
+++ b/test/classy_module_test.py
@@ -14,7 +14,7 @@ from classy_vision.models.classy_vision_model import ClassyVisionModel
 class TestClassyModule(unittest.TestCase):
     class DummyTestHead(ClassyVisionHead):
         def __init__(self):
-            super().__init__({"name": "dummy_head", "unique_id": "head_id"})
+            super().__init__(unique_id="head_id")
             self.layer = torch.nn.Linear(2, 2)
 
         def forward(self, x):
@@ -54,5 +54,5 @@ class TestClassyModule(unittest.TestCase):
         with self.assertRaises(ValueError):
             model.set_heads(heads, True)
 
-        head2._config["unique_id"] = "head_id2"
+        head2.unique_id = "head_id2"
         model.set_heads(heads, True)

--- a/test/classy_vision_head_test.py
+++ b/test/classy_vision_head_test.py
@@ -13,12 +13,20 @@ from classy_vision.heads import ClassyVisionHead, build_head, register_head
 class TestClassyVisionHead(unittest.TestCase):
     @register_head("dummy_head")
     class DummyHead(ClassyVisionHead):
-        def __init__(self, config):
-            super().__init__(config)
-            self.fc = torch.nn.Linear(config["in_plane"], config["num_classes"])
+        def __init__(self, unique_id, in_plane, num_classes):
+            super().__init__(unique_id)
+            self.fc = torch.nn.Linear(in_plane, num_classes)
 
         def forward(self, x):
             return self.fc(x)
+
+        @classmethod
+        def from_config(cls, config):
+            return cls(
+                unique_id=config["unique_id"],
+                in_plane=config["in_plane"],
+                num_classes=config["num_classes"],
+            )
 
     def _get_config(self):
         return {


### PR DESCRIPTION
Summary:
Instead of forcing heads to take a config in the constructor, change ClassyHead
to use the .from_config idiom.

Differential Revision: D17723558

