### PR TITLE
Fix bug in checkpoint loading

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -467,24 +467,18 @@ def update_classy_state(state, state_dict, reset_heads=False):
         state: ClassyState instance to update
         state_dict: State dict, should be the output of a call to
             ClassyState.get_classy_state().
-        reset_heads: if True, retains the new heads from the state.
+        reset_heads: if False, uses the heads' state from the checkpoint.
     """
     logging.info("Loading classy state from checkpoint")
 
     try:
-        current_state_dict = state.get_classy_state()
-        model_state_dict = current_state_dict["base_model"]
-        # update trunk from checkpoint
-        model_state_dict["model"]["trunk"] = state_dict["base_model"]["model"]["trunk"]
-
-        if not reset_heads:
-            # replace previous head states with source head states
-            model_state_dict["model"]["heads"] = state_dict["base_model"]["model"][
-                "heads"
-            ]
-
-        current_state_dict["base_model"] = model_state_dict
-        state.set_classy_state(current_state_dict)
+        if reset_heads:
+            current_state_dict = state.get_classy_state()
+            # replace the checkpointed head states with source head states
+            state_dict["base_model"]["model"]["heads"] = current_state_dict[
+                "base_model"
+            ]["model"]["heads"]
+        state.set_classy_state(state_dict)
         logging.info("Checkpoint load successful")
         return True
     except Exception:

--- a/test/state_classy_state_test.py
+++ b/test/state_classy_state_test.py
@@ -21,13 +21,15 @@ class TestClassyState(unittest.TestCase):
     def _compare_samples(self, sample_1, sample_2):
         compare_samples(self, sample_1, sample_2)
 
-    def _compare_states(self, state_1, state_2):
+    def _compare_states(self, state_1, state_2, check_heads=True):
         """
         Tests the classy state dicts for equality, but skips the member objects
         which implement their own {get, set}_classy_state functions.
         """
         # check base_model
-        self._compare_model_state(state_1["base_model"], state_2["base_model"])
+        self._compare_model_state(
+            state_1["base_model"], state_2["base_model"], check_heads
+        )
         # check losses
         self.assertEqual(len(state_1["losses"]), len(state_2["losses"]))
         for loss_1, loss_2 in zip(state_1["losses"], state_2["losses"]):
@@ -105,9 +107,9 @@ class TestClassyState(unittest.TestCase):
                 update_classy_state(
                     state_2, state.get_classy_state(deep_copy=True), reset_heads
                 )
-                self._compare_model_state(
-                    state.get_classy_state()["base_model"],
-                    state_2.get_classy_state()["base_model"],
+                self._compare_states(
+                    state.get_classy_state(),
+                    state_2.get_classy_state(),
                     not reset_heads,
                 )
 


### PR DESCRIPTION
Summary: D17481209 updated `update_classy_state` to support fine tuning, but introduced a bug wherein we only loaded the model state from the checkpoint instead of the whole state. It wasn't caught because the test which was added only compared the model state and not the whole state.

Differential Revision: D17855725

