### PR TITLE
Initialize optimizer after moving model to gpu

### DIFF
--- a/classy_vision/optim/classy_optimizer.py
+++ b/classy_vision/optim/classy_optimizer.py
@@ -83,6 +83,13 @@ class ClassyOptimizer(object):
         """
         return {"lr": self.lr}
 
+    def init_pytorch_optimizer(self):
+        """
+        Initialize the underlying Pytorch optimizer. The initialization should happen
+        only after the model has been moved to the correct device.
+        """
+        pass
+
     def get_classy_state(self):
         """
         Return the optimizer's state dict.

--- a/classy_vision/optim/rmsprop.py
+++ b/classy_vision/optim/rmsprop.py
@@ -34,14 +34,16 @@ class RMSProp(ClassyOptimizer):
         self.alpha = alpha
         self.eps = eps
         self.centered = centered
+
+    def init_pytorch_optimizer(self):
         self._optimizer = torch.optim.RMSprop(
             self.param_groups_override,
             lr=self.lr,
-            momentum=momentum,
-            weight_decay=weight_decay,
-            alpha=alpha,
-            eps=eps,
-            centered=centered,
+            momentum=self.momentum,
+            weight_decay=self.weight_decay,
+            alpha=self.alpha,
+            eps=self.eps,
+            centered=self.centered,
         )
 
     @classmethod

--- a/classy_vision/optim/sgd.py
+++ b/classy_vision/optim/sgd.py
@@ -19,12 +19,14 @@ class SGD(ClassyOptimizer):
         self.momentum = momentum
         self.weight_decay = weight_decay
         self.nesterov = nesterov
+
+    def init_pytorch_optimizer(self):
         self._optimizer = torch.optim.SGD(
             self.param_groups_override,
             lr=self.lr,
-            nesterov=nesterov,
-            momentum=momentum,
-            weight_decay=weight_decay,
+            nesterov=self.nesterov,
+            momentum=self.momentum,
+            weight_decay=self.weight_decay,
         )
 
     @classmethod

--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -7,7 +7,6 @@
 import torch
 from classy_vision.generic.classy_trainer_common import train_step
 from classy_vision.generic.distributed_util import barrier, is_distributed_training_run
-from classy_vision.generic.util import copy_model_to_gpu
 from classy_vision.hooks import ClassyHookFunctions
 from classy_vision.tasks import ClassyVisionTask
 
@@ -23,12 +22,10 @@ class ClassyTrainer:
         """
 
         pin_memory = self.use_gpu and torch.cuda.device_count() > 1
-        task.prepare(num_workers=self.num_workers, pin_memory=pin_memory)
+        task.prepare(
+            num_workers=self.num_workers, pin_memory=pin_memory, use_gpu=self.use_gpu
+        )
         assert isinstance(task, ClassyVisionTask)
-
-        if self.use_gpu:
-            task.criterion = task.criterion.cuda()
-            task.base_model = copy_model_to_gpu(task.base_model)
 
         if is_distributed_training_run():
             task.init_distributed_data_parallel_model()

--- a/test/generic/optim_test_util.py
+++ b/test/generic/optim_test_util.py
@@ -89,6 +89,7 @@ class TestOptimizer(ABC):
 
         mock_classy_vision_model = self._get_mock_classy_vision_model()
         opt1 = build_optimizer(config, mock_classy_vision_model)
+        opt1.init_pytorch_optimizer()
 
         self._set_model_gradient(mock_classy_vision_model, grad_values)
         opt1.step()
@@ -96,6 +97,7 @@ class TestOptimizer(ABC):
 
         config["lr"] += 0.1
         opt2 = build_optimizer(config, mock_classy_vision_model)
+        opt2.init_pytorch_optimizer()
         self.assertTrue(isinstance(opt1, self._instance_to_test()))
         opt2.set_classy_state(state)
         self.assertEqual(opt1.parameters, opt2.parameters)
@@ -116,7 +118,9 @@ class TestOptimizer(ABC):
         self._set_model_gradient(mock_classy_vision_model1, grad_values)
         self._set_model_gradient(mock_classy_vision_model2, grad_values)
         opt1 = build_optimizer(config, mock_classy_vision_model1)
+        opt1.init_pytorch_optimizer()
         opt2 = build_optimizer(config, mock_classy_vision_model2)
+        opt2.init_pytorch_optimizer()
         opt1.step()
         opt2.step()
         for i in range(len(opt1.optimizer.param_groups[0]["params"])):
@@ -137,15 +141,17 @@ class TestOptimizer(ABC):
             trainable_params=True
         )
         opt = build_optimizer(config, mock_classy_vision_model)
+        opt.init_pytorch_optimizer()
         self.assertTrue(isinstance(opt, self._instance_to_test()))
 
     def test_raise_error_on_non_trainable_params(self):
         # Test Raise ValueError if there are no trainable params in the model.
         config = self._get_config()
         with self.assertRaises(ValueError):
-            build_optimizer(
+            opt = build_optimizer(
                 config, self._get_mock_classy_vision_model(trainable_params=False)
             )
+            opt.init_pytorch_optimizer()
 
     def test_get_set_state(self):
         for grad_values in [[0.1, 0.1], [-0.1, -0.1], [0.0, 0.0], [0.1, -0.1]]:
@@ -155,6 +161,7 @@ class TestOptimizer(ABC):
         config = self._get_config()
         mock_classy_vision_model = self._get_mock_classy_vision_model()
         opt = build_optimizer(config, mock_classy_vision_model)
+        opt.init_pytorch_optimizer()
         self.assertTrue(isinstance(opt, self._instance_to_test()))
 
         with self.assertRaises(KeyError):
@@ -165,6 +172,7 @@ class TestOptimizer(ABC):
 
         mock_classy_vision_model = self._get_mock_classy_vision_model()
         opt = build_optimizer(config, mock_classy_vision_model)
+        opt.init_pytorch_optimizer()
 
         # Test initial learning rate
         for group in opt._optimizer.param_groups:
@@ -191,6 +199,7 @@ class TestOptimizer(ABC):
         # Test step learning schedule
         config["lr"] = {"name": "step", "values": [0.1, 0.01, 0.001]}
         opt = build_optimizer(config, mock_classy_vision_model)
+        opt.init_pytorch_optimizer()
         targets = [0.1] * 8 + [0.01] * 3 + [0.001] * 4
         _test_lr_schedule(opt, num_epochs, epochs, targets)
 
@@ -204,5 +213,6 @@ class TestOptimizer(ABC):
         }
 
         opt = build_optimizer(config, mock_classy_vision_model)
+        opt.init_pytorch_optimizer()
         targets = [0.01, 0.0325, 0.055] + [0.1] * 5 + [0.01] * 3 + [0.001] * 4
         _test_lr_schedule(opt, num_epochs, epochs, targets)


### PR DESCRIPTION
Summary:
Added a method - `init_pytorch_optimizer()` to `ClassyOptimizer`. Instead of initializing the pytorch optimizers in `__init__()`, they are initialized here. This is needed because we create the optimizer before moving the model to the gpu.

 `ClassyTask.build_initial_state()` now takes `use_gpu` as an arg, and copies the model and criterion to the gpu (if needed), and then calls `init_pytorch_optimizer()`.

Differential Revision: D17936851

