### PR TITLE
Remove sync side effect from .value call

### DIFF
--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -42,6 +42,7 @@ class LossLrMeterLoggingHook(ClassyHook):
             return
         batches = len(task.losses)
         if batches and batches % self.log_freq == 0:
+            logging.info("Local unsynced metric values:")
             self._log_loss_lr_meters(task, local_variables)
 
     def on_phase_end(
@@ -52,6 +53,11 @@ class LossLrMeterLoggingHook(ClassyHook):
         """
         batches = len(task.losses)
         if batches:
+            # Most trainers will sync meters on phase end, however we
+            # do not explicitly state this since it is possible for a
+            # trainer to implement an unsynced end of phase meter or
+            # for meters to not provide a sync function.
+            logging.info("End of phase metric values:")
             self._log_loss_lr_meters(task, local_variables)
 
     def _log_loss_lr_meters(

--- a/classy_vision/meters/classy_meter.py
+++ b/classy_vision/meters/classy_meter.py
@@ -28,7 +28,13 @@ class ClassyMeter(object):
 
     @property
     def value(self):
-        """Value of meter, can be any python object.
+        """Value of meter based on local state, can be any python object.
+
+        Note: If there are multiple training processes then this
+        represents the local state of the meter. If sync meter is
+        implemented, then value will return the global state since the
+        last sync PLUS any local unsynced updates that have occurred
+        in the local process.
         """
         raise NotImplementedError
 
@@ -46,6 +52,19 @@ class ClassyMeter(object):
             classy_state: State to restore from.
         """
         raise NotImplementedError
+
+    def sync_state(self):
+        """Syncs state with all other meters in distributed training.
+
+        WARNING: Calls to sync_state could involve communications via
+        torch.distributed which can result in a loss of performance or
+        deadlocks if not coordinated among threads
+        """
+        # If not provided by child class this does nothing by default
+        # and meter only provides the local process stats. If
+        # implemented then the meter provides the global stats at last
+        # sync + any local updates since the last sync
+        pass
 
     def reset(self):
         """Resets any internal meter state.

--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import logging
+
 import torch
 from classy_vision.generic.distributed_util import barrier, is_distributed_training_run
 from classy_vision.hooks import ClassyHookFunctions
@@ -44,6 +46,10 @@ class ClassyTrainer:
                 except StopIteration:
                     break
 
+            logging.info("Syncing meters on phase end...")
+            for meter in task.meters:
+                meter.sync_state()
+            logging.info("...meters synced")
             barrier()
             task.run_hooks(local_variables, ClassyHookFunctions.on_phase_end.name)
 

--- a/test/generic/meter_test_utils.py
+++ b/test/generic/meter_test_utils.py
@@ -52,6 +52,7 @@ def _meter_worker(qin, qout, meter, world_size, rank, filename):
             meter.update(val[0], val[1])
 
         elif signal == VALUE_SIGNAL:
+            meter.sync_state()
             qout.put(meter.value)
 
         elif signal == SHUTDOWN_SIGNAL:
@@ -99,6 +100,7 @@ class ClassificationMeterTest(unittest.TestCase):
         for i in range(len(model_output)):
             meter.update(model_output[i], target[i], **kwargs)
 
+        meter.sync_state()
         meter_value = meter.value
         for key, val in expected_value.items():
             self.assertTrue(
@@ -184,7 +186,10 @@ class ClassificationMeterTest(unittest.TestCase):
         meter0.update(model_outputs[0], targets[0], **kwargs)
         meter1.update(model_outputs[1], targets[1], **kwargs)
 
+        meter0.sync_state()
         value0 = meter0.value
+
+        meter1.sync_state()
         value1 = meter1.value
         for key, val in value0.items():
             self.assertNotEqual(


### PR DESCRIPTION
Summary:
Several of our meters silently call the sync_state function when .value is called...which .value is called when str(meter) is called which is a surprising side effect.

In particular, the sync_state function is dangerous because it blocks until all other processes also call it.

This diff makes the sync_state() call explicit and optional.

I modified the hooks and the tests where the meters are called.

Differential Revision: D18077857

