### PR TITLE
Composite parameter schedule

### DIFF
--- a/classy_vision/optim/param_scheduler/__init__.py
+++ b/classy_vision/optim/param_scheduler/__init__.py
@@ -47,6 +47,7 @@ def register_param_scheduler(name):
 # automatically import any Python files in the optim/param_scheduler/ directory
 import_all_modules(FILE_ROOT, "classy_vision.optim.param_scheduler")
 
+from .composite_scheduler import CompositeParamScheduler  # isort:skip
 from .constant_scheduler import ConstantParamScheduler  # isort:skip
 from .cosine_scheduler import CosineParamScheduler  # isort:skip
 from .multi_step_scheduler import MultiStepParamScheduler  # isort:skip
@@ -58,6 +59,7 @@ from .step_with_fixed_gamma_scheduler import (  # isort:skip
 
 __all__ = [
     "ClassyParamScheduler",
+    "CompositeParamScheduler",
     "ConstantParamScheduler",
     "CosineParamScheduler",
     "MultiStepParamScheduler",

--- a/classy_vision/optim/param_scheduler/composite_scheduler.py
+++ b/classy_vision/optim/param_scheduler/composite_scheduler.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum, auto
+from typing import Sequence
+
+from . import (
+    ClassyParamScheduler,
+    UpdateInterval,
+    build_param_scheduler,
+    register_param_scheduler,
+)
+
+
+@register_param_scheduler("composite")
+class CompositeParamScheduler(ClassyParamScheduler):
+    """
+    Composite parameter scheduler composed of intermediate schedulers.
+    Takes a list of schedulers and a list of lengths corresponding to
+    percentage of training each scheduler should run for. Schedulers
+    are run in order. All values in lengths should sum to 1.0.
+
+    Each scheduler also has a corresponding interval scale. If interval
+    scale is 'fixed', the intermidiate scheduler will be run without any rescaling
+    of the time. If interval scale is 'rescaled', intermediate scheduler is
+    run such that each scheduler will start and end at the same values as it
+    would if it were the only scheduler. Default is 'fixed' for all schedulers.
+
+    Example:
+      interval = "step"
+      schedulers = [
+        {"name": "constant", "value": 0.42},
+        {"name": "cosine_decay", "start_lr": 0.42, "end_lr": 0.0001}
+      ]
+      interval_scaling = ['rescaled', 'rescaled'],
+      lengths =  [0.3, 0.7]
+
+    The parameter value will be 0.42 for the first [0%, 30%) of steps,
+    and then will cosine decay from 0.42 to 0.0001 for [30%, 100%) of
+    training.
+    """
+
+    class IntervalScaling(Enum):
+        RESCALED = auto()
+        FIXED = auto()
+
+    def __init__(
+        self,
+        schedulers: Sequence[ClassyParamScheduler],
+        lengths: Sequence[float],
+        update_interval: UpdateInterval,
+        interval_scaling: Sequence[IntervalScaling],
+    ):
+        super().__init__()
+        self.update_interval = update_interval
+        self._lengths = lengths
+        self._schedulers = schedulers
+        self._interval_scaling = interval_scaling
+
+    @classmethod
+    def from_config(cls, config):
+        assert (
+            "schedulers" in config and "lengths" in config
+        ), "Composite scheduler needs both a list of schedulers and lengths"
+        assert len(config["schedulers"]) == len(
+            config["lengths"]
+        ), "Schedulers and lengths must be same length"
+        assert (
+            len(config["schedulers"]) > 0
+        ), "There must be at least one scheduler in the composite scheduler"
+        assert (
+            abs(sum(config["lengths"]) - 1.0) < 1e-3
+        ), "The sum of all values in lengths must be 1"
+        if sum(config["lengths"]) != 1.0:
+            config["lengths"][-1] = 1.0 - sum(config["lengths"][:-1])
+        update_interval = UpdateInterval.STEP
+        if "update_interval" in config:
+            assert config["update_interval"] in {
+                "step",
+                "epoch",
+            }, "Choices for update interval are 'step' or 'epoch'"
+            update_interval = UpdateInterval[config["update_interval"].upper()]
+        interval_scaling = []
+        if "interval_scaling" in config:
+            assert len(config["schedulers"]) == len(
+                config["interval_scaling"]
+            ), "Schedulers and interval scaling must be the same length"
+            for interval_scale in config["interval_scaling"]:
+                assert interval_scale in {
+                    "fixed",
+                    "rescaled",
+                }, "Choices for interval scaline are 'fixed' or 'rescaled'"
+                interval_scaling.append(cls.IntervalScaling[interval_scale.upper()])
+        else:
+            interval_scaling = [cls.IntervalScaling.RESCALED] * len(
+                config["schedulers"]
+            )
+        return cls(
+            schedulers=[
+                build_param_scheduler(scheduler) for scheduler in config["schedulers"]
+            ],
+            lengths=config["lengths"],
+            update_interval=update_interval,
+            interval_scaling=interval_scaling,
+        )
+
+    def __call__(self, where: float):
+        # Find scheduler corresponding to where
+        i = 0
+        running_total = self._lengths[i]
+        while (where + self.WHERE_EPSILON) > running_total and i < len(
+            self._schedulers
+        ) - 1:
+            i += 1
+            running_total += self._lengths[i]
+        scheduler = self._schedulers[i]
+        scheduler_where = where
+        interval_scale = self._interval_scaling[i]
+        if interval_scale == self.IntervalScaling.RESCALED:
+            # Calculate corresponding where % for scheduler
+            scheduler_start = running_total - self._lengths[i]
+            scheduler_where = (where - scheduler_start) / self._lengths[i]
+        return scheduler(scheduler_where)

--- a/test/optim_param_scheduler_composite_test.py
+++ b/test/optim_param_scheduler_composite_test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import unittest
+
+from classy_vision.optim.param_scheduler import build_param_scheduler
+from classy_vision.optim.param_scheduler.composite_scheduler import (
+    CompositeParamScheduler,
+    UpdateInterval,
+)
+
+
+class TestCompositeScheduler(unittest.TestCase):
+    _num_epochs = 10
+
+    def _get_valid_long_config(self):
+        return {
+            "name": "composite",
+            "schedulers": [
+                {"name": "constant", "value": 0.1},
+                {"name": "constant", "value": 0.2},
+                {"name": "constant", "value": 0.3},
+                {"name": "constant", "value": 0.4},
+            ],
+            "lengths": [0.2, 0.4, 0.1, 0.3],
+        }
+
+    def _get_lengths_sum_less_one_config(self):
+        return {
+            "name": "composite",
+            "schedulers": [
+                {"name": "constant", "value": 0.1},
+                {"name": "constant", "value": 0.2},
+            ],
+            "lengths": [0.7, 0.2999],
+        }
+
+    def _get_valid_mixed_config(self):
+        return {
+            "name": "composite",
+            "schedulers": [
+                {"name": "step", "values": [0.1, 0.2, 0.3, 0.4, 0.5], "num_epochs": 10},
+                {"name": "cosine", "start_lr": 0.42, "end_lr": 0.0001},
+            ],
+            "lengths": [0.5, 0.5],
+        }
+
+    def test_invalid_config(self):
+        config = self._get_valid_mixed_config()
+        bad_config = copy.deepcopy(config)
+
+        # No schedulers
+        bad_config["schedulers"] = []
+        bad_config["lengths"] = []
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Size of schedulers and lengths doesn't match
+        bad_config["schedulers"] = copy.deepcopy(config["schedulers"])
+        bad_config["lengths"] = copy.deepcopy(config["lengths"])
+        bad_config["schedulers"].append(bad_config["schedulers"][-1])
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Sum of lengths < 1
+        bad_config["schedulers"] = copy.deepcopy(config["schedulers"])
+        bad_config["lengths"][-1] -= 0.1
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Sum of lengths > 1
+        bad_config["lengths"] = copy.deepcopy(config["lengths"])
+        bad_config["lengths"][-1] += 0.1
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Bad value for update_interval
+        bad_config["lengths"] = copy.deepcopy(config["lengths"])
+        bad_config["update_interval"] = "epochs"
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Bad value for composition_mode
+        del bad_config["update_interval"]
+        bad_config["interval_scaling"] = ["rescaled", "rescaleds"]
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Wrong number composition modes
+        del bad_config["interval_scaling"]
+        bad_config["interval_scaling"] = ["rescaled"]
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        # Missing required parameters
+        del bad_config["interval_scaling"]
+        bad_config["lengths"] = config["lengths"]
+        del bad_config["lengths"]
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+        bad_config["lengths"] = config["lengths"]
+        del bad_config["schedulers"]
+        with self.assertRaises(AssertionError):
+            CompositeParamScheduler.from_config(bad_config)
+
+    def test_long_scheduler(self):
+        config = self._get_valid_long_config()
+
+        scheduler = CompositeParamScheduler.from_config(config)
+        schedule = [
+            scheduler(epoch_num / self._num_epochs)
+            for epoch_num in range(self._num_epochs)
+        ]
+        expected_schedule = [0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.3, 0.4, 0.4, 0.4]
+
+        self.assertEqual(schedule, expected_schedule)
+
+    def test_scheduler_lengths_within_epsilon_of_one(self):
+        config = self._get_lengths_sum_less_one_config()
+        scheduler = CompositeParamScheduler.from_config(config)
+        schedule = [
+            scheduler(epoch_num / self._num_epochs)
+            for epoch_num in range(self._num_epochs)
+        ]
+        expected_schedule = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2]
+        self.assertEqual(schedule, expected_schedule)
+
+    def test_scheduler_update_interval(self):
+        config = self._get_valid_mixed_config()
+
+        # Check default
+        scheduler = CompositeParamScheduler.from_config(config)
+        self.assertEqual(scheduler.update_interval, UpdateInterval.STEP)
+
+        # Check step
+        step_config = copy.deepcopy(config)
+        step_config["update_interval"] = "step"
+        scheduler = build_param_scheduler(step_config)
+        self.assertEqual(scheduler.update_interval, UpdateInterval.STEP)
+
+        # Check epoch
+        epoch_config = copy.deepcopy(config)
+        epoch_config["update_interval"] = "epoch"
+        scheduler = build_param_scheduler(epoch_config)
+        self.assertEqual(scheduler.update_interval, UpdateInterval.EPOCH)
+
+    def test_build_composite_scheduler(self):
+        config = self._get_valid_mixed_config()
+        scheduler = build_param_scheduler(config)
+        self.assertTrue(isinstance(scheduler, CompositeParamScheduler))
+
+    def test_scheduler_with_mixed_types(self):
+        config = self._get_valid_mixed_config()
+        scheduler_0 = build_param_scheduler(config["schedulers"][0])
+        scheduler_1 = build_param_scheduler(config["schedulers"][1])
+
+        # Check scaled
+        config["interval_scaling"] = ["rescaled", "rescaled"]
+        scheduler = CompositeParamScheduler.from_config(config)
+        scaled_schedule = [
+            round(scheduler(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(self._num_epochs)
+        ]
+        expected_schedule = [
+            round(scheduler_0(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(0, self._num_epochs, 2)
+        ] + [
+            round(scheduler_1(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(0, self._num_epochs, 2)
+        ]
+        self.assertEqual(scaled_schedule, expected_schedule)
+
+        # Check fixed
+        config["interval_scaling"] = ["fixed", "fixed"]
+        scheduler = CompositeParamScheduler.from_config(config)
+        fixed_schedule = [
+            round(scheduler(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(self._num_epochs)
+        ]
+        expected_schedule = [
+            round(scheduler_0(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(0, int(self._num_epochs / 2))
+        ] + [
+            round(scheduler_1(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(int(self._num_epochs / 2), self._num_epochs)
+        ]
+        self.assertEqual(fixed_schedule, expected_schedule)
+
+        # Check that default is rescaled
+        del config["interval_scaling"]
+        scheduler = CompositeParamScheduler.from_config(config)
+        schedule = [
+            round(scheduler(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(self._num_epochs)
+        ]
+        self.assertEqual(scaled_schedule, schedule)
+
+        # Check warmup of rescaled then fixed
+        config["interval_scaling"] = ["rescaled", "fixed"]
+        scheduler = CompositeParamScheduler.from_config(config)
+        fixed_schedule = [
+            round(scheduler(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(self._num_epochs)
+        ]
+        expected_schedule = [
+            round(scheduler_0(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(0, int(self._num_epochs), 2)
+        ] + [
+            round(scheduler_1(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(int(self._num_epochs / 2), self._num_epochs)
+        ]
+        self.assertEqual(fixed_schedule, expected_schedule)


### PR DESCRIPTION
Summary:
Creates a composite scheduler, based on [design doc](https://our.intern.facebook.com/intern/anp/view/?id=148450). Allows scheduler for a parameter to be composed of different intermediate schedulers, each for a given percentage of training.

The following is an example config for a scheduler that updates based on steps, and for the first 30% of training the learning rate is 0.42, and during the last 70% of training the learning rate is cosine decayed from 0.42 to 0.0001.

     {
            "name": "composite",
            "interval": "step",
            "schedulers": [
               {"name": "constant", "value": 0.42},
               {"name": "cosine", "max_lr": 0.42, "min_lr": 0.0001},
            ],
            "lengths": [0.3, 0.7],
      }

Differential Revision: D18071498

