### PR TITLE
Fix convert_to_one_hot using incorrect device

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -681,12 +681,9 @@ def convert_to_one_hot(targets, classes):
     assert (
         torch.max(targets).item() < classes
     ), "Class Index must be less than number of classes"
-    usecuda = False
-    if torch.cuda.is_available():
-        usecuda = True
-    one_hot_targets = torch.zeros((targets.shape[0], classes), dtype=torch.long)
-    if usecuda:
-        one_hot_targets = one_hot_targets.cuda()
+    one_hot_targets = torch.zeros(
+        (targets.shape[0], classes), dtype=torch.long, device=targets.device
+    )
     one_hot_targets.scatter_(1, targets.long(), 1)
     return one_hot_targets
 


### PR DESCRIPTION
Summary: `convert_to_one_hot()` takes a target tensor containing just the target index and returns a one hot tensor. It used to check if cuda was available to determine the device of the returned tensor. Instead, the returned tensor now uses the same device as the input tensor.

Reviewed By: vreis

Differential Revision: D17973726

