### PR TITLE
video accuracy meter

### DIFF
--- a/classy_vision/meters/accuracy_meter.py
+++ b/classy_vision/meters/accuracy_meter.py
@@ -109,7 +109,7 @@ class AccuracyMeter(ClassyMeter):
     def __repr__(self):
         return repr({"name": self.name, "value": self.value})
 
-    def update(self, model_output, target):
+    def update(self, model_output, target, **kwargs):
         """
         args:
             model_output: tensor of shape (B, C) where each value is

--- a/classy_vision/meters/classy_meter.py
+++ b/classy_vision/meters/classy_meter.py
@@ -53,7 +53,7 @@ class ClassyMeter(object):
         """
         raise NotImplementedError
 
-    def update(self, model_output, target):
+    def update(self, model_output, target, **kwargs):
         """Updates any internal state of meter.
         Gets called after each batch processing of each phase.
 

--- a/classy_vision/meters/precision_meter.py
+++ b/classy_vision/meters/precision_meter.py
@@ -124,7 +124,7 @@ class PrecisionAtKMeter(ClassyMeter):
     def __repr__(self):
         return repr({"name": self.name, "value": self.value})
 
-    def update(self, model_output, target):
+    def update(self, model_output, target, **kwargs):
         """
         args:
             model_output: tensor of shape (B, C) where each value is

--- a/classy_vision/meters/recall_meter.py
+++ b/classy_vision/meters/recall_meter.py
@@ -123,14 +123,13 @@ class RecallAtKMeter(ClassyMeter):
     def __repr__(self):
         return repr({"name": self.name, "value": self.value})
 
-    def update(self, model_output, target):
+    def update(self, model_output, target, **kwargs):
         """
         args:
             model_output: tensor of shape (B, C) where each value is
                           either logit or class probability.
             target:       tensor of shape (B, C), one-hot encoded
                           or integer encoded.
-
             Note: For binary classification, C=2.
                   For integer encoded target, C=1.
         """

