### PR TITLE
use nightly torchvision and torch 1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
+            pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
 
       - save_cache:
           paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-torch==1.2
-torchvision==0.4.0
+torch==1.3


### PR DESCRIPTION
Summary:
Current dependency torchvision 0.4.0 was released in August.
It missed quite a few PRs that are merged after that, and that are needed for video classification, such as

- https://github.com/pytorch/vision/pull/1437
- https://github.com/pytorch/vision/pull/1431
- https://github.com/pytorch/vision/pull/1423
- https://github.com/pytorch/vision/pull/1418
- https://github.com/pytorch/vision/pull/1408
- https://github.com/pytorch/vision/pull/1376
- https://github.com/pytorch/vision/pull/1363
- https://github.com/pytorch/vision/pull/1353
- https://github.com/pytorch/vision/pull/1303

This will fail the CI test when a diff uses changes made in those PRs.
Before a new official version of TorchVision is released, we can temporarily use the nightly torchvision to get all the recent PRs, and unblock the PR merging.
We plan to use a fixed version of TorchVision later.

Differential Revision: D17944239

