### PR TITLE
Classy model wrapper

### DIFF
--- a/classy_vision/hub/classy_hub_interface.py
+++ b/classy_vision/hub/classy_hub_interface.py
@@ -7,10 +7,12 @@
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 import torch
+import torch.nn as nn
 from classy_vision.dataset import ClassyDataset
 from classy_vision.dataset.image_path_dataset import ImagePathDataset
 from classy_vision.dataset.transforms import build_transforms
 from classy_vision.models import ClassyVisionModel
+from classy_vision.models.classy_model_wrapper import ClassyModelWrapper
 from classy_vision.tasks import ClassyVisionTask
 
 
@@ -40,7 +42,11 @@ class ClassyHubInterface:
         return cls(task=task)
 
     @classmethod
-    def from_model(cls, model: ClassyVisionModel) -> "ClassyHubInterface":
+    def from_model(
+        cls, model: Union[nn.Module, ClassyVisionModel]
+    ) -> "ClassyHubInterface":
+        if not isinstance(model, ClassyVisionModel):
+            model = ClassyModelWrapper(model)
         return cls(model=model)
 
     def create_image_dataset(

--- a/classy_vision/models/classy_model_wrapper.py
+++ b/classy_vision/models/classy_model_wrapper.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict, Optional, Tuple
+
+import torch.nn as nn
+
+from . import ClassyVisionModel
+
+
+class ClassyModelWrapper(ClassyVisionModel):
+    """
+    Class which wraps an nn.Module within a ClassyVisionModel.
+
+    The only required argument is the model, the additional args are needed
+    to get some additional capabilities from Classy Vision to work.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        input_shape: Optional[Tuple] = None,
+        output_shape: Optional[Tuple] = None,
+        model_depth: Optional[int] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ):
+        if config is None:
+            config = {}
+        super().__init__(config)
+        self.model = model
+        self._input_shape = input_shape
+        self._output_shape = output_shape
+        self._model_depth = model_depth
+
+    def forward(self, x):
+        return self.model(x)
+
+    def extract_features(self, x):
+        if hasattr(self.model, "extract_features"):
+            return self.model.extract_features(x)
+        return super().extract_features(x)
+
+    @property
+    def input_shape(self):
+        if self._input_shape is not None:
+            return self._input_shape
+        return super().input_shape
+
+    @property
+    def output_shape(self):
+        if self._output_shape is not None:
+            return self._output_shape
+        return super().output_shape
+
+    @property
+    def model_depth(self):
+        if self._model_depth is not None:
+            return self._model_depth
+        return super().model_depth

--- a/test/hub_classy_hub_interface_test.py
+++ b/test/hub_classy_hub_interface_test.py
@@ -13,7 +13,7 @@ import torch
 from classy_vision.hub import ClassyHubInterface
 from classy_vision.models import ClassyVisionModel, build_model
 from classy_vision.tasks import ClassyVisionTask, build_task
-from torchvision import transforms
+from torchvision import models, transforms
 
 
 class TestClassyHubInterface(unittest.TestCase):
@@ -29,7 +29,29 @@ class TestClassyHubInterface(unittest.TestCase):
         # delete all the temporary data created
         shutil.rmtree(self.base_dir)
 
-    def test_interface_with_task(self):
+    def _test_predict_and_extract_features(self, hub_interface: ClassyHubInterface):
+        dataset = hub_interface.create_image_dataset([self.image_path], split="test")
+        data_iterator = hub_interface.get_data_iterator(dataset)
+        input = next(data_iterator)
+        # set the model to eval mode
+        hub_interface.eval()
+        output = hub_interface.predict(input)
+        self.assertIsNotNone(output)
+        # see the prediction for the input
+        hub_interface.predict(input).argmax().item()
+        # check extract features
+        output = hub_interface.extract_features(input)
+        self.assertIsNotNone(output)
+
+    def _get_classy_model(self):
+        config = get_test_task_config()
+        model_config = config["model"]
+        return build_model(model_config)
+
+    def _get_non_classy_model(self):
+        return models.resnet18(pretrained=False)
+
+    def test_from_task(self):
         config = get_test_task_config()
         args = get_test_args()
         task = build_task(config, args)
@@ -39,32 +61,14 @@ class TestClassyHubInterface(unittest.TestCase):
         self.assertIsInstance(hub_interface.model, ClassyVisionModel)
 
         # this will pick up the transform from the task's config
-        dataset = hub_interface.create_image_dataset([self.image_path], split="test")
-        data_iterator = hub_interface.get_data_iterator(dataset)
-        input = next(data_iterator)
-        # set the model to eval mode
-        hub_interface.eval()
-        output = hub_interface.predict(input)
-        self.assertIsNotNone(output)
-        # see the prediction for the input
-        hub_interface.predict(input).argmax().item()
+        self._test_predict_and_extract_features(hub_interface)
 
-    def test_interface_with_model(self):
-        config = get_test_task_config()
-        model_config = config["model"]
-        model = build_model(model_config)
-        hub_interface = ClassyHubInterface.from_model(model)
+    def test_from_model(self):
+        for model in [self._get_classy_model(), self._get_non_classy_model()]:
+            hub_interface = ClassyHubInterface.from_model(model)
 
-        self.assertIsNone(hub_interface.task)
-        self.assertIsInstance(hub_interface.model, ClassyVisionModel)
+            self.assertIsNone(hub_interface.task)
+            self.assertIsInstance(hub_interface.model, ClassyVisionModel)
 
-        # this will pick up the transform from imagenet
-        dataset = hub_interface.create_image_dataset([self.image_path], split="test")
-        data_iterator = hub_interface.get_data_iterator(dataset)
-        input = next(data_iterator)
-        # set the model to eval mode
-        hub_interface.eval()
-        output = hub_interface.predict(input)
-        self.assertIsNotNone(output)
-        # see the prediction for the input
-        hub_interface.predict(input).argmax().item()
+            # this will pick up the transform from imagenet
+            self._test_predict_and_extract_features(hub_interface)

--- a/test/models_classy_model_wrapper_test.py
+++ b/test/models_classy_model_wrapper_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from test.generic.config_utils import get_test_args, get_test_task_config
+
+import torch
+import torch.nn as nn
+from classy_vision.models import ClassyVisionModel
+from classy_vision.models.classy_model_wrapper import ClassyModelWrapper
+from classy_vision.tasks import build_task
+from classy_vision.trainer import ClassyTrainer
+from torchvision import models
+
+
+class TestModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(10, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+    def extract_features(self, x):
+        return torch.cat([x, x], dim=1)
+
+
+class TestClassyModelWrapper(unittest.TestCase):
+    def test_classy_model_wrapper(self):
+        model = TestModel()
+        classy_model = ClassyModelWrapper(model)
+        # test that the returned object is an instance of ClassyVisionModel
+        self.assertIsInstance(classy_model, ClassyVisionModel)
+
+        # test that forward works correctly
+        input = torch.zeros((100, 10))
+        output = classy_model(input)
+        self.assertEqual(output.shape, (100, 5))
+
+        # test that extract_features works correctly
+        input = torch.zeros((100, 10))
+        output = classy_model.extract_features(input)
+        self.assertEqual(output.shape, (100, 20))
+
+        # test that get_classy_state and set_classy_state work
+        nn.init.constant_(classy_model.model.linear.weight, 1)
+        weights = copy.deepcopy(classy_model.model.linear.weight.data)
+        state_dict = classy_model.get_classy_state(deep_copy=True)
+        nn.init.constant_(classy_model.model.linear.weight, 0)
+        classy_model.set_classy_state(state_dict)
+        self.assertTrue(torch.allclose(weights, classy_model.model.linear.weight.data))
+
+    def test_classy_model_wrapper_properties(self):
+        # test that the properties work correctly when passed to the wrapper
+        model = TestModel()
+        num_classes = 5
+        input_shape = (10,)
+        output_shape = (num_classes,)
+        model_depth = 1
+        config = {"num_classes": num_classes}
+        classy_model = ClassyModelWrapper(
+            model,
+            input_shape=input_shape,
+            output_shape=output_shape,
+            model_depth=model_depth,
+            config=config,
+        )
+        self.assertEqual(classy_model.input_shape, input_shape)
+        self.assertEqual(classy_model.num_classes, num_classes)
+        self.assertEqual(classy_model.output_shape, output_shape)
+        self.assertEqual(classy_model.model_depth, model_depth)
+
+    def test_train_step(self):
+        # test that the model can be run in a train step
+        model = models.resnet34(pretrained=False)
+        classy_model = ClassyModelWrapper(model)
+
+        config = get_test_task_config()
+        args = get_test_args()
+        # use 2 samples and 1 phase for faster testing
+        for split in ["train", "test"]:
+            config["dataset"][split]["num_samples"] = 2
+        config["num_phases"] = 1
+        task = build_task(config, args)
+        # TODO(@mannatsingh): Use a set_model method when the task refactor is
+        # complete
+        task.model = classy_model
+        hooks = []
+        trainer = ClassyTrainer(hooks, use_gpu=False)
+        trainer.train(task)


### PR DESCRIPTION
Summary:
Created a `ClassyModelWrapper` which wraps an `nn.Module` by a `ClassyVisionModel`, so that the model can be used in Classy Vision.

This wrapper is used in `ClassyHubInterface` so that `from_model()` can support any general models.

Differential Revision: D17767522

