### PR TITLE
Pick up the correct transform in the hub interface

### DIFF
--- a/classy_vision/hub/classy_hub_interface.py
+++ b/classy_vision/hub/classy_hub_interface.py
@@ -76,18 +76,15 @@ class ClassyHubInterface:
             if it is not found there.
         """
         if transform is None:
-            transform_config = None
-            if self.task is not None:
-                # TODO (@mannatsingh): The transforms aren't picked up from
-                # self.task's datasets, but from the task's config.
-                transform_config = (
-                    self.task.get_config()["dataset"]
-                    .get(split, {})
-                    .get("transforms", None)
+            if self.task is not None and split in self.task.datasets:
+                # use the transform from the dataset for the split
+                dataset = self.task.datasets[split]
+                transform = dataset.transform
+                assert transform is not None, "Cannot infer transform from the task"
+            else:
+                transform = build_field_transform_default_imagenet(
+                    config=None, split=split
                 )
-            transform = build_field_transform_default_imagenet(
-                transform_config, split=split
-            )
         return ImagePathDataset(
             batchsize_per_replica,
             shuffle,

--- a/test/hub_classy_hub_interface_test.py
+++ b/test/hub_classy_hub_interface_test.py
@@ -10,10 +10,16 @@ import unittest
 from test.generic.config_utils import get_test_args, get_test_task_config
 
 import torch
+from classy_vision.dataset.transforms import ClassyTransform
 from classy_vision.hub import ClassyHubInterface
 from classy_vision.models import ClassyVisionModel, build_model
 from classy_vision.tasks import ClassyVisionTask, build_task
 from torchvision import models, transforms
+
+
+class TestTransform(ClassyTransform):
+    def __call__(self, x):
+        return x
 
 
 class TestClassyHubInterface(unittest.TestCase):
@@ -62,6 +68,14 @@ class TestClassyHubInterface(unittest.TestCase):
 
         # this will pick up the transform from the task's config
         self._test_predict_and_extract_features(hub_interface)
+
+        # test that the correct transform is picked up
+        split = "test"
+        test_transform = TestTransform()
+        task.datasets[split].transform = test_transform
+        hub_interface = ClassyHubInterface.from_task(task)
+        dataset = hub_interface.create_image_dataset([self.image_path], split=split)
+        self.assertIsInstance(dataset.transform, TestTransform)
 
     def test_from_model(self):
         for model in [self._get_classy_model(), self._get_non_classy_model()]:


### PR DESCRIPTION
Summary: Now that a dataset's `transform` is part of the `ClassyDataset` API, we can pick up the correct transform in `ClassyHubInterface().create_image_dataset()`.

Differential Revision: D17912094

