### PR TITLE
Raise NotImplementedError in ClassyTask.from_config

### DIFF
--- a/classy_vision/tasks/classy_task.py
+++ b/classy_vision/tasks/classy_task.py
@@ -16,7 +16,7 @@ class ClassyTask(ABC):
     @classmethod
     @abstractmethod
     def from_config(cls, config):
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def init_distributed_data_parallel_model(self):


### PR DESCRIPTION
Summary: According to Mannat abstract class methods need to do this.

Reviewed By: mannatsingh

Differential Revision: D18093957

