### PR TITLE
extend profiler and visualizer to support dict-type input in model forward method

### DIFF
--- a/classy_vision/generic/profiler.py
+++ b/classy_vision/generic/profiler.py
@@ -10,7 +10,7 @@ import operator
 
 import torch
 import torch.nn as nn
-from classy_vision.generic.util import is_leaf, is_on_gpu
+from classy_vision.generic.util import get_model_dummy_input, is_leaf, is_on_gpu
 from torch.cuda import cudart
 
 
@@ -219,7 +219,7 @@ def restore_forward(model):
     return model
 
 
-def compute_flops(model, input_shape=(3, 244, 244)):
+def compute_flops(model, input_shape=(3, 244, 244), input_key=None):
     """
     Compute the number of FLOPs needed for a forward pass.
     """
@@ -228,11 +228,7 @@ def compute_flops(model, input_shape=(3, 244, 244)):
     assert isinstance(model, nn.Module)
     if not isinstance(input_shape, abc.Sequence):
         return None
-    shape = (1,) + tuple(input_shape)
-    input = torch.zeros(shape)
-    if next(model.parameters()).is_cuda:
-        input = input.cuda()
-
+    input = get_model_dummy_input(model, input_shape, input_key)
     flops_list = []
 
     # measure FLOPs:

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -696,3 +696,14 @@ def bind_method_to_class(method, cls):
     Binds an already bound method to the provided class.
     """
     return method.__func__.__get__(cls)
+
+
+def get_model_dummy_input(model, input_shape, input_key):
+    # add a dimension to represent minibatch axis
+    shape = (1,) + tuple(input_shape)
+    input = torch.zeros(shape)
+    if next(model.parameters()).is_cuda:
+        input = input.cuda()
+    if input_key:
+        input = {input_key: input}
+    return input

--- a/classy_vision/generic/visualize.py
+++ b/classy_vision/generic/visualize.py
@@ -9,7 +9,7 @@ import math
 import numpy as np
 import torch
 import torch.nn.modules as nn
-from classy_vision.generic.util import is_pos_int
+from classy_vision.generic.util import get_model_dummy_input, is_pos_int
 from PIL import Image
 
 
@@ -125,7 +125,9 @@ def plot_losses(losses, visdom_server=None, env=None, win=None, title=""):
     return win
 
 
-def plot_model(model, size=(3, 224, 224), writer=None, folder="", train=True):
+def plot_model(
+    model, size=(3, 224, 224), input_key=None, writer=None, folder="", train=True
+):
     """Visualizes a model in TensorBoard.
 
     The TensorBoard writer can be either specified directly via `writer` or can
@@ -141,13 +143,7 @@ def plot_model(model, size=(3, 224, 224), writer=None, folder="", train=True):
     assert (
         writer is not None or folder != ""
     ), "must specify SummaryWriter or folder to create SummaryWriter in"
-    if len(size) == 3:
-        size = (1,) + size
-    assert len(size) == 4, "size must be tuple of length 4 (NCHW)"
-
-    input = torch.zeros(size)
-    if next(model.parameters()).is_cuda:
-        input = input.cuda()
+    input = get_model_dummy_input(model, size, input_key)
     if writer is None:
         writer = SummaryWriter(log_dir=folder, comment="Model graph")
     with writer:

--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -33,7 +33,11 @@ class ModelComplexityHook(ClassyHook):
         """
         try:
             num_flops = compute_flops(
-                state.model, input_shape=state.base_model.input_shape
+                state.model,
+                input_shape=state.base_model.input_shape,
+                input_key=state.base_model.input_key
+                if hasattr(state.base_model, "input_key")
+                else None,
             )
             if num_flops is None:
                 logging.info("FLOPs for forward pass: skipped.")

--- a/classy_vision/hooks/model_tensorboard_hook.py
+++ b/classy_vision/hooks/model_tensorboard_hook.py
@@ -57,6 +57,9 @@ class ModelTensorboardHook(ClassyHook):
                 plot_model(
                     state.base_model,
                     size=state.base_model.input_shape,
+                    input_key=state.base_model.input_key
+                    if hasattr(state.base_model, "input_key")
+                    else None,
                     writer=self.tb_writer,
                 )
             except Exception:


### PR DESCRIPTION
Summary:
In `forward` method of video models, we take input of data type dictionary where key is modality such as 'video' and `audio`.
To support this, we extend profiler and `plot_model` to prepare dictionary input as needed.

Reviewed By: mannatsingh

Differential Revision: D17770657

