### PR TITLE
Initialize DenseNet linear bias to zero

### DIFF
--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -198,6 +198,8 @@ class DenseNet(ClassyModel):
             elif isinstance(m, nn.BatchNorm2d):
                 m.weight.data.fill_(1)
                 m.bias.data.zero_()
+            elif isinstance(m, nn.Linear):
+                m.bias.data.zero_()
 
     @classmethod
     def from_config(cls, config):


### PR DESCRIPTION
Summary: Based on https://github.com/liuzhuang13/DenseNet/blob/master/models/densenet.lua#L161, initialize the linear bias to 0.

Differential Revision: D18039773

