### PR TITLE
Take kwargs in Classy Datasets

### DIFF
--- a/classy_vision/dataset/classy_sun397.py
+++ b/classy_vision/dataset/classy_sun397.py
@@ -21,20 +21,11 @@ NUM_CLASSES = 397
 
 @register_dataset("sun397")
 class Sun397Dataset(ClassyDataset):
-    def __init__(self, config):
-        super(Sun397Dataset, self).__init__(config)
+    def __init__(self, split, batchsize_per_replica, shuffle, transform, num_samples):
+        super().__init__(split, batchsize_per_replica, shuffle, transform, num_samples)
         # For memoizing target names
         self._target_names = None
         self.dataset = self._load_dataset()
-        (
-            transform_config,
-            batchsize_per_replica,
-            shuffle,
-            num_samples,
-        ) = self.parse_config(config)
-        transform = build_field_transform_default_imagenet(
-            transform_config, split=self._split
-        )
         self.dataset = self.wrap_dataset(
             self.dataset,
             transform,
@@ -45,7 +36,18 @@ class Sun397Dataset(ClassyDataset):
 
     @classmethod
     def from_config(cls, config):
-        return cls(config)
+        assert "split" in config
+        split = config["split"]
+        (
+            transform_config,
+            batchsize_per_replica,
+            shuffle,
+            num_samples,
+        ) = cls.parse_config(config)
+        transform = build_field_transform_default_imagenet(
+            transform_config, split=split
+        )
+        return cls(split, batchsize_per_replica, shuffle, transform, num_samples)
 
     def _load_dataset(self):
         # TODO(aadcock): allow access to predefined train / test splits

--- a/classy_vision/dataset/core/random_image_datasets.py
+++ b/classy_vision/dataset/core/random_image_datasets.py
@@ -12,19 +12,21 @@ from .dataset import Dataset
 
 
 class RandomImageDataset(Dataset):
-    def __init__(self, config):
-        self.config = config
-        self.size = config["crop_size"]
-        self.channels = config["num_channels"]
-        self.num_classes = config["num_classes"]
-        self.seed = config["seed"]
+    def __init__(self, crop_size, num_channels, num_classes, num_samples, seed):
+        self.crop_size = crop_size
+        self.num_channels = num_channels
+        self.num_classes = num_classes
+        self.num_samples = num_samples
+        self.seed = seed
 
     def __getitem__(self, idx):
         with numpy_seed(self.seed + idx):
             return {
                 "input": Image.fromarray(
                     (
-                        np.random.standard_normal([self.size, self.size, self.channels])
+                        np.random.standard_normal(
+                            [self.crop_size, self.crop_size, self.num_channels]
+                        )
                         * 255
                     ).astype(np.uint8)
                 ),
@@ -32,27 +34,27 @@ class RandomImageDataset(Dataset):
             }
 
     def __len__(self):
-        return self.config["num_samples"]
+        return self.num_samples
 
 
 class RandomImageBinaryClassDataset(Dataset):
-    def __init__(self, config):
-        self.config = config
-        self.size = config["crop_size"]
-        self.seed = config["seed"]
+    def __init__(self, crop_size, class_ratio, num_samples, seed):
+        self.crop_size = crop_size
         # User Defined Class Imbalace Ratio
-        self.ratio = config["class_ratio"]
+        self.class_ratio = class_ratio
+        self.num_samples = num_samples
+        self.seed = seed
 
     def __getitem__(self, idx):
         with numpy_seed(self.seed + idx):
-            class_id = int(np.random.random() < self.ratio)
-            image = np.zeros((self.size, self.size, 3))
-            image[:, :, class_id] = np.random.random([self.size, self.size])
-            image[:, :, 2] = np.random.random([self.size, self.size])
+            class_id = int(np.random.random() < self.class_ratio)
+            image = np.zeros((self.crop_size, self.crop_size, 3))
+            image[:, :, class_id] = np.random.random([self.crop_size, self.crop_size])
+            image[:, :, 2] = np.random.random([self.crop_size, self.crop_size])
             return {
                 "input": Image.fromarray((image * 255).astype(np.uint8)),
                 "target": class_id,
             }
 
     def __len__(self):
-        return self.config["num_samples"]
+        return self.num_samples

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -32,16 +32,22 @@ OTHER_DUMMY_CONFIG = {"name": "other_test_dataset", "dummy0": 0, "dummy1": 1}
 class TestDataset(ClassyDataset):
     """Test dataset for validating registry functions"""
 
-    def __init__(self, config, samples):
-        super(TestDataset, self).__init__(config)
-        self.samples = samples
-        input_tensors = [sample["input"] for sample in samples]
-        target_tensors = [sample["target"] for sample in samples]
+    def __init__(self, num_samples):
+        super().__init__(
+            split=None,
+            batchsize_per_replica=1,
+            shuffle=False,
+            transform=None,
+            num_samples=num_samples,
+        )
+        self.num_samples = num_samples
+        input_tensors = [sample["input"] for sample in num_samples]
+        target_tensors = [sample["target"] for sample in num_samples]
         self.dataset = ListDataset(input_tensors, target_tensors, loader=lambda x: x)
 
     @classmethod
     def from_config(cls, config, *args, **kwargs):
-        return cls(config, *args, **kwargs)
+        return cls(*args, **kwargs)
 
 
 @register_dataset("other_test_dataset")
@@ -55,16 +61,22 @@ class OtherTestDataset(ClassyDataset):
     def get_available_splits(cls):
         return ["split0", "split1"]
 
-    def __init__(self, config):
-        super(OtherTestDataset, self).__init__(config)
-        self.samples = DUMMY_SAMPLES_1
-        input_tensors = [sample["input"] for sample in self.samples]
-        target_tensors = [sample["target"] for sample in self.samples]
+    def __init__(self, num_samples):
+        super().__init__(
+            split=None,
+            batchsize_per_replica=1,
+            shuffle=False,
+            transform=None,
+            num_samples=num_samples,
+        )
+        self.num_samples = num_samples
+        input_tensors = [sample["input"] for sample in self.num_samples]
+        target_tensors = [sample["target"] for sample in self.num_samples]
         self.dataset = ListDataset(input_tensors, target_tensors, loader=lambda x: x)
 
     @classmethod
-    def from_config(cls, config):
-        return cls(config)
+    def from_config(cls, config, *args, **kwargs):
+        return cls(*args, **kwargs)
 
 
 class TestRegistryFunctions(unittest.TestCase):
@@ -129,9 +141,9 @@ class TestClassyDataset(unittest.TestCase):
 
         # Check assert for changing dataset types
         with self.assertRaises(AssertionError):
-            other_dataset = build_dataset(OTHER_DUMMY_CONFIG)
+            other_dataset = build_dataset(OTHER_DUMMY_CONFIG, DUMMY_SAMPLES_1)
             other_dataset.set_classy_state(state)
 
         # Verify when strict flag is false, this does not throw
-        other_dataset = build_dataset(OTHER_DUMMY_CONFIG)
+        other_dataset = build_dataset(OTHER_DUMMY_CONFIG, DUMMY_SAMPLES_1)
         other_dataset.set_classy_state(state, strict=False)

--- a/test/dataset_image_path_dataset_test.py
+++ b/test/dataset_image_path_dataset_test.py
@@ -78,7 +78,9 @@ class TestImageDataset(unittest.TestCase):
         config = self.get_dataset_config()
 
         # create an image dataset from the list of images
-        dataset = ImagePathDataset(config, image_paths=image_paths, targets=targets)
+        dataset = ImagePathDataset.from_config(
+            config, image_paths=image_paths, targets=targets
+        )
         dataloader = dataset.iterator()
         # the samples should be in the same order
         for sample, expected_input, expected_target in zip(dataloader, inputs, targets):
@@ -86,14 +88,14 @@ class TestImageDataset(unittest.TestCase):
             self.assertEqual(sample["target"], expected_target)
 
         # test the dataset works without targets as well
-        dataset = ImagePathDataset(config, image_paths=image_paths)
+        dataset = ImagePathDataset.from_config(config, image_paths=image_paths)
         dataloader = dataset.iterator()
         # the samples should be in the same order
         for sample, expected_input in zip(dataloader, inputs):
             self.assertTrue(torch.allclose(sample["input"], expected_input))
 
         # create an image dataset from the root dir
-        dataset = ImagePathDataset(config, image_paths=self.base_dir)
+        dataset = ImagePathDataset.from_config(config, image_paths=self.base_dir)
         dataloader = dataset.iterator()
         # test that we get the same class distribution
         # we don't test the actual samples since the ordering isn't defined

--- a/test/dataset_transforms_lighting_transform_test.py
+++ b/test/dataset_transforms_lighting_transform_test.py
@@ -14,16 +14,9 @@ from classy_vision.dataset.transforms.util import build_field_transform_default_
 
 class LightingTransformTest(unittest.TestCase):
     def get_test_image_dataset(self):
-        config = {
-            "crop_size": 224,
-            "num_channels": 3,
-            "num_classes": 10,
-            "seed": 0,
-            "class_ratio": 0.5,
-            "num_samples": 100,
-        }
-        dataset = RandomImageBinaryClassDataset(config)
-        return dataset
+        return RandomImageBinaryClassDataset(
+            crop_size=224, class_ratio=0.5, num_samples=100, seed=0
+        )
 
     def test_lighting_transform_no_errors(self):
         """

--- a/test/dataset_transforms_util_test.py
+++ b/test/dataset_transforms_util_test.py
@@ -19,16 +19,9 @@ from classy_vision.dataset.transforms.util import (
 
 class DatasetTransformsUtilTest(unittest.TestCase):
     def get_test_image_dataset(self):
-        config = {
-            "crop_size": 224,
-            "num_channels": 3,
-            "num_classes": 10,
-            "seed": 0,
-            "class_ratio": 0.5,
-            "num_samples": 100,
-        }
-        dataset = RandomImageBinaryClassDataset(config)
-        return dataset
+        return RandomImageBinaryClassDataset(
+            crop_size=224, class_ratio=0.5, num_samples=100, seed=0
+        )
 
     def test_build_field_transform_default_imagenet(self):
         dataset = self.get_test_image_dataset()


### PR DESCRIPTION
Summary:
Currently, for all datasets, the initialization happens through the config. This diff changes it so that all the OSS datasets take kwargs instead. `ClassyDataset` now expects the following args to be provided during initialization - `split, batchsize_per_replica, shuffle, transform, num_samples`. Converted `parse_config` and `wrap_dataset` to `classmethod`s (In a strict sense, they shoud be `staticmethod`s, but that conversion will do more harm than good).

There are a lot of other things which need to be cleaned up in datasets, but this is a start!

Differential Revision: D17869562

