### PR TITLE
Remove model and optimizer from ClassyTask constructor

### DIFF
--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -63,15 +63,15 @@ def register_model(name):
     return register_model_cls
 
 
-def build_model(model_config):
-    assert model_config["name"] in MODEL_REGISTRY, "unknown model"
-    model = MODEL_REGISTRY[model_config["name"]](model_config)
-    if "heads" in model_config:
+def build_model(config):
+    assert config["name"] in MODEL_REGISTRY, "unknown model"
+    model = MODEL_REGISTRY[config["name"]](config)
+    if "heads" in config:
         assert (
-            "freeze_trunk" in model_config
+            "freeze_trunk" in config
         ), "Expect freeze_trunk to be specified in config when there is head"
         heads = defaultdict(dict)
-        for head_config in model_config["heads"]:
+        for head_config in config["heads"]:
             assert "fork_block" in head_config, "Expect fork_block in config"
             fork_block = head_config["fork_block"]
             updated_config = head_config.copy()
@@ -79,7 +79,8 @@ def build_model(model_config):
 
             head = build_head(updated_config)
             heads[fork_block][head.unique_id] = head
-        model.set_heads(heads, model_config["freeze_trunk"])
+        model.set_heads(heads, config["freeze_trunk"])
+    model._config_DO_NOT_USE = config
     return model
 
 

--- a/classy_vision/optim/__init__.py
+++ b/classy_vision/optim/__init__.py
@@ -19,7 +19,11 @@ OPTIMIZER_CLASS_NAMES = set()
 
 
 def build_optimizer(config, model):
-    return OPTIMIZER_REGISTRY[config["name"]].from_config(config=config, model=model)
+    instance = OPTIMIZER_REGISTRY[config["name"]].from_config(
+        config=config, model=model
+    )
+    instance._config_DO_NOT_USE = config
+    return instance
 
 
 def register_optimizer(name):

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -8,6 +8,8 @@ import unittest
 from unittest.mock import Mock
 
 from classy_vision.criterions import build_criterion
+from classy_vision.models import build_model
+from classy_vision.optim import build_optimizer
 from classy_vision.optim.param_scheduler import UpdateInterval
 from classy_vision.tasks.classy_vision_task import ClassyVisionTask
 from classy_vision.trainer import ClassyTrainer
@@ -64,12 +66,13 @@ class TestParamSchedulerIntegration(unittest.TestCase):
     def _build_task(self, num_phases):
         config = self._get_config()
         config["optimizer"]["num_epochs"] = num_phases
-        task = ClassyVisionTask(
-            num_phases=num_phases,
-            dataset_config=config["dataset"],
-            model_config=config["model"],
-            optimizer_config=config["optimizer"],
-        ).set_criterion(build_criterion(config["criterion"]))
+        model = build_model(config["model"])
+        task = (
+            ClassyVisionTask(num_phases=num_phases, dataset_config=config["dataset"])
+            .set_criterion(build_criterion(config["criterion"]))
+            .set_model(model)
+            .set_optimizer(build_optimizer(config["optimizer"], model))
+        )
 
         self.assertTrue(task is not None)
         return task

--- a/test/state_classy_state_test.py
+++ b/test/state_classy_state_test.py
@@ -94,7 +94,7 @@ class TestClassyState(unittest.TestCase):
         task = build_task(config, args, local_rank=0)
 
         for reset_heads in [True, False]:
-            config["model"]["reset_heads"] = reset_heads
+            config["reset_heads"] = reset_heads
 
             state = task.build_initial_state()
             state_2 = task.build_initial_state()
@@ -117,7 +117,7 @@ class TestClassyState(unittest.TestCase):
         """
         config = get_test_task_config()
         config["model"]["freeze_trunk"] = True
-        config["model"]["reset_heads"] = True
+        config["reset_heads"] = True
         # use a batchsize of 1 for faster testing
         for split in ["train", "test"]:
             config["dataset"][split]["batchsize_per_replica"] = 1

--- a/test/tasks_classy_vision_task_test.py
+++ b/test/tasks_classy_vision_task_test.py
@@ -8,6 +8,8 @@ import unittest
 from test.generic.config_utils import get_test_args, get_test_task_config
 
 from classy_vision.criterions import build_criterion
+from classy_vision.models import build_model
+from classy_vision.optim import build_optimizer
 from classy_vision.tasks import build_task
 from classy_vision.tasks.classy_vision_task import ClassyVisionTask
 
@@ -21,13 +23,14 @@ class TestClassyVisionTask(unittest.TestCase):
 
     def test_get_state(self):
         config = get_test_task_config()
+        model = build_model(config["model"])
         criterion = build_criterion(config["criterion"])
-        task = ClassyVisionTask(
-            num_phases=1,
-            dataset_config=config["dataset"],
-            model_config=config["model"],
-            optimizer_config=config["optimizer"],
-        ).set_criterion(criterion)
+        task = (
+            ClassyVisionTask(num_phases=1, dataset_config=config["dataset"])
+            .set_criterion(criterion)
+            .set_model(model)
+            .set_optimizer(build_optimizer(config["optimizer"], model))
+        )
 
         state = task.build_initial_state(num_workers=1, pin_memory=False)
         self.assertTrue(state is not None)

--- a/test/trainer_test.py
+++ b/test/trainer_test.py
@@ -9,6 +9,8 @@ import unittest
 from classy_vision.criterions import build_criterion
 from classy_vision.hooks import LossLrMeterLoggingHook
 from classy_vision.meters.accuracy_meter import AccuracyMeter
+from classy_vision.models import build_model
+from classy_vision.optim import build_optimizer
 from classy_vision.tasks.classy_vision_task import ClassyVisionTask
 from classy_vision.trainer import ClassyTrainer
 
@@ -64,14 +66,12 @@ class TestClassyTrainer(unittest.TestCase):
     def test_cpu_training(self):
         """Checks we can train a small MLP model on a CPU."""
         config = self._get_config()
+        model = build_model(config["model"])
         task = (
-            ClassyVisionTask(
-                num_phases=10,
-                dataset_config=config["dataset"],
-                model_config=config["model"],
-                optimizer_config=config["optimizer"],
-            )
+            ClassyVisionTask(num_phases=10, dataset_config=config["dataset"])
             .set_criterion(build_criterion(config["criterion"]))
+            .set_model(model)
+            .set_optimizer(build_optimizer(config["optimizer"], model))
             .set_meters([AccuracyMeter(topk=[1])])
             .set_hooks([LossLrMeterLoggingHook()])
         )


### PR DESCRIPTION
Summary:
Instead of taking the model and optimizer config in the constructor, store the model and optimizer
instances themselves in ClassyTask. These can be set using the `set_model` and `set_optimizer` methods.

Also, moved `rest_heads` to the task config instead of the `model_config`.

Differential Revision: D17770367

