### PR TITLE
Add support to save and load state in classy hooks

### DIFF
--- a/classy_vision/hooks/classy_hook.py
+++ b/classy_vision/hooks/classy_hook.py
@@ -28,11 +28,39 @@ class ClassyHookFunctions(Enum):
     on_end = auto()
 
 
+class ClassyHookState:
+    """
+    Class to store state within instances of ClassyHook.
+
+    Any serializable data can be stored in the instance's attributes.
+    """
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.__dict__
+
+    def load_state_dict(self, state_dict: Dict[str, Any]):
+        self.__dict__ = state_dict
+
+
 class ClassyHook(ABC):
     """
     Abstract class for hooks to plug in to the classy workflow at various points
     to add various functionalities such as logging and reporting.
+
+    Deriving classes should call super().__init__() and store any state in
+    self.state. Any state added to this property should be serializable.
+    E.g. -
+    class MyHook(ClassyHook):
+        def __init__(self, a, b):
+            super().__init__()
+            self.state.a = [1,2,3]
+            self.state.b = "my_hook"
+            # the following line is not allowed
+            # self.state.my_lambda = lambda x: x^2
     """
+
+    def __init__(self):
+        self.state = ClassyHookState()
 
     def _noop(self, state: ClassyState, local_variables: Dict[str, Any]) -> None:
         """
@@ -114,3 +142,9 @@ class ClassyHook(ABC):
         Called at the end of training.
         """
         pass
+
+    def state_dict(self) -> Dict[str, Any]:
+        return self.state.state_dict()
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.state.load_state_dict(state_dict)

--- a/test/hooks_classy_hook_test.py
+++ b/test/hooks_classy_hook_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+from classy_vision.hooks import ClassyHook
+
+
+class TestHook(ClassyHook):
+    on_rendezvous = ClassyHook._noop
+    on_start = ClassyHook._noop
+    on_phase_start = ClassyHook._noop
+    on_sample = ClassyHook._noop
+    on_forward = ClassyHook._noop
+    on_loss = ClassyHook._noop
+    on_backward = ClassyHook._noop
+    on_update = ClassyHook._noop
+    on_phase_end = ClassyHook._noop
+    on_end = ClassyHook._noop
+
+    def __init__(self, a, b):
+        super().__init__()
+        self.state.a = a
+        self.state.b = b
+
+
+class TestClassyHook(unittest.TestCase):
+    def test_state_dict(self):
+        a = 0
+        b = {1: 2, 3: [4]}
+        test_hook = TestHook(a, b)
+        state_dict = test_hook.state_dict()
+        # create a new test_hook and set its state to the old hook's.
+        test_hook = TestHook("", 0)
+        test_hook.load_state_dict(state_dict)
+        self.assertEqual(test_hook.state.a, a)
+        self.assertEqual(test_hook.state.b, b)


### PR DESCRIPTION
Summary:
Added support to store state within the hooks. Using the functions names `load_state_dict` and `state_dict` - we will be updating all the state functions to have these names.

This will be followed by a diff to migrate the hooks to `ClassyState`, so that hooks can resume from checkpoints. This will also allow the hooks to work seamlessly with PET.

Differential Revision: D17772753

