### PR TITLE
Create a fine tuning task

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -467,6 +467,31 @@ def load_checkpoint(checkpoint_folder, device, checkpoint_file=CHECKPOINT_FILE):
         )
 
 
+def update_classy_model(model, model_state_dict, reset_heads):
+    """
+    Updates the model with the provided model state dictionary.
+
+    Args:
+        model: ClassyVisionModel instance to update
+        model_state_dict: State dict, should be the output of a call to
+            ClassyVisionModel.get_classy_state().
+        reset_heads: if False, uses the heads' state from model_state_dict.
+    """
+    try:
+        if reset_heads:
+            current_model_state_dict = model.get_classy_state()
+            # replace the checkpointed head states with source head states
+            model_state_dict["model"]["heads"] = current_model_state_dict["model"][
+                "heads"
+            ]
+        model.set_classy_state(model_state_dict)
+        logging.info("Model state load successful")
+        return True
+    except Exception:
+        logging.exception("Could not load the model state")
+    return False
+
+
 def update_classy_state(task, state_dict):
     """
     Updates the task with the provided task dictionary.

--- a/classy_vision/tasks/__init__.py
+++ b/classy_vision/tasks/__init__.py
@@ -68,3 +68,9 @@ def register_task(name):
 
 # automatically import any Python files in the tasks/ directory
 import_all_modules(FILE_ROOT, "classy_vision.tasks")
+
+
+from .fine_tuning_task import FineTuningTask  # isort:skip
+
+
+__all__ = ["ClassyTask", "FineTuningTask", "build_task", "register_task"]

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+from classy_vision.generic.util import update_classy_model
+from classy_vision.tasks import register_task
+from classy_vision.tasks.classy_task import ClassyTask
+
+
+@register_task("fine_tuning")
+class FineTuningTask(ClassyTask):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pretrained_checkpoint = None
+        self.reset_heads = False
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "FineTuningTask":
+        task = super().from_config(config)
+        task.reset_heads = config.get("reset_heads", False)
+        return task
+
+    def set_pretrained_checkpoint(self, checkpoint: Dict[str, Any]) -> "FineTuningTask":
+        assert (
+            "classy_state_dict" in checkpoint
+        ), "Checkpoint does not contain classy_state_dict"
+        self.pretrained_checkpoint = checkpoint
+        return self
+
+    def set_reset_heads(self, reset_heads: bool) -> "FineTuningTask":
+        self.reset_heads = reset_heads
+        return self
+
+    def prepare(
+        self, num_workers: int = 0, pin_memory: bool = False, use_gpu: bool = False
+    ) -> None:
+        assert (
+            self.pretrained_checkpoint is not None
+        ), "Need a pretrained checkpoint for fine tuning"
+        super().prepare(num_workers, pin_memory, use_gpu)
+        if self.checkpoint is None:
+            # no checkpoint exists, load the model's state from the pretrained
+            # checkpoint
+            state_load_success = update_classy_model(
+                self.base_model,
+                self.pretrained_checkpoint["classy_state_dict"]["base_model"],
+                self.reset_heads,
+            )
+            assert (
+                state_load_success
+            ), "Update classy state from pretrained checkpoint was unsuccessful."

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+from test.generic.config_utils import get_fast_test_task_config, get_test_args
+from test.generic.utils import compare_model_state
+
+from classy_vision.generic.util import get_checkpoint_dict
+from classy_vision.tasks import FineTuningTask, build_task
+from classy_vision.trainer import ClassyTrainer
+
+
+class TestFineTuningTask(unittest.TestCase):
+    def _compare_model_state(self, state_1, state_2, check_heads=True):
+        return compare_model_state(self, state_1, state_2, check_heads=check_heads)
+
+    def _get_fine_tuning_config(self, head_num_classes=1000):
+        config = get_fast_test_task_config(head_num_classes=head_num_classes)
+        config["name"] = "fine_tuning"
+        config["num_epochs"] = 10
+        return config
+
+    def _get_pre_train_config(self, head_num_classes=1000):
+        config = get_fast_test_task_config(head_num_classes=head_num_classes)
+        config["num_epochs"] = 10
+        return config
+
+    def test_build_task(self):
+        config = self._get_fine_tuning_config()
+        args = get_test_args()
+        task = build_task(config, args)
+        self.assertIsInstance(task, FineTuningTask)
+
+    def test_prepare(self):
+        pre_train_config = self._get_pre_train_config()
+        args = get_test_args()
+        pre_train_task = build_task(pre_train_config, args)
+        pre_train_task.prepare()
+        checkpoint = get_checkpoint_dict(pre_train_task, args)
+
+        fine_tuning_config = self._get_fine_tuning_config()
+        args = get_test_args()
+        fine_tuning_task = build_task(fine_tuning_config, args)
+        # cannot prepare a fine tuning task without a pre training checkpoint
+        with self.assertRaises(Exception):
+            fine_tuning_task.prepare()
+
+        fine_tuning_task.set_pretrained_checkpoint(checkpoint)
+        fine_tuning_task.prepare()
+
+        # test a fine tuning task with incompatible heads
+        fine_tuning_config = self._get_fine_tuning_config(head_num_classes=10)
+        args = get_test_args()
+        fine_tuning_task = build_task(fine_tuning_config, args)
+        fine_tuning_task.set_pretrained_checkpoint(checkpoint)
+        # cannot prepare a fine tuning task with a pre training checkpoint which
+        # has incompatible heads
+        with self.assertRaises(Exception):
+            fine_tuning_task.prepare()
+
+        fine_tuning_task.set_pretrained_checkpoint(checkpoint).set_reset_heads(True)
+        fine_tuning_task.prepare()
+
+    def test_train(self):
+        pre_train_config = self._get_pre_train_config(head_num_classes=1000)
+        args = get_test_args()
+        pre_train_task = build_task(pre_train_config, args)
+        trainer = ClassyTrainer(use_gpu=False)
+        trainer.train(pre_train_task)
+        checkpoint = get_checkpoint_dict(pre_train_task, args)
+
+        for reset_heads, heads_num_classes in [(False, 1000), (True, 200)]:
+            fine_tuning_config = self._get_fine_tuning_config(
+                head_num_classes=heads_num_classes
+            )
+            fine_tuning_task = build_task(fine_tuning_config, args)
+            fine_tuning_task.set_pretrained_checkpoint(
+                copy.deepcopy(checkpoint)
+            ).set_reset_heads(reset_heads)
+            # run in test mode to compare the model state
+            fine_tuning_task.set_test_only(True)
+            trainer.train(fine_tuning_task)
+            self._compare_model_state(
+                pre_train_task.model.get_classy_state(),
+                fine_tuning_task.model.get_classy_state(),
+                check_heads=not reset_heads,
+            )
+            # run in train mode to check accuracy
+            fine_tuning_task.set_test_only(False)
+            trainer.train(fine_tuning_task)
+            accuracy = fine_tuning_task.meters[0].value["top_1"]
+            self.assertAlmostEqual(accuracy, 1.0)


### PR DESCRIPTION
Summary: Implement a `FineTuningTask`. This will support the same API as a regular task, with the additional option to set the pre trained checkpoint and reset_heads. This task also supports regular checkpointing - so the pretrained_checkpoint will only be used if we're not resuming from a checkpoint.

Differential Revision: D18008366

