### PR TITLE
extend profiler to support 3D video model

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -721,12 +721,14 @@ def bind_method_to_class(method, cls):
     return method.__func__.__get__(cls)
 
 
-def get_model_dummy_input(model, input_shape, input_key):
+def get_model_dummy_input(
+    model, input_shape, input_key, batchsize=1, non_blocking=False
+):
     # add a dimension to represent minibatch axis
-    shape = (1,) + tuple(input_shape)
+    shape = (batchsize,) + tuple(input_shape)
     input = torch.zeros(shape)
     if next(model.parameters()).is_cuda:
-        input = input.cuda()
+        input = input.cuda(non_blocking=non_blocking)
     if input_key:
         input = {input_key: input}
     return input

--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from math import floor
 from typing import Any, Dict, Optional
 
 from classy_vision import tasks

--- a/classy_vision/hooks/profiler_hook.py
+++ b/classy_vision/hooks/profiler_hook.py
@@ -42,5 +42,6 @@ class ProfilerHook(ClassyHook):
             task.model,
             batchsize_per_replica=batchsize_per_replica,
             input_shape=input_shape,
+            input_key=getattr(task.base_model, "input_key", None),
         )
         logging.info(summarize_profiler_info(p))

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -180,3 +180,91 @@ def get_test_model_configs():
             "small_input": False,
         },
     ]
+
+
+def get_test_video_task_config():
+    return {
+        "name": "classy_vision",
+        "num_epochs": 27,
+        "loss": {"name": "CrossEntropyLoss"},
+        "dataset": {
+            "train": {
+                "name": "synthetic_video",
+                "split": "train",
+                "batchsize_per_replica": 8,
+                "use_shuffle": True,
+                "num_samples": 128,
+                "frames_per_clip": 8,
+                "video_height": 128,
+                "video_width": 160,
+                "num_classes": 50,
+                "clips_per_video": 1,
+            },
+            "test": {
+                "name": "synthetic_video",
+                "split": "test",
+                "batchsize_per_replica": 10,
+                "use_shuffle": False,
+                "num_samples": 40,
+                "frames_per_clip": 8,
+                "video_height": 128,
+                "video_width": 160,
+                "num_classes": 50,
+                "clips_per_video": 10,
+            },
+        },
+        "meters": {"accuracy": {"topk": [1, 5]}},
+        "model": {
+            "name": "resnext3d",
+            "frames_per_clip": 8,
+            "input_planes": 3,
+            "clip_crop_size": 224,
+            "transformation_type": "bottleneck_transformation",
+            "num_blocks": [3, 4, 6, 3],
+            "input_key": "video",
+            "stem_name": "resnext3d_stem",
+            "stem_planes": 64,
+            "stem_temporal_kernel": 5,
+            "stem_spatial_kernel": 7,
+            "stem_maxpool": True,
+            "stage_planes": 64,
+            "stage_temporal_kernel_basis": [[3], [3, 1], [3, 1], [1, 3]],
+            "temporal_conv_1x1": [True, True, True, True],
+            "stage_temporal_stride": [1, 1, 1, 1],
+            "stage_spatial_stride": [1, 2, 2, 2],
+            "num_groups": 1,
+            "width_per_group": 64,
+            "num_classes": 50,
+            "freeze_trunk": False,
+            "heads": [
+                {
+                    "name": "fully_convolutional_linear",
+                    "unique_id": "default_head",
+                    "pool_size": [8, 7, 7],
+                    "activation_func": "softmax",
+                    "num_classes": 50,
+                    "fork_block": "pathway1-stage5-block3",
+                    "in_plane": 512,
+                    "use_dropout": True,
+                }
+            ],
+        },
+        "optimizer": {
+            "name": "sgd",
+            "lr": {
+                "name": "multistep",
+                "num_epochs": 10,
+                "values": [0.1, 0.01, 0.001, 0.0001],
+                "milestones": [3, 7, 9],
+            },
+            "weight_decay": 0.0001,
+            "momentum": 0.9,
+        },
+    }
+
+
+def get_test_classy_video_task():
+    config = get_test_video_task_config()
+    args = get_test_args()
+    task = build_task(config, args)
+    return task

--- a/test/hooks_profiler_hook_test.py
+++ b/test/hooks_profiler_hook_test.py
@@ -6,7 +6,7 @@
 
 import unittest
 import unittest.mock as mock
-from test.generic.config_utils import get_test_classy_task
+from test.generic.config_utils import get_test_classy_task, get_test_classy_video_task
 
 from classy_vision.hooks import ProfilerHook
 
@@ -30,23 +30,22 @@ class TestProfilerHook(unittest.TestCase):
         mock_profile.__enter__.return_value = mock_profile_returned
         mock_profile_cls.return_value = mock_profile
 
-        local_variables = {}
+        for task in [get_test_classy_task(), get_test_classy_video_task()]:
+            task.prepare()
+            local_variables = {}
 
-        task = get_test_classy_task()
-        task.prepare()
+            # create a model tensorboard hook
+            profiler_hook = ProfilerHook()
 
-        # create a model tensorboard hook
-        profiler_hook = ProfilerHook()
+            with self.assertLogs():
+                profiler_hook.on_start(task, local_variables)
 
-        with self.assertLogs():
-            profiler_hook.on_start(task, local_variables)
+            # a new profile should be created with use_cuda=True
+            mock_profile_cls.assert_called_once_with(use_cuda=True)
+            mock_profile_cls.reset_mock()
 
-        # a new profile should be created with use_cuda=True
-        mock_profile_cls.assert_called_once_with(use_cuda=True)
-        mock_profile_cls.reset_mock()
-
-        # summarize_profiler_info should have been called once with the profile
-        mock_summarize_profiler_info.assert_called_once()
-        profile = mock_summarize_profiler_info.call_args[0][0]
-        mock_summarize_profiler_info.reset_mock()
-        self.assertEqual(profile, mock_profile_returned)
+            # summarize_profiler_info should have been called once with the profile
+            mock_summarize_profiler_info.assert_called_once()
+            profile = mock_summarize_profiler_info.call_args[0][0]
+            mock_summarize_profiler_info.reset_mock()
+            self.assertEqual(profile, mock_profile_returned)

--- a/test/manual/hooks_model_complexity_hook_test.py
+++ b/test/manual/hooks_model_complexity_hook_test.py
@@ -18,7 +18,7 @@ class TestModelComplexityHook(unittest.TestCase):
         Test that the number of parameters and the FLOPs are calcuated correctly.
         """
         model_configs = get_test_model_configs()
-        expected_mega_flops = [4100, 4245, None]
+        expected_mega_flops = [4122, 4274, 106152]
         expected_params = [25557032, 25028904, 43009448]
         local_variables = {}
 


### PR DESCRIPTION
Summary:
-  Current profiler only supports to profile 2D image models. It does not compute flops for modules that are commonly used in 3D video model, such as `Conv3D`, `BatchNorm3D`, 'maxpool3d' and `avgpool3d`. This diff extends profiler to support 3D video model profiling.
- Fix the bug in computing flops for module 'BatchNorm2D`.

Reviewed By: taylorgordon20

Differential Revision: D17977048

