### PR TITLE
Remove num_classes in ClassyModel

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
-import logging
 from enum import Enum
 
 import torch.nn as nn
@@ -29,18 +28,6 @@ class ClassyModel(nn.Module):
     @classmethod
     def from_config(cls, config):
         raise NotImplementedError
-
-    @property
-    def num_classes(self):
-        # Flatten the dictionary of dictionaries into a list of heads
-        heads = [head for heads in self.get_heads().values() for head in heads.values()]
-
-        if len(heads) == 1:
-            return heads[0].num_classes
-        elif len(heads) >= 1:
-            logging.error("Tried to get num_classes on a model with multiple heads")
-            raise RuntimeError
-        return self._num_classes
 
     def get_classy_state(self, deep_copy=False):
         """

--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -247,7 +247,7 @@ class DenseNet(ClassyModel):
 
     @property
     def output_shape(self):
-        return (1, self.num_classes)
+        return (1, self._num_classes)
 
     @property
     def model_depth(self):

--- a/classy_vision/models/inception.py
+++ b/classy_vision/models/inception.py
@@ -150,7 +150,7 @@ class Inception3(ClassyModel):
 
     @property
     def output_shape(self):
-        return (1, self.num_classes)
+        return (1, self._num_classes)
 
     @property
     def model_depth(self):

--- a/classy_vision/models/msdnet.py
+++ b/classy_vision/models/msdnet.py
@@ -514,7 +514,7 @@ class MSDNet(ClassyModel):
 
     @property
     def output_shape(self):
-        return (1, self.num_classes)
+        return (1, self._num_classes)
 
     @property
     def model_depth(self):

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -394,7 +394,7 @@ class ResNeXt(ClassyModel):
 
     @property
     def output_shape(self):
-        return (1, self.num_classes)
+        return (1, self._num_classes)
 
     @property
     def model_depth(self):

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -273,7 +273,7 @@ class ResNeXt3D(ClassyModel):
 
     @property
     def output_shape(self):
-        return (1, self.num_classes)
+        return (1, self._num_classes)
 
     @property
     def model_depth(self):

--- a/classy_vision/models/vgg.py
+++ b/classy_vision/models/vgg.py
@@ -180,7 +180,7 @@ class VGG(ClassyModel):
 
     @property
     def output_shape(self):
-        return (1, self.num_classes)
+        return (1, self._num_classes)
 
     @property
     def model_depth(self):

--- a/test/manual/models_classy_vision_model_test.py
+++ b/test/manual/models_classy_vision_model_test.py
@@ -42,10 +42,6 @@ class TestClassyModel(unittest.TestCase):
         for cfg in self.model_configs:
             config = self._get_config(cfg)
             model = build_model(config["model"])
-            num_classes = (
-                cfg["heads"][0]["num_classes"] if "heads" in cfg else cfg["num_classes"]
-            )
-            self.assertEqual(num_classes, model.num_classes)
             self.assertTrue(isinstance(model, ClassyModel))
             self.assertTrue(
                 type(model.input_shape) == tuple and len(model.input_shape) == 3

--- a/test/models_classy_model_wrapper_test.py
+++ b/test/models_classy_model_wrapper_test.py
@@ -69,7 +69,6 @@ class TestClassyModelWrapper(unittest.TestCase):
             model_depth=model_depth,
         )
         self.assertEqual(classy_model.input_shape, input_shape)
-        self.assertEqual(classy_model.num_classes, num_classes)
         self.assertEqual(classy_model.output_shape, output_shape)
         self.assertEqual(classy_model.model_depth, model_depth)
 

--- a/test/models_resnext3d_test.py
+++ b/test/models_resnext3d_test.py
@@ -90,8 +90,6 @@ class TestResNeXt3D(unittest.TestCase):
     def test_build_model(self):
         for model_config in self.model_configs:
             model = build_model(model_config)
-            num_classes = model_config["heads"][0]["num_classes"]
-            self.assertEqual(num_classes, model.num_classes)
             self.assertTrue(isinstance(model, ClassyModel))
             self.assertTrue(
                 type(model.output_shape) == tuple and len(model.output_shape) == 2


### PR DESCRIPTION
Summary:
Having both num_classes and output_shape is a bit redundant. This diff removes `num_classes` from ClassyModel because
1. In most cases, user just want to see the output shape of the model.
2. For some models with non classification heads, it doesn't make sense to have `num_classes`

Differential Revision: D18111973

