### PR TITLE
Add finetuning support to the flow trainers

### DIFF
--- a/configs/resnext101_32x4d_fine_tuning_config.json
+++ b/configs/resnext101_32x4d_fine_tuning_config.json
@@ -1,0 +1,56 @@
+{
+    "name": "fine_tuning",
+    "num_epochs": 10,
+    "loss": {
+        "name": "CrossEntropyLoss"
+    },
+    "dataset": {
+        "train": {
+            "name": "imagenet",
+            "split": "train",
+            "batchsize_per_replica": 32,
+            "num_samples": null,
+            "use_shuffle": true
+        },
+        "test": {
+            "name": "imagenet",
+            "split": "val",
+            "batchsize_per_replica": 32,
+            "num_samples": null,
+            "use_shuffle": false
+        }
+    },
+    "meters": {
+        "accuracy": {
+            "topk": [1, 5]
+        }
+    },
+    "model": {
+        "name": "resnext",
+        "num_blocks": [3, 4, 23, 3],
+        "base_width_and_cardinality": [4, 32],
+        "small_input": false,
+        "zero_init_bn_residuals": true,
+        "freeze_trunk": true,
+        "heads": [
+            {
+                "name": "fully_connected",
+                "unique_id": "default_head",
+                "num_classes": 1000,
+                "fork_block": "block3-2",
+                "in_plane": 2048
+            }
+        ]
+    },
+    "optimizer": {
+        "name": "sgd",
+        "lr": {
+            "name": "step",
+            "values": [0.1, 0.01, 0.001]
+        },
+        "weight_decay": 1e-4,
+        "momentum": 0.9,
+        "nesterov": true
+    },
+    "reset_heads": true
+}


### PR DESCRIPTION
Summary:
Added support for fine-tuning models in the fblearner workflows. The fine tuning task is like a regular task, but it needs a pretrained_checkpoint to run.

There are two ways to pass the pretrained_checkpoint - workflow id / checkpoint folder.  There should ideally be just one way, but that'll happen when we enforce just one way to pass the checkpoint URI.

Differential Revision: D18069548