--- a/classy_vision/meters/video_accuracy_meter.py
+++ b/classy_vision/meters/video_accuracy_meter.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from classy_vision.generic.util import is_pos_int
+from classy_vision.meters.accuracy_meter import AccuracyMeter
+from classy_vision.meters.classy_meter import ClassyMeter
+
+from . import register_meter
+
+
+@register_meter("video_accuracy")
+class VideoAccuracyMeter(ClassyMeter):
+    """Meter to calculate top-k video-level accuracy for single label
+       video classification task. Video-level accuarcy is computed by averaging
+       clip-level predictions and compare the reslt with video-level groundtruth
+       label.
+    """
+
+    def __init__(self, topk, clips_per_video_train, clips_per_video_test):
+        """
+        args:
+            topk: list of int `k` values.
+            clips_per_video_train: No. of clips sampled per video at train time
+            clips_per_video_test: No. of clips sampled per video at test time
+        """
+        assert isinstance(topk, list), "topk must be a list"
+        assert len(topk) > 0, "topk list should have at least one element"
+        assert [is_pos_int(x) for x in topk], "each value in topk must be >= 1"
+
+        self._clips_per_video_train = clips_per_video_train
+        self._clips_per_video_test = clips_per_video_test
+        self._accuracy_meter = AccuracyMeter(topk)
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(
+            topk=config["topk"],
+            clips_per_video_train=config.get("clips_per_video_train", 1),
+            clips_per_video_test=config["clips_per_video_test"],
+        )
+
+    @property
+    def name(self):
+        return "video_accuracy"
+
+    @property
+    def value(self):
+        return self._accuracy_meter.value
+
+    @property
+    def meter_state_dict(self):
+        """Contains the states of the meter.
+        """
+        state_dict = self._accuracy_meter.meter_state_dict
+        state_dict["name"] = "video_accuracy"
+        state_dict["clips_per_video_train"] = self._clips_per_video_train
+        state_dict["clips_per_video_test"] = self._clips_per_video_test
+        return state_dict
+
+    @meter_state_dict.setter
+    def meter_state_dict(self, state):
+        assert (
+            self._clips_per_video_train == state["clips_per_video_train"]
+        ), "incompatible clips_per_video_train for video accuracy"
+        assert (
+            self._clips_per_video_test == state["clips_per_video_test"]
+        ), "incompatible clips_per_video_test for video accuracy"
+        # Restore the state -- correct_predictions and sample_count.
+        self.reset()
+        self._accuracy_meter.meter_state_dict = state
+
+    def __repr__(self):
+        return repr({"name": self.name, "value": self._accuracy_meter.value})
+
+    def update(self, model_output, target, is_train, **kwargs):
+        """
+        args:
+            model_output: tensor of shape (B * clips_per_video, C) where each value is
+                          either logit or class probability.
+            target:       tensor of shape (B * clips_per_video).
+            is_train     if True, it is training stage when meter is updated
+
+            Note: For binary classification, C=2.
+        """
+        num_clips = len(model_output)
+        if num_clips == 0:
+            # It is possible that a minibatch entirely contains dummy samples
+            # when dataset is sharded. In such case, the effective target and output
+            # can be empty, and we immediately return
+            return
+
+        clips_per_video = (
+            self._clips_per_video_train if is_train else self._clips_per_video_test
+        )
+        assert num_clips % clips_per_video == 0, (
+            "For video model testing, batch size must be a multplier of No. of "
+            "clips per video"
+        )
+        num_videos = num_clips // clips_per_video
+        for i in range(num_videos):
+            clip_labels = target[i * clips_per_video : (i + 1) * clips_per_video]
+            assert (
+                len(torch.unique(clip_labels)) == 1
+            ), "all clips from the same video should have same label"
+
+        video_target = target[::clips_per_video]
+        video_model_output = torch.mean(
+            torch.reshape(model_output, (num_videos, clips_per_video, -1)), 1
+        )
+        self._accuracy_meter.update(video_model_output, video_target)
+
+    def reset(self):
+        self._accuracy_meter.reset()
+
+    def validate(self, model_output_shape, target_shape):
+        self._accuracy_meter.validate(model_output_shape, target_shape)

--- a/classy_vision/tasks/classy_task.py
+++ b/classy_vision/tasks/classy_task.py
@@ -491,7 +491,9 @@ class ClassyTask(object):
             # Update meters
             with PerfTimer("meters_update", perf_stats):
                 for meter in self.meters:
-                    meter.update(model_output_cpu, target.detach().cpu())
+                    meter.update(
+                        model_output_cpu, target.detach().cpu(), is_train=self.train
+                    )
 
         num_samples_in_step = self.get_global_batchsize()
         self.num_samples_this_phase += num_samples_in_step

--- a/test/generic/meter_test_utils.py
+++ b/test/generic/meter_test_utils.py
@@ -85,7 +85,7 @@ class ClassificationMeterTest(unittest.TestCase):
         return qio
 
     def _apply_updates_and_test_meter(
-        self, meter, model_output, target, expected_value
+        self, meter, model_output, target, expected_value, **kwargs
     ):
         """
         Runs a valid meter test. Does not reset meter before / after running
@@ -97,7 +97,7 @@ class ClassificationMeterTest(unittest.TestCase):
             target = [target]
 
         for i in range(len(model_output)):
-            meter.update(model_output[i], target[i])
+            meter.update(model_output[i], target[i], **kwargs)
 
         meter_value = meter.value
         for key, val in expected_value.items():
@@ -123,7 +123,7 @@ class ClassificationMeterTest(unittest.TestCase):
             )
 
     def meter_update_and_reset_test(
-        self, meter, model_outputs, targets, expected_value
+        self, meter, model_outputs, targets, expected_value, **kwargs
     ):
         """
         This test verifies that a single update on the meter is successful,
