### PR TITLE
use nightly torchvision 0.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
+            pip install --pre torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
 
       - save_cache:
           paths:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-torch==1.3
-torchvision==0.4.1
+torch==1.3.0


### PR DESCRIPTION
Summary:
The latest torchvision version `0.5.0` is recently uploaded to nightly page, and supports all linux, osx and win platforms.

Upgrade ClassyVision to use nightly version and get access to many new features that are needed for video classification.

Reviewed By: vreis

Differential Revision: D17964239

