### PR TITLE
Add LocalTrainer

### DIFF
--- a/classy_vision/trainer/__init__.py
+++ b/classy_vision/trainer/__init__.py
@@ -6,6 +6,7 @@
 
 from .classy_trainer import ClassyTrainer
 from .distributed_trainer import DistributedTrainer
+from .local_trainer import LocalTrainer
 
 
-__all__ = ["ClassyTrainer", "DistributedTrainer"]
+__all__ = ["ClassyTrainer", "DistributedTrainer", "LocalTrainer"]

--- a/classy_vision/trainer/local_trainer.py
+++ b/classy_vision/trainer/local_trainer.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+from classy_vision.generic.distributed_util import set_cpu_device, set_cuda_device_index
+
+from .classy_trainer import ClassyTrainer
+
+
+class LocalTrainer(ClassyTrainer):
+    def __init__(self, use_gpu, num_workers=0):
+        super().__init__(use_gpu=use_gpu, num_workers=num_workers)
+        if self.use_gpu:
+            logging.info("Using GPU, CUDA device index: {}".format(0))
+            set_cuda_device_index(0)
+        else:
+            logging.info("Using CPU")
+            set_cpu_device()

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -14,7 +14,7 @@ import classy_vision.generic.util as util
 import torch
 from classy_vision.generic.util import update_classy_model, update_classy_state
 from classy_vision.tasks import build_task
-from classy_vision.trainer import ClassyTrainer
+from classy_vision.trainer import LocalTrainer
 
 
 ROOT = Path(__file__).parent
@@ -346,7 +346,7 @@ class TestUpdateStateFunctions(unittest.TestCase):
         task = build_task(config, args)
         task_2 = build_task(config, args)
         task_2.prepare()
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
         update_classy_state(task_2, task.get_classy_state(deep_copy=True))
         self._compare_states(task.get_classy_state(), task_2.get_classy_state())
@@ -359,7 +359,7 @@ class TestUpdateStateFunctions(unittest.TestCase):
         config = get_fast_test_task_config()
         args = get_test_args()
         task = build_task(config, args)
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
         for reset_heads in [False, True]:
             task_2 = build_task(config, args)

--- a/test/models_classy_model_wrapper_test.py
+++ b/test/models_classy_model_wrapper_test.py
@@ -13,7 +13,7 @@ import torch.nn as nn
 from classy_vision.models import ClassyModel
 from classy_vision.models.classy_model_wrapper import ClassyModelWrapper
 from classy_vision.tasks import build_task
-from classy_vision.trainer import ClassyTrainer
+from classy_vision.trainer import LocalTrainer
 from torchvision import models
 
 
@@ -82,5 +82,5 @@ class TestClassyModelWrapper(unittest.TestCase):
         args = get_test_args()
         task = build_task(config, args)
         task.set_model(classy_model)
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -13,7 +13,7 @@ from classy_vision.models import build_model
 from classy_vision.optim import build_optimizer
 from classy_vision.optim.param_scheduler import UpdateInterval
 from classy_vision.tasks import ClassificationTask
-from classy_vision.trainer import ClassyTrainer
+from classy_vision.trainer import LocalTrainer
 
 
 class TestParamSchedulerIntegration(unittest.TestCase):
@@ -94,7 +94,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
         mock.update_interval = UpdateInterval.EPOCH
         task.optimizer._lr_scheduler = mock
 
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
 
         self.assertEqual(where_list, [0, 1 / 3, 2 / 3])
@@ -112,7 +112,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
         mock.update_interval = UpdateInterval.STEP
         task.optimizer._lr_scheduler = mock
 
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
 
         # We have 10 samples, batch size is 5. Each epoch is done in two steps.

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -11,7 +11,7 @@ from test.generic.utils import compare_model_state
 
 from classy_vision.generic.util import get_checkpoint_dict
 from classy_vision.tasks import FineTuningTask, build_task
-from classy_vision.trainer import ClassyTrainer
+from classy_vision.trainer import LocalTrainer
 
 
 class TestFineTuningTask(unittest.TestCase):
@@ -69,7 +69,7 @@ class TestFineTuningTask(unittest.TestCase):
         pre_train_config = self._get_pre_train_config(head_num_classes=1000)
         args = get_test_args()
         pre_train_task = build_task(pre_train_config, args)
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(pre_train_task)
         checkpoint = get_checkpoint_dict(pre_train_task, args)
 

--- a/test/trainer_test.py
+++ b/test/trainer_test.py
@@ -13,7 +13,7 @@ from classy_vision.meters.accuracy_meter import AccuracyMeter
 from classy_vision.models import build_model
 from classy_vision.optim import build_optimizer
 from classy_vision.tasks import ClassificationTask
-from classy_vision.trainer import ClassyTrainer
+from classy_vision.trainer import LocalTrainer
 
 
 class TestClassyTrainer(unittest.TestCase):
@@ -82,7 +82,7 @@ class TestClassyTrainer(unittest.TestCase):
 
         self.assertTrue(task is not None)
 
-        trainer = ClassyTrainer(use_gpu=False)
+        trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
         accuracy = task.meters[0].value["top_1"]
         self.assertAlmostEqual(accuracy, 1.0)


### PR DESCRIPTION
Summary:
Right now we are instantiating ClassyTrainer directly in a bunch of places,
but ClassyTrainer is supposed to be a base class. Create a LocalTrainer class
and switch most call sites to that.

Differential Revision: D18086693

