### PR TITLE
Change cosine parameter scheduler to support decay and warmup schedules

### DIFF
--- a/configs/r3d34_hmdb51_classy_config.json
+++ b/configs/r3d34_hmdb51_classy_config.json
@@ -146,8 +146,8 @@
     "name": "sgd",
     "lr": {
       "name": "cosine",
-      "max_lr": 0.04,
-      "min_lr": 0.00004,
+      "start_lr": 0.04,
+      "end_lr": 0.00004,
       "warmup": {
         "init_lr": 0.005,
         "length": 0.13

--- a/configs/r3d34_ucf101_classy_config.json
+++ b/configs/r3d34_ucf101_classy_config.json
@@ -144,8 +144,8 @@
         "name": "sgd",
         "lr": {
             "name": "cosine",
-            "max_lr": 0.04,
-            "min_lr": 0.00004,
+            "start_lr": 0.04,
+            "end_lr": 0.00004,
             "warmup": {
                 "init_lr": 0.005,
                 "length": 0.13

--- a/test/optim_param_scheduler_cosine_test.py
+++ b/test/optim_param_scheduler_cosine_test.py
@@ -8,78 +8,109 @@ import copy
 import unittest
 
 from classy_vision.optim.param_scheduler import build_param_scheduler
-from classy_vision.optim.param_scheduler.cosine_decay_scheduler import (
-    CosineDecayParamScheduler,
-)
+from classy_vision.optim.param_scheduler.cosine_scheduler import CosineParamScheduler
 
 
 class TestCosineScheduler(unittest.TestCase):
     _num_epochs = 10
 
-    def _get_valid_config(self):
-        return {"name": "cosine", "max_lr": 0.1, "min_lr": 0}
+    def _get_valid_decay_config(self):
+        return {"name": "cosine", "start_lr": 0.1, "end_lr": 0}
+
+    def _get_valid_decay_config_intermediate_values(self):
+        return [0.0976, 0.0905, 0.0794, 0.0655, 0.05, 0.0345, 0.0206, 0.0095, 0.0024]
 
     def _get_valid_config_with_warmup(self):
         return {
             "name": "cosine",
-            "max_lr": 0.1,
-            "min_lr": 0.01,
+            "start_lr": 0.1,
+            "end_lr": 0.01,
             "warmup": {"init_lr": 0.01, "length": 0.2},
         }
 
     def test_invalid_config(self):
         # Invalid num epochs
-        config = self._get_valid_config()
+        config = self._get_valid_decay_config()
 
         bad_config = copy.deepcopy(config)
         # Invalid Base lr
-        del bad_config["max_lr"]
+        del bad_config["start_lr"]
         with self.assertRaises(AssertionError):
-            CosineDecayParamScheduler.from_config(bad_config)
+            CosineParamScheduler.from_config(bad_config)
 
-        # Invalid min_lr
-        bad_config["max_lr"] = config["max_lr"]
-        del bad_config["min_lr"]
+        # Invalid end_lr
+        bad_config["start_lr"] = config["start_lr"]
+        del bad_config["end_lr"]
         with self.assertRaises(AssertionError):
-            CosineDecayParamScheduler.from_config(bad_config)
+            CosineParamScheduler.from_config(bad_config)
 
-    def test_scheduler(self):
-        config = self._get_valid_config()
+    def test_scheduler_as_decay(self):
+        config = self._get_valid_decay_config()
 
-        scheduler = CosineDecayParamScheduler.from_config(config)
+        scheduler = CosineParamScheduler.from_config(config)
         schedule = [
             round(scheduler(epoch_num / self._num_epochs), 4)
             for epoch_num in range(self._num_epochs)
         ]
         expected_schedule = [
-            0.1,
-            0.0976,
-            0.0905,
-            0.0794,
-            0.0655,
-            0.05,
-            0.0345,
-            0.0206,
-            0.0095,
-            0.0024,
-        ]
+            config["start_lr"]
+        ] + self._get_valid_decay_config_intermediate_values()
 
         self.assertEqual(schedule, expected_schedule)
 
+    def test_scheduler_as_warmup(self):
+        config = self._get_valid_decay_config()
+        # Swap start and end lr to change to warmup
+        tmp = config["start_lr"]
+        config["start_lr"] = config["end_lr"]
+        config["end_lr"] = tmp
+
+        scheduler = CosineParamScheduler.from_config(config)
+        schedule = [
+            round(scheduler(epoch_num / self._num_epochs), 4)
+            for epoch_num in range(self._num_epochs)
+        ]
+        # Schedule should be decay reversed
+        expected_schedule = [config["start_lr"]] + list(
+            reversed(self._get_valid_decay_config_intermediate_values())
+        )
+
+        self.assertEqual(schedule, expected_schedule)
+
+    def test_scheduler_warmup_decay_match(self):
+        decay_config = self._get_valid_decay_config()
+        decay_scheduler = CosineParamScheduler.from_config(decay_config)
+
+        warmup_config = copy.deepcopy(decay_config)
+        # Swap start and end lr to change to warmup
+        tmp = warmup_config["start_lr"]
+        warmup_config["start_lr"] = warmup_config["end_lr"]
+        warmup_config["end_lr"] = tmp
+        warmup_scheduler = CosineParamScheduler.from_config(warmup_config)
+
+        decay_schedule = [
+            round(decay_scheduler(epoch_num / 1000), 8) for epoch_num in range(1, 1000)
+        ]
+        warmup_schedule = [
+            round(warmup_scheduler(epoch_num / 1000), 8) for epoch_num in range(1, 1000)
+        ]
+
+        self.assertEqual(decay_schedule, list(reversed(warmup_schedule)))
+
     def test_build_cosine_scheduler(self):
-        config = self._get_valid_config()
+        config = self._get_valid_decay_config()
         scheduler = build_param_scheduler(config)
-        self.assertTrue(isinstance(scheduler, CosineDecayParamScheduler))
+        self.assertTrue(isinstance(scheduler, CosineParamScheduler))
 
     def test_build_cosine_scheduler_with_warmup(self):
         config = self._get_valid_config_with_warmup()
         scheduler = build_param_scheduler(config)
-        self.assertTrue(isinstance(scheduler, CosineDecayParamScheduler))
+        self.assertTrue(isinstance(scheduler, CosineParamScheduler))
 
     def test_scheduler_with_warmup(self):
         config = self._get_valid_config_with_warmup()
 
-        scheduler = CosineDecayParamScheduler.from_config(config)
+        scheduler = CosineParamScheduler.from_config(config)
         schedule = [
             round(scheduler(epoch_num / self._num_epochs), 4)
             for epoch_num in range(self._num_epochs)


### PR DESCRIPTION
Summary:
Changes cosine parameter scheduler to use a scheduler for either cosine decay or cosine warmup depending on the start/end values of the parameter.
End goal is to replace the exising warmup in the scheduler with composite schedulers from D18071498, composed of either a cosine/linear warmup and the existing schedule.

Differential Revision: D18088008

