### PR TITLE
Switch to .from_config for models

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -689,3 +689,10 @@ def convert_to_one_hot(targets, classes):
         one_hot_targets = one_hot_targets.cuda()
     one_hot_targets.scatter_(1, targets.long(), 1)
     return one_hot_targets
+
+
+def bind_method_to_class(method, cls):
+    """
+    Binds an already bound method to the provided class.
+    """
+    return method.__func__.__get__(cls)

--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -65,7 +65,7 @@ def register_model(name):
 
 def build_model(config):
     assert config["name"] in MODEL_REGISTRY, "unknown model"
-    model = MODEL_REGISTRY[config["name"]](config)
+    model = MODEL_REGISTRY[config["name"]].from_config(config)
     if "heads" in config:
         assert (
             "freeze_trunk" in config

--- a/classy_vision/models/classy_model_wrapper.py
+++ b/classy_vision/models/classy_model_wrapper.py
@@ -22,14 +22,13 @@ class ClassyModelWrapper(ClassyVisionModel):
     def __init__(
         self,
         model: nn.Module,
+        num_classes: Optional[int] = None,
+        freeze_trunk: bool = False,
         input_shape: Optional[Tuple] = None,
         output_shape: Optional[Tuple] = None,
         model_depth: Optional[int] = None,
-        config: Optional[Dict[str, Any]] = None,
     ):
-        if config is None:
-            config = {}
-        super().__init__(config)
+        super().__init__(num_classes, freeze_trunk)
         self.model = model
         self._input_shape = input_shape
         self._output_shape = output_shape

--- a/classy_vision/models/mlp.py
+++ b/classy_vision/models/mlp.py
@@ -16,20 +16,21 @@ from .classy_vision_model import ClassyVisionModel
 class MLP(ClassyVisionModel):
     """MLP model using ReLU. Useful for testing on CPUs."""
 
-    def __init__(self, config):
-        super().__init__(config)
-
-        assert (key in config for key in ["input_dim", "output_dim", "hidden_dims"])
+    def __init__(
+        self,
+        input_dim,
+        output_dim,
+        hidden_dims,
+        dropout,
+        first_dropout,
+        use_batchnorm,
+        first_batchnorm,
+        num_classes,
+        freeze_trunk,
+    ):
+        super().__init__(num_classes, freeze_trunk)
 
         layers = []
-        input_dim = config["input_dim"]
-        output_dim = config["output_dim"]
-        hidden_dims = config["hidden_dims"]
-        dropout = config.get("dropout", 0)
-        first_dropout = config.get("first_dropout", False)
-        use_batchnorm = config.get("use_batchnorm", False)
-        first_batchnorm = config.get("first_batchnorm", False)
-
         # If first_batchnorm is set, must be using batchnorm
         assert not first_batchnorm or use_batchnorm
 
@@ -54,6 +55,23 @@ class MLP(ClassyVisionModel):
 
         layers.append(nn.Linear(input_dim, output_dim))
         self.mlp = nn.Sequential(*layers)
+
+    @classmethod
+    def from_config(cls, config):
+        assert (key in config for key in ["input_dim", "output_dim", "hidden_dims"])
+
+        output_dim = config["output_dim"]
+        return cls(
+            input_dim=config["input_dim"],
+            output_dim=output_dim,
+            hidden_dims=config["hidden_dims"],
+            dropout=config.get("dropout", 0),
+            first_dropout=config.get("first_dropout", False),
+            use_batchnorm=config.get("use_batchnorm", False),
+            first_batchnorm=config.get("first_batchnorm", False),
+            num_classes=output_dim,
+            freeze_trunk=config.get("freeze_trunk", False),
+        )
 
     def forward(self, x):
         batchsize_per_replica = x.shape[0]

--- a/classy_vision/models/resnet.py
+++ b/classy_vision/models/resnet.py
@@ -23,6 +23,8 @@ class ResNet(ResNeXt):
         ResNet is a special case of ResNeXt.
     """
 
-    def __init__(self, config):
-        config["base_width_and_cardinality"] = None
-        super().__init__(config)
+    def __init__(self, **kwargs):
+        assert (
+            kwargs["base_width_and_cardinality"] is None
+        ), "base_width_and_cardinality should be None for ResNet"
+        super().__init__(**kwargs)

--- a/classy_vision/models/vgg.py
+++ b/classy_vision/models/vgg.py
@@ -38,7 +38,100 @@ _STAGES = {
 class VGG(ClassyVisionModel):
     """VGG model."""
 
-    def __init__(self, config):
+    def __init__(
+        self,
+        num_classes,
+        freeze_trunk,
+        depth,
+        num_stages,
+        stride2_inds,
+        max_pool_inds,
+        ds_mult,
+        ws_mult,
+        bn_epsilon,
+        bn_momentum,
+        relu_inplace,
+        small_input,
+    ):
+        super().__init__(num_classes, freeze_trunk)
+
+        assert num_classes is None or is_pos_int(num_classes)
+        assert depth in _STAGES.keys(), "VGG{} not supported".format(depth)
+        assert is_pos_int(num_stages) and num_stages <= 5
+        assert type(stride2_inds) == list and type(max_pool_inds) == list
+        assert type(small_input) == bool and type(relu_inplace) == bool
+        assert type(bn_epsilon) == float and type(bn_momentum) == float
+        assert type(ds_mult) == float and type(ws_mult) == float
+
+        logging.info(
+            "Constructing: VGG-{}, stgs {}, s2c {}, mp {}, ds {}, ws {}".format(
+                depth, num_stages, stride2_inds, max_pool_inds, ds_mult, ws_mult
+            )
+        )
+
+        # Retrieve the original body structure
+        stages = _STAGES[depth][:num_stages]
+
+        # Adjust the widths and depths
+        stages = [[int(stage[0] * ws_mult)] * len(stage) for stage in stages]
+        stages = [[stage[0]] * int(len(stage) * ds_mult) for stage in stages]
+
+        # Construct the body
+        body_layers = []
+        dim_in = 3
+
+        for i, stage in enumerate(stages):
+            # Construct the blocks for the stage
+            for j, dim_out in enumerate(stage):
+                # Determine the block stride
+                stride = 2 if j == 0 and i in stride2_inds else 1
+                # Basic block: Conv, BN, ReLU
+                body_layers += [
+                    nn.Conv2d(
+                        dim_in,
+                        dim_out,
+                        kernel_size=3,
+                        stride=stride,
+                        padding=1,
+                        bias=False,
+                    ),
+                    nn.BatchNorm2d(dim_out, eps=bn_epsilon, momentum=bn_momentum),
+                    nn.ReLU(inplace=relu_inplace),
+                ]
+                dim_in = dim_out
+            # Perform reduction by pooling
+            if i in max_pool_inds:
+                body_layers += [nn.MaxPool2d(kernel_size=2, stride=2, padding=0)]
+        self.body = nn.Sequential(*body_layers)
+
+        # Construct the head
+        self.head = nn.AdaptiveAvgPool2d((1, 1))
+
+        # Construct the classifier layer
+        self.num_planes = dim_in
+        self.classifier = (
+            None
+            if num_classes is None
+            else nn.Sequential(
+                nn.Linear(self.num_planes, 4096),
+                nn.ReLU(inplace=relu_inplace),
+                nn.Dropout(),
+                nn.Linear(4096, 4096),
+                nn.ReLU(inplace=relu_inplace),
+                nn.Dropout(),
+                nn.Linear(4096, num_classes),
+            )
+        )
+
+        self.small_input = small_input
+        self.depth = depth
+
+        self._init_weights()
+
+    @classmethod
+    def from_config(cls, config):
+        config = config.copy()
+        del config["name"]
         assert all(
             e in config
             for e in [
@@ -53,102 +146,10 @@ class VGG(ClassyVisionModel):
                 "relu_inplace",
             ]
         )
-        super().__init__(config)
 
-        # assertions on inputs:
-        assert "num_classes" not in config or is_pos_int(config["num_classes"])
-        assert config["depth"] in _STAGES.keys(), "VGG{} not supported".format(
-            config["depth"]
-        )
-        assert is_pos_int(config["num_stages"]) and config["num_stages"] <= 5
-        assert (
-            type(config["stride2_inds"]) == list
-            and type(config["max_pool_inds"]) == list
-        )
-        assert (
-            type(config["small_input"]) == bool and type(config["relu_inplace"]) == bool
-        )
-        assert (
-            type(config["bn_epsilon"]) == float and type(config["bn_momentum"]) == float
-        )
-        assert type(config["ds_mult"]) == float and type(config["ws_mult"]) == float
-
-        self._construct()
-        self._init_weights()
-
-    def _construct(self):
-        logging.info(
-            "Constructing: VGG-{}, stgs {}, s2c {}, mp {}, ds {}, ws {}".format(
-                self._config["depth"],
-                self._config["num_stages"],
-                self._config["stride2_inds"],
-                self._config["max_pool_inds"],
-                self._config["ds_mult"],
-                self._config["ws_mult"],
-            )
-        )
-
-        # Retrieve the original body structure
-        stages = _STAGES[self._config["depth"]][: self._config["num_stages"]]
-
-        # Adjust the widths and depths
-        stages = [
-            [int(stage[0] * self._config["ws_mult"])] * len(stage) for stage in stages
-        ]
-        stages = [
-            [stage[0]] * int(len(stage) * self._config["ds_mult"]) for stage in stages
-        ]
-
-        # Construct the body
-        body_layers = []
-        dim_in = 3
-
-        for i, stage in enumerate(stages):
-            # Construct the blocks for the stage
-            for j, dim_out in enumerate(stage):
-                # Determine the block stride
-                stride = 2 if j == 0 and i in self._config["stride2_inds"] else 1
-                # Basic block: Conv, BN, ReLU
-                body_layers += [
-                    nn.Conv2d(
-                        dim_in,
-                        dim_out,
-                        kernel_size=3,
-                        stride=stride,
-                        padding=1,
-                        bias=False,
-                    ),
-                    nn.BatchNorm2d(
-                        dim_out,
-                        eps=self._config["bn_epsilon"],
-                        momentum=self._config["bn_momentum"],
-                    ),
-                    nn.ReLU(inplace=self._config["relu_inplace"]),
-                ]
-                dim_in = dim_out
-            # Perform reduction by pooling
-            if i in self._config["max_pool_inds"]:
-                body_layers += [nn.MaxPool2d(kernel_size=2, stride=2, padding=0)]
-        self.body = nn.Sequential(*body_layers)
-
-        # Construct the head
-        self.head = nn.AdaptiveAvgPool2d((1, 1))
-
-        # Construct the classifier layer
-        self.num_planes = dim_in
-        self.classifier = (
-            None
-            if self._config["num_classes"] is None
-            else nn.Sequential(
-                nn.Linear(self.num_planes, 4096),
-                nn.ReLU(inplace=self._config["relu_inplace"]),
-                nn.Dropout(),
-                nn.Linear(4096, 4096),
-                nn.ReLU(inplace=self._config["relu_inplace"]),
-                nn.Dropout(),
-                nn.Linear(4096, self._config["num_classes"]),
-            )
-        )
+        config.setdefault("num_classes", None)
+        config.setdefault("freeze_trunk", False)
+        return cls(**config)
 
     def _init_weights(self):
         for m in self.modules():
@@ -172,18 +173,18 @@ class VGG(ClassyVisionModel):
 
     @property
     def input_shape(self):
-        if self._config["small_input"]:
+        if self.small_input:
             return (3, 32, 32)
         else:
             return (3, 224, 224)
 
     @property
     def output_shape(self):
-        return (1, self._config["num_classes"])
+        return (1, self.num_classes)
 
     @property
     def model_depth(self):
-        return self._config["depth"]
+        return self.depth
 
     def validate(self, dataset_output_shape):
         return self.input_shape == dataset_output_shape

--- a/classy_vision/state/classy_state.py
+++ b/classy_vision/state/classy_state.py
@@ -220,7 +220,7 @@ class ClassyState:
 
     def _set_model_train_mode(self):
         phase = self.phases[self.phase_idx]
-        if self.base_model._config.get("freeze_trunk", False):
+        if self.base_model.freeze_trunk:
             self.model.eval()
             for heads in self.base_model.get_heads().values():
                 for h in heads.values():

--- a/test/generic/optim_test_util.py
+++ b/test/generic/optim_test_util.py
@@ -31,7 +31,7 @@ class TestOptimizer(ABC):
         }
 
     def _get_mock_classy_vision_model(self, trainable_params=True):
-        mock_classy_vision_model = ClassyVisionModel(model_config={})
+        mock_classy_vision_model = ClassyVisionModel(num_classes=0)
 
         if trainable_params:
             mock_classy_vision_model.get_optimizer_params = MagicMock(

--- a/test/generic/utils.py
+++ b/test/generic/utils.py
@@ -240,7 +240,6 @@ def recursive_unpack(batch):
 
 
 def compare_model_state(test_fixture, state, state2, check_heads=True):
-    test_fixture.assertEqual(state["config"], state2["config"])
     for k in state["model"]["trunk"].keys():
         if not torch.allclose(state["model"]["trunk"][k], state2["model"]["trunk"][k]):
             print(k, state["model"]["trunk"][k], state2["model"]["trunk"][k])

--- a/test/models_classy_model_wrapper_test.py
+++ b/test/models_classy_model_wrapper_test.py
@@ -61,13 +61,12 @@ class TestClassyModelWrapper(unittest.TestCase):
         input_shape = (10,)
         output_shape = (num_classes,)
         model_depth = 1
-        config = {"num_classes": num_classes}
         classy_model = ClassyModelWrapper(
             model,
+            num_classes=num_classes,
             input_shape=input_shape,
             output_shape=output_shape,
             model_depth=model_depth,
-            config=config,
         )
         self.assertEqual(classy_model.input_shape, input_shape)
         self.assertEqual(classy_model.num_classes, num_classes)


### PR DESCRIPTION
Summary: Instead of taking the config in the models' constructor, added a `from_config` classmethod. All the OSS models don't take the config as an arg in their `__init__`s.

Differential Revision: D17724370

