### PR TITLE
support group size in ShardDataset

### DIFF
--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -97,6 +97,7 @@ class ClassyDataset(Dataset):
         filter_func=_return_true,
         shuffle=True,
         subsample=None,
+        shard_group_size=1,
     ):
         """
         Wraps a dataset with TransformDataset, ShuffleDataset,
@@ -125,7 +126,9 @@ class ClassyDataset(Dataset):
             dataset = dataset.resample([n for n in range(subsample)])
 
         # shard data
-        dataset = dataset.shard(get_world_size(), get_rank())
+        dataset = dataset.shard(
+            get_world_size(), get_rank(), group_size=shard_group_size
+        )
 
         # batch data if requested:
         dataset = dataset.batch(batchsize_per_replica, filter_func=filter_func)

--- a/classy_vision/dataset/core/shard_dataset.py
+++ b/classy_vision/dataset/core/shard_dataset.py
@@ -22,20 +22,32 @@ class ShardDataset(Dataset):
         Meters and loss from dummy_sample will be ignored.
 
         Sharding logic:
-        Sharding is done by going over the original dataset by taking `mod` operation
-        (detailed example below).
-        For incomplete shards, roll over the real samples to generate dummy samples.
+            Dataset is first divided into groups of samples. Sharding is done by
+            going over the original dataset by taking `mod` operation to sample
+            groups.  (detailed example below). For incomplete shards, roll over
+            the real samples to generate dummy samples.
 
-        Example:
-            dataset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-            world_size: 4
+            Example:
+                dataset: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+                world_size: 4
 
-            RANK    |  shard_dataset  | is_dummy_sample
-            ===========================================
-            rank_0  |  [0, 4, 8, 12]  |  [0, 0, 0, 0]
-            rank_1  |  [1, 5, 9, 13]  |  [0, 0, 0, 0]
-            rank_2  |  [2, 6, 10, 2]  |  [0, 0, 0, 1]
-            rank_3  |  [3, 7, 11, 3]  |  [0, 0, 0, 1]
+            when group_size = 1
+                    RANK    |  shard_dataset  | is_dummy_sample
+                    ===========================================
+                    rank_0  |  [0, 4, 8, 12]  |  [0, 0, 0, 0]
+                    rank_1  |  [1, 5, 9, 13]  |  [0, 0, 0, 0]
+                    rank_2  |  [2, 6, 10, 2]  |  [0, 0, 0, 1]
+                    rank_3  |  [3, 7, 11, 3]  |  [0, 0, 0, 1]
+
+            when group_size = 2
+
+                    RANK    |  shard_dataset  | is_dummy_sample
+                    ===========================================
+                    rank_0  |  [0, 1, 8, 9]  |  [0, 0, 0, 0]
+                    rank_1  |  [2, 3, 10, 11]  |  [0, 0, 0, 0]
+                    rank_2  |  [4, 5, 4, 5]  |  [0, 0, 1, 1]
+                    rank_3  |  [6, 7, 6, 7]  |  [0, 0, 1, 1]
+
 
         Note:
             shard_dataset operates only on dataset with individual samples and
@@ -43,13 +55,20 @@ class ShardDataset(Dataset):
             .batch() call on dataset must happen after .shard() call.
     """
 
-    def __init__(self, dataset, world_size, rank):
+    def __init__(self, dataset, world_size, rank, group_size=1):
+        assert len(dataset) % group_size == 0, (
+            "dataset length must be a multiplier of group size"
+            "dataset length: %d, group size: %d" % (len(dataset), group_size)
+        )
         self.world_size = world_size
         self.rank = rank
         self.dataset = dataset
