### PR TITLE
Kill classy state from classy dataset

### DIFF
--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -126,24 +126,3 @@ class ClassyDataset:
 
     def get_global_batchsize(self):
         return self.get_batchsize_per_replica() * get_world_size()
-
-    def get_classy_state(self):
-        """Get state for object (e.g. shuffle)"""
-        return {
-            "split": self.split,
-            "batchsize_per_replica": self.batchsize_per_replica,
-            "shuffle": self.shuffle,
-            "num_samples": self.num_samples,
-            "state": {"dataset_type": type(self)},
-        }
-
-    def set_classy_state(self, state, strict=True):
-        """Sets state for object (e.g. shuffle)"""
-        assert isinstance(self, state["state"]["dataset_type"]) or not strict, (
-            "Type of saved state does not match current object. "
-            "If intentional, use non-strict flag"
-        )
-        self.split = state["split"]
-        self.batchsize_per_replica = state["batchsize_per_replica"]
-        self.shuffle = state["shuffle"]
-        self.num_samples = state["num_samples"]

--- a/classy_vision/dataset/core/wrap_torchvision_video_dataset.py
+++ b/classy_vision/dataset/core/wrap_torchvision_video_dataset.py
@@ -25,10 +25,3 @@ class WrapTorchVisionVideoDataset:
 
     def __len__(self):
         return len(self.dataset)
-
-    def get_classy_state(self):
-        # Pytorch datasets don't have state
-        return {
-            # For debugging saved states
-            "state": {"dataset_type": type(self)}
-        }

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -149,22 +149,6 @@ class TestClassyDataset(unittest.TestCase):
             sample = self.dataset2[idx]
             self._compare_samples(sample, DUMMY_SAMPLES_2[idx])
 
-    def test_get_set_classy_state(self):
-        state = self.dataset1.get_classy_state()
-        new_state = copy.deepcopy(state)
-        new_state["split"] = "new_split"
-        self.dataset1.set_classy_state(state)
-        self.assertFalse(new_state == state, "State should have changed")
-
-        # Check assert for changing dataset types
-        with self.assertRaises(AssertionError):
-            other_dataset = build_dataset(OTHER_DUMMY_CONFIG, DUMMY_SAMPLES_1)
-            other_dataset.set_classy_state(state)
-
-        # Verify when strict flag is false, this does not throw
-        other_dataset = build_dataset(OTHER_DUMMY_CONFIG, DUMMY_SAMPLES_1)
-        other_dataset.set_classy_state(state, strict=False)
-
     def test_get_iterator(self):
         # Verifies that we can retrieve samples with iterators
         dl = self.dataset1.iterator(num_workers=0)

--- a/test/generic/merge_dataset.py
+++ b/test/generic/merge_dataset.py
@@ -53,27 +53,3 @@ class MergeDataset:
 
     def __len__(self):
         return len(self.datasets[0])
-
-    def get_classy_state(self):
-        state = {"state": {"dataset_type": type(self)}}
-        if isinstance(self.datasets, list):
-            state["wrapped_states"] = [
-                dataset.get_classy_state() for dataset in self.datasets
-            ]
-        else:
-            state["wrapped_states"] = {
-                key: dataset.get_classy_state()
-                for key, dataset in self.datasets.items()
-            }
-
-        return state
-
-    def set_classy_state(self, state):
-        if isinstance(self.datasets, list):
-            for idx, dataset in enumerate(self.datasets):
-                dataset.set_classy_state(state["wrapped_states"][idx])
-        else:
-            for key, dataset in self.datasets.items():
-                dataset.set_classy_state(state["wrapped_states"][key])
-
-        return self


### PR DESCRIPTION
Summary: get_classy_state is not needed for datasets now that we use epoch + seed for shuffling and we eliminated all of the wrappers.

Differential Revision: D18104669