@@ -138,14 +138,14 @@ class ClassificationMeterTest(unittest.TestCase):
             meter.validate(model_outputs[i].size(), targets[i].size())
 
         self._apply_updates_and_test_meter(
-            meter, model_outputs, targets, expected_value
+            meter, model_outputs, targets, expected_value, **kwargs
         )
 
         meter.reset()
 
         # Verify reset works by reusing single update test
         self._apply_updates_and_test_meter(
-            meter, model_outputs, targets, expected_value
+            meter, model_outputs, targets, expected_value, **kwargs
         )
 
     def meter_invalid_meter_input_test(self, meter, model_output, target):
@@ -153,8 +153,22 @@ class ClassificationMeterTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             meter.validate(model_output.shape, target.shape)
 
+    def meter_invalid_update_test(self, meter, model_output, target, **kwargs):
+        """
+        Runs a valid meter test. Does not reset meter before / after running
+        """
+        if not isinstance(model_output, list):
+            model_output = [model_output]
+
+        if not isinstance(target, list):
+            target = [target]
+
+        with self.assertRaises(AssertionError):
+            for i in range(len(model_output)):
+                meter.update(model_output[i], target[i], **kwargs)
+
     def meter_get_set_classy_state_test(
-        self, meters, model_outputs, targets, expected_value
+        self, meters, model_outputs, targets, expected_value, **kwargs
     ):
         """
         Tests get and set classy state methods of meter.
@@ -167,8 +181,8 @@ class ClassificationMeterTest(unittest.TestCase):
         meter0 = meters[0]
         meter1 = meters[1]
 
-        meter0.update(model_outputs[0], targets[0])
-        meter1.update(model_outputs[1], targets[1])
+        meter0.update(model_outputs[0], targets[0], **kwargs)
+        meter1.update(model_outputs[1], targets[1], **kwargs)
 
         value0 = meter0.value
         value1 = meter1.value

--- a/test/meters_video_accuracy_meter_test.py
+++ b/test/meters_video_accuracy_meter_test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from test.generic.meter_test_utils import ClassificationMeterTest
+
+import torch
+from classy_vision import meters
+from classy_vision.meters.video_accuracy_meter import VideoAccuracyMeter
+
+
+class TestVideoAccuracyMeter(ClassificationMeterTest):
+    def test_accuracy_meter_registry(self):
+        accuracy_meter = meters.build_meter(
+            {
+                "name": "video_accuracy",
+                "topk": [1, 2],
+                "clips_per_video_train": 1,
+                "clips_per_video_test": 2,
+            }
+        )
+        self.assertTrue(isinstance(accuracy_meter, VideoAccuracyMeter))
+
+    def test_single_meter_update_and_reset(self):
+        """
+        This test verifies that the meter works as expected on a single
+        update + reset + same single update.
+        """
+        meter = VideoAccuracyMeter(
+            topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+        )
+        # Batchsize = 3, num classes = 3, clips_per_video is 2,
+        # score is a value in {1, 2, 3}
+        model_output = torch.tensor(
+            [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+            dtype=torch.float,
+        )
+        # Class 0 is the correct class for video 1, class 2 for video 2, and
+        # class 1 for video
+        target = torch.tensor([0, 0, 1, 1, 2, 2])
+
+        # Only the first sample has top class correct, first and third
+        # sample have correct class in top 2
+        expected_value = {"top_1": 1 / 3.0, "top_2": 3 / 3.0}
+
+        self.meter_update_and_reset_test(
+            meter, model_output, target, expected_value, is_train=False
+        )
+
+    def test_double_meter_update_and_reset(self):
+        meter = VideoAccuracyMeter(
+            topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+        )
+        # Batchsize = 3, num classes = 3, clips_per_video is 2,
+        # score is a value in {1, 2, 3}.
+        # Data of two batch is provided
+        model_outputs = [
+            torch.tensor(
+                [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+                dtype=torch.float,
+            ),
+            torch.tensor(
+                [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+                dtype=torch.float,
+            ),
+        ]
+        # Class 0 is the correct class for video 1, class 2 for video 2, and
+        # class 1 for video, in both batches
+        targets = [torch.tensor([0, 0, 1, 1, 2, 2]), torch.tensor([0, 0, 1, 1, 2, 2])]
+
+        # First batch has top-1 accuracy of 1/3.0, top-2 accuracy of 2/3.0
+        # Second batch has top-1 accuracy of 2/3.0, top-2 accuracy of 3/3.0
+        expected_value = {"top_1": 2 / 6.0, "top_2": 6 / 6.0}
+
+        self.meter_update_and_reset_test(
+            meter, model_outputs, targets, expected_value, is_train=False
+        )
+
+    def test_meter_invalid_model_output(self):
+        meter = VideoAccuracyMeter(
+            topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+        )
+        # This model output has 3 dimensions instead of expected 2
+        model_output = torch.tensor(
+            [[[3, 2, 1], [1, 2, 3]], [[-1, -3, -4], [-10, -90, -100]]],
+            dtype=torch.float,
+        )
+        target = torch.tensor([0, 1, 2])
+
+        self.meter_invalid_meter_input_test(meter, model_output, target)
+
+    def test_meter_invalid_target(self):
+        meter = VideoAccuracyMeter(
+            topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+        )
+        model_output = torch.tensor(
+            [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+            dtype=torch.float,
+        )
+        # Target has 2 dimensions instead of expected 1
+        target = torch.tensor([[0, 1, 2], [0, 1, 2]])
+
+        self.meter_invalid_meter_input_test(meter, model_output, target)
+        # Target of clips from the same video is not consistent
+        target = torch.tensor([0, 2, 1, 1, 2, 2])
+
+        self.meter_invalid_update_test(meter, model_output, target, is_train=False)
+
+    def test_meter_invalid_topk(self):
+        meter = VideoAccuracyMeter(
+            topk=[1, 5], clips_per_video_train=1, clips_per_video_test=2
+        )
+        model_output = torch.tensor(
+            [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+            dtype=torch.float,
+        )
+        target = torch.tensor([0, 1, 2])
+        self.meter_invalid_meter_input_test(meter, model_output, target)
+
+    def test_meter_get_set_classy_state_test(self):
+        # In this test we update meter0 with model_output0 & target0
+        # and we update meter1 with model_output1 & target1 then
+        # transfer the state from meter1 to meter0 and validate they
+        # give same expected value.
+        # Expected value is the expected value of meter1
+        meters = [
+            VideoAccuracyMeter(
+                topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+            ),
+            VideoAccuracyMeter(
+                topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+            ),
+        ]
+        # Batchsize = 3, num classes = 3, score is a value in {1, 2,
+        # 3}...3 is the highest score
+        model_outputs = [
+            torch.tensor(
+                [[1, 2, 3], [1, 1, 3], [2, 2, 1], [3, 2, 1], [2, 2, 2], [2, 3, 1]],
+                dtype=torch.float,
+            ),
+            torch.tensor(
+                [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+                dtype=torch.float,
+            ),
+        ]
+        # Class 0 is the correct class for sample 1, class 2 for sample 2, etc
+        targets = [torch.tensor([0, 0, 1, 1, 2, 2]), torch.tensor([0, 0, 1, 1, 2, 2])]
+        # Value for second update
+        expected_value = {"top_1": 1 / 3.0, "top_2": 3 / 3.0}
+
+        self.meter_get_set_classy_state_test(
+            meters, model_outputs, targets, expected_value, is_train=False
+        )


### PR DESCRIPTION
Summary:
- For video classification, at test time, we evenly sample N clips from a video, and want to average clip-level predictions to get a video-level prediction. This diff implements a new meter to support video-level accuracy compute.
- Fix a small bug in trainer where No. of processes should be from user argument ` nprocs=params.num_gpus_per_node`

Differential Revision: D17996847