-        self.real_shard_length = (len(self.dataset) // self.world_size) + (
-            self.rank < (len(self.dataset) % self.world_size)
-        )
+        self.group_size = group_size
+        dataset_group_size = len(self.dataset) // group_size
+        self.real_shard_length = (
+            (dataset_group_size // self.world_size)
+            + (self.rank < (dataset_group_size % self.world_size))
+        ) * self.group_size
 
     def __getitem__(self, idx):
         # For last shard, loop over the real samples to generate dummy samples.
@@ -58,7 +77,13 @@ class ShardDataset(Dataset):
             is_dummy_sample = 1
         is_dummy_sample = torch.tensor(is_dummy_sample)
         idx = idx % self.real_shard_length
-        dataset_index = int(idx * self.world_size + self.rank)
+        group_idx = idx // self.group_size
+        group_remainder = idx % self.group_size
+        dataset_index = (
+            int(group_idx * self.world_size + self.rank) * self.group_size
+            + group_remainder
+        )
+
         sample = self.dataset[dataset_index]
         assert sample is None or isinstance(
             sample, dict
@@ -69,4 +94,5 @@ class ShardDataset(Dataset):
         return sample
 
     def __len__(self):
-        return int(math.ceil(len(self.dataset) * 1.0 / self.world_size))
+        dataset_group_size = len(self.dataset) // self.group_size
+        return int(math.ceil(dataset_group_size / self.world_size)) * self.group_size

--- a/test/dataset_core_shard_dataset_test.py
+++ b/test/dataset_core_shard_dataset_test.py
@@ -83,3 +83,88 @@ class ShardDatasetTest(unittest.TestCase):
 
         # Check that last two samples are dummy samples.
         self.assertTrue(shard_dataset[3]["is_dummy_sample"] == torch.tensor(1))
+
+    def test_shard_dataset_length_group_size(self):
+        """
+        Test that sharded dataset length is correct.
+        """
+        test_dataset, _ = create_test_dataset(tensor_size=(260, 3, 224, 224))
+        WORLD_SIZE = 8
+
+        for rank in range(WORLD_SIZE):
+            shard_dataset = ShardDataset(
+                test_dataset, world_size=WORLD_SIZE, rank=rank, group_size=10
+            )
+            self.assertTrue(len(shard_dataset) == 40)
+
+    def test_non_final_shard_dataset_index_group_size(self):
+        """
+        Test that for non-final shard, the indices map to
+        correct indices from the main dataset.
+        """
+        test_dataset, _ = create_test_dataset(tensor_size=(260, 3, 224, 224))
+        WORLD_SIZE = 8
+        RANK = 1
+
+        shard_dataset = ShardDataset(
+            test_dataset, world_size=WORLD_SIZE, rank=RANK, group_size=10
+        )
+
+        for i in range(len(shard_dataset)):
+            # Check if video clip is correct.
+            group_idx = i // 10
+            group_reminder = i % 10
+            ind = (group_idx * WORLD_SIZE + RANK) * 10 + group_reminder
+            self.assertTrue(
+                torch.all(
+                    shard_dataset[i]["input"] == test_dataset[ind]["input"]
+                ).item()
+                == 1
+            )
+            # Check if target is correct
+            self.assertTrue(
+                torch.all(
+                    shard_dataset[i]["target"] == test_dataset[ind]["target"]
+                ).item()
+                == 1
+            )
+            # For rank 0 and 1, all 40 samples are real
+            self.assertTrue(shard_dataset[i]["is_dummy_sample"] == torch.tensor(0))
+
+    def test_final_shard_dataset_index_sequential_mode(self):
+        """
+        Test that for final shard, the indices map to correct indices from the
+        main dataset and is_dummy_sample is as expected.
+        """
+        test_dataset, _ = create_test_dataset(tensor_size=(260, 3, 224, 224))
+        WORLD_SIZE = 8
+        RANK = 4
+
+        shard_dataset = ShardDataset(
+            test_dataset, world_size=WORLD_SIZE, rank=RANK, group_size=10
+        )
+        # Check that for rank 2, 3, 4, 5, 6, 7, first 30 samples are real and
+        # last 10 samples are dummy.
+        for i in range(30):
+            # Check if video clip is correct.
+            group_idx = i // 10
+            group_reminder = i % 10
+            ind = (group_idx * WORLD_SIZE + RANK) * 10 + group_reminder
+            self.assertTrue(
+                torch.all(
+                    shard_dataset[i]["input"] == test_dataset[ind]["input"]
+                ).item()
+                == 1
+            )
+            # Check if target is correct
+            self.assertTrue(
+                torch.all(
+                    shard_dataset[i]["target"] == test_dataset[ind]["target"]
+                ).item()
+                == 1
+            )
+            self.assertTrue(shard_dataset[i]["is_dummy_sample"] == torch.tensor(0))
+
+        for i in range(30, 40):
+            # Check that last 10 samples are dummy samples.
+            self.assertTrue(shard_dataset[i]["is_dummy_sample"] == torch.tensor(1))


### PR DESCRIPTION
Summary:
For video model evaluation, we sample N clips from a video, and average clip predictions to get a video-level prediction.
Assume, we sample 2 clips per video. The test dataset, which has 4 videos {A,B,C,D} is illustrated below.

    [A_0, A_1, B_0, B_1, C_0, C_1, D_0, D_1]

Assume we have 2 gpus. The existing ShardDataset will distribute clips from the same video to different gpus, and make it difficult to average clip predictions.
    GPU 0: [A_0, B_0, C_0, D_0]
    GPU 1: [A_1, B_1, C_1, D_1]

This is called Stride Shading.

We extend ShardDataset to support Sequential Sharding, which will shard clips below.
    GPU 0: [A_0, A_1, B_0, B_1]
    GPU 1: [C_0, C_1, D_0, D_1]

This facilitates the averaging of clip predictions.

Reviewed By: mannatsingh

Differential Revision: D17662575

