### PR TITLE
Remove reset_heads from ClassyVisionTask

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -459,7 +459,7 @@ def load_checkpoint(checkpoint_folder, device, checkpoint_file=CHECKPOINT_FILE):
         )
 
 
-def update_classy_state(task, state_dict, reset_heads=False):
+def update_classy_state(task, state_dict):
     """
     Updates the task with the provided task dictionary.
 
@@ -467,17 +467,10 @@ def update_classy_state(task, state_dict, reset_heads=False):
         task: ClassyTask instance to update
         state_dict: State dict, should be the output of a call to
             ClassyTask.get_classy_state().
-        reset_heads: if False, uses the heads' state from the checkpoint.
     """
     logging.info("Loading classy state from checkpoint")
 
     try:
-        if reset_heads:
-            current_state_dict = task.get_classy_state()
-            # replace the checkpointed head states with source head states
-            state_dict["base_model"]["model"]["heads"] = current_state_dict[
-                "base_model"
-            ]["model"]["heads"]
         task.set_classy_state(state_dict)
         logging.info("Checkpoint load successful")
         return True

--- a/classy_vision/tasks/classy_vision_task.py
+++ b/classy_vision/tasks/classy_vision_task.py
@@ -27,7 +27,6 @@ class ClassyVisionTask(object):
         self.meters = []
         self.num_phases = num_phases
         self.test_only = False
-        self.reset_heads = False
         self.base_model = None
         self.optimizer = None
         self.checkpoint = None
@@ -108,7 +107,6 @@ class ClassyVisionTask(object):
         for split in splits:
             task.set_dataset(datasets[split], split)
 
-        task.reset_heads = config.get("reset_heads", False)
         return task
 
     def get_config(self):
@@ -191,9 +189,7 @@ class ClassyVisionTask(object):
         )
 
         if classy_state_dict is not None:
-            state_load_success = update_classy_state(
-                self, classy_state_dict, reset_heads=self.reset_heads
-            )
+            state_load_success = update_classy_state(self, classy_state_dict)
             assert (
                 state_load_success
             ), "Update classy state from checkpoint was unsuccessful."

--- a/test/state_classy_state_test.py
+++ b/test/state_classy_state_test.py
@@ -96,24 +96,14 @@ class TestClassyState(unittest.TestCase):
         task = build_task(config, args, local_rank=0)
         task_2 = build_task(config, args, local_rank=0)
 
-        for reset_heads in [True, False]:
-            task.reset_heads = reset_heads
-            task_2.reset_heads = reset_heads
+        task.prepare()
+        task_2.prepare()
 
-            task.prepare()
-            task_2.prepare()
-
-            # test in both train and test mode
-            for _ in range(2):
-                task.advance_phase()
-
-                update_classy_state(
-                    task_2, task.get_classy_state(deep_copy=True), reset_heads
-                )
-
-                self._compare_states(
-                    task.get_classy_state(), task_2.get_classy_state(), not reset_heads
-                )
+        # test in both train and test mode
+        for _ in range(2):
+            task.advance_phase()
+            update_classy_state(task_2, task.get_classy_state(deep_copy=True))
+            self._compare_states(task.get_classy_state(), task_2.get_classy_state())
 
     def test_freeze_trunk(self):
         """
@@ -121,7 +111,6 @@ class TestClassyState(unittest.TestCase):
         """
         config = get_test_task_config()
         config["model"]["freeze_trunk"] = True
-        config["reset_heads"] = True
         # use a batchsize of 1 for faster testing
         for split in ["train", "test"]:
             config["dataset"][split]["batchsize_per_replica"] = 1


### PR DESCRIPTION
Summary:
Since we are creating a separate task for fine tuning, removing `reset_heads` as a parameter from `ClassyVisionTask`

This is my plans for the diffs in this stack -
- Remove reset_heads from base task
- Refactor tests
- Create a fine tuning task
- Add support for this task in fblearner and actually run fine tuning in the test plan

Differential Revision: D18007666

