### PR TITLE
Rename ClassyModule to ClassyBlock

### DIFF
--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -87,7 +87,7 @@ import_all_modules(FILE_ROOT, "classy_vision.models")
 
 from .classy_model import ClassyModelEvaluationMode  # isort:skip
 from .classy_model_wrapper import ClassyModelWrapper  # isort:skip
-from .classy_module import ClassyModule  # isort:skip
+from .classy_block import ClassyBlock  # isort:skip
 from .densenet import DenseNet  # isort:skip
 from .inception import Inception3  # isort:skip
 from .mlp import MLP  # isort:skip
@@ -110,7 +110,7 @@ __all__ = [
     "register_model",
     "ClassyModel",
     "ClassyModelEvaluationMode",
-    "ClassyModule",
+    "ClassyBlock",
     "ClassyModelWrapper",
     "Inception3",
     "DenseNet",

--- a/classy_vision/models/classy_block.py
+++ b/classy_vision/models/classy_block.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 from classy_vision.heads import ClassyHead
 
 
-class ClassyModule(nn.Module):
+class ClassyBlock(nn.Module):
     def __init__(self, name, module):
         super().__init__()
         self._name = name
@@ -41,7 +41,7 @@ class ClassyModule(nn.Module):
 
     def set_heads(self, heads):
         """
-        attach heads to current module.
+        attach heads to current block.
         Args:
             heads (list): a list of ClassyHead
         """

--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -10,7 +10,7 @@ from enum import Enum
 
 import torch.nn as nn
 
-from .classy_module import ClassyModule
+from .classy_block import ClassyBlock
 
 
 class ClassyModelEvaluationMode(Enum):
@@ -104,7 +104,7 @@ class ClassyModel(nn.Module):
         """
         if name in self._attachable_blocks:
             raise ValueError("Found duplicated block name {}".format(name))
-        block = ClassyModule(name, module)
+        block = ClassyBlock(name, module)
         self._attachable_blocks[name] = block
         return block
 

--- a/test/classy_block_test.py
+++ b/test/classy_block_test.py
@@ -11,7 +11,7 @@ from classy_vision.heads import ClassyHead
 from classy_vision.models import ClassyModel
 
 
-class TestClassyModule(unittest.TestCase):
+class TestClassyBlock(unittest.TestCase):
     class DummyTestHead(ClassyHead):
         def __init__(self):
             super().__init__("head_id")


### PR DESCRIPTION
Summary:
ClassyModule is a very generic name: anything is a module. Rename it to
ClassyBlock per discussion in T54419016.

Differential Revision: D18078578

