### PR TITLE
use torchvision 0.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
-            pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
 
       - save_cache:
           paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 torch==1.3
+torchvision==0.4.1


### PR DESCRIPTION
Summary:
In D17944239, we try to get a more recent version of Torchvision by pip installing from nightly page.
After a close look, we find for linux platform, we can only get version `0.4.1`.
We can achieve this by noting `torchvision==0.4.1` in the `requirements.txt` file.
Thus, we don't need to use nightly page.

Differential Revision: D17949130

