### PR TITLE
set torchvision video backend

### DIFF
--- a/classy_vision/dataset/__init__.py
+++ b/classy_vision/dataset/__init__.py
@@ -7,9 +7,20 @@
 from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
+from torchvision import set_video_backend
 
 from .classy_dataset import ClassyDataset
 
+
+# TorchVision supports 2 types of video backend, namely pyav and video_reader.
+# pyav backend has pyav dependency, which is easy to resolve for both pip and conda
+# installation setup in TorchVision prebuilt package.
+# video_reader backend has ffmpeg dependency, which is easy to resolve in conda
+# setup but is hard to resolve in pip setup.
+# To ensure ClassyVision is easy to install for both pip and conda users, we
+# choose to use pyav backend by default.
+
+set_video_backend("pyav")
 
 FILE_ROOT = Path(__file__).parent
 


### PR DESCRIPTION
Summary:
TorchVision supports 2 types of video backend
- pyav
- video_reader

`video_reader` is generally faster for video decoding but has dependency on ffmpeg.  However, it has ffmpeg dependency, and is hard to be automatically resolved in TorchVision release with prebuilt package.
Therefore, by default, for OSS ClassyVision, we choose to use `pyav` backend.

Reviewed By: taylorgordon20, kazhang

Differential Revision: D17587685

