### PR TITLE
change hash key and force to update cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v2-dependencies-{{ checksum "requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
 
       - run:
           name: install dependencies
@@ -31,7 +31,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
           name: run tests


### PR DESCRIPTION
Summary:
TorchVision on CI hosts remains version `0.4.1` even we choose to use nightly version `0.5.0` in D17964239.
The reason is the hash key of cache remains the same, and the cached TV installation is used.
Change to hash key, and force to update cache to use TV `0.5.0`.

Differential Revision: D17970613

