### PR TITLE
Fix shuffling order

### DIFF
--- a/classy_vision/dataset/classy_synthetic_video.py
+++ b/classy_vision/dataset/classy_synthetic_video.py
@@ -72,6 +72,15 @@ class SyntheticVideoClassificationDataset(ClassyVideoDataset):
             clips_per_video,
         )
 
+    def _get_sampler(self, epoch):
+        world_size = get_world_size()
+        rank = get_rank()
+        sampler = DistributedSampler(
+            self, num_replicas=world_size, rank=rank, shuffle=self.shuffle
+        )
+        sampler.set_epoch(epoch)
+        return sampler
+
     @classmethod
     def from_config(cls, config):
         split = config["split"]
@@ -107,11 +116,4 @@ class SyntheticVideoClassificationDataset(ClassyVideoDataset):
             step_between_clips,
             frame_rate,
             clips_per_video,
-        )
-
-    def _get_sampler(self):
-        world_size = get_world_size()
-        rank = get_rank()
-        return DistributedSampler(
-            self.dataset, num_replicas=world_size, rank=rank, shuffle=self.shuffle
         )

--- a/classy_vision/dataset/classy_video_dataset.py
+++ b/classy_vision/dataset/classy_video_dataset.py
@@ -127,7 +127,7 @@ class ClassyVideoDataset(ClassyDataset):
         except ValueError:
             logging.warn(f"Fail to save metadata to file: {filepath}")
 
-    def _get_sampler(self):
+    def _get_sampler(self, epoch):
         if self.split == "train":
             # For video model training, we don't necessarily want to use all possible
             # clips in the video in one training epoch. More often, we randomly
@@ -143,7 +143,7 @@ class ClassyVideoDataset(ClassyDataset):
             )
         world_size = get_world_size()
         rank = get_rank()
-        return DistributedSampler(
+        sampler = DistributedSampler(
             clip_sampler,
             num_replicas=world_size,
             rank=rank,
@@ -151,6 +151,8 @@ class ClassyVideoDataset(ClassyDataset):
             group_size=self.clips_per_video,
             num_samples=self.num_samples,
         )
+        sampler.set_epoch(epoch)
+        return sampler
 
     def iterator(self, *args, **kwargs):
         # for video dataset, it may use VideoClips class from TorchVision,


### PR DESCRIPTION
Summary:
In my dataset refactor, I forgot to pass the epoch to the sampler so it was using the same shuffle for every epoch.

This diff passes epoch to the _get_sampler function.

Reviewed By: mannatsingh

Differential Revision: D18137655

