### PR TITLE
Densenet weight decay on BN

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -169,7 +169,7 @@ class ClassyModel(nn.Module):
     def validate(self, dataset_output_shape):
         raise NotImplementedError
 
-    def get_optimizer_params(self):
+    def get_optimizer_params(self, bn_weight_decay=False):
         """
         Function to return dict of params with "keys" from
         {"regularized_params", "unregularized_params"}
@@ -180,7 +180,7 @@ class ClassyModel(nn.Module):
         to 0.0
 
         This implementation sets BatchNorm's all trainable params to be
-        unregularized_params.
+        unregularized_params if bn_weight_decay is False.
 
         Override this function for any custom behavior.
         """
@@ -194,7 +194,9 @@ class ClassyModel(nn.Module):
                 for params in module.parameters(recurse=False):
                     if params.requires_grad:
                         regularized_params.append(params)
-            elif isinstance(module, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)):
+            elif not bn_weight_decay and isinstance(
+                module, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)
+            ):
                 for params in module.parameters():
                     if params.requires_grad:
                         unregularized_params.append(params)

--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -234,6 +234,10 @@ class DenseNet(ClassyModel):
             out = self.fc(out)
         return out
 
+    def get_optimizer_params(self):
+        # use weight decay on BatchNorm for DenseNets
+        return super().get_optimizer_params(bn_weight_decay=True)
+
     @property
     def input_shape(self):
         if self.small_input:


### PR DESCRIPTION
Summary:
Made it so that we apply weight decay on batch norm for DenseNets.

Added an optional arg to `ClassyModel.get_optimizer_params()`, `bn_weight_decay` (default `False`), which models can change to enable weight decay on batch norm. I did not add an attribute in `self` during `__init__()` since this is only used once and I didn't want to add unnecessary properties to the base class.

Differential Revision: D18040246

