### PR TITLE
Use gpu for tests if available

### DIFF
--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -13,7 +13,9 @@ from classy_vision.tasks import ClassyTask
 
 
 class ClassyTrainer:
-    def __init__(self, use_gpu, num_workers=0):
+    def __init__(self, use_gpu=None, num_workers=0):
+        if use_gpu is None:
+            use_gpu = torch.cuda.is_available()
         self.use_gpu = use_gpu
         self.num_workers = num_workers
 

--- a/classy_vision/trainer/distributed_trainer.py
+++ b/classy_vision/trainer/distributed_trainer.py
@@ -45,7 +45,7 @@ def _init_distributed(use_gpu):
 
 
 class DistributedTrainer(ClassyTrainer):
-    def __init__(self, use_gpu, num_workers):
+    def __init__(self, use_gpu=None, num_workers=0):
         super().__init__(use_gpu=use_gpu, num_workers=num_workers)
         _init_env_vars()
         _init_distributed(self.use_gpu)

--- a/classy_vision/trainer/local_trainer.py
+++ b/classy_vision/trainer/local_trainer.py
@@ -12,7 +12,7 @@ from .classy_trainer import ClassyTrainer
 
 
 class LocalTrainer(ClassyTrainer):
-    def __init__(self, use_gpu, num_workers=0):
+    def __init__(self, use_gpu=None, num_workers=0):
         super().__init__(use_gpu=use_gpu, num_workers=num_workers)
         if self.use_gpu:
             logging.info("Using GPU, CUDA device index: {}".format(0))

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -117,7 +117,7 @@ def get_fast_test_task_config(head_num_classes=1000):
 
 
 def get_test_args():
-    return Arguments(device="cpu", num_workers=8, test_only=False)
+    return Arguments(test_only=False)
 
 
 def get_test_classy_task():

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -10,7 +10,7 @@ import unittest
 import unittest.mock as mock
 from pathlib import Path
 from test.generic.config_utils import get_fast_test_task_config, get_test_args
-from test.generic.utils import compare_model_state, compare_samples, compare_states
+from test.generic.utils import compare_model_state, compare_states
 
 import classy_vision.generic.util as util
 import torch

--- a/test/models_classy_model_wrapper_test.py
+++ b/test/models_classy_model_wrapper_test.py
@@ -81,5 +81,5 @@ class TestClassyModelWrapper(unittest.TestCase):
         args = get_test_args()
         task = build_task(config, args)
         task.set_model(classy_model)
-        trainer = LocalTrainer(use_gpu=False)
+        trainer = LocalTrainer()
         trainer.train(task)

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -94,7 +94,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
         mock.update_interval = UpdateInterval.EPOCH
         task.optimizer._lr_scheduler = mock
 
-        trainer = LocalTrainer(use_gpu=False)
+        trainer = LocalTrainer()
         trainer.train(task)
 
         self.assertEqual(where_list, [0, 1 / 3, 2 / 3])
@@ -112,7 +112,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
         mock.update_interval = UpdateInterval.STEP
         task.optimizer._lr_scheduler = mock
 
-        trainer = LocalTrainer(use_gpu=False)
+        trainer = LocalTrainer()
         trainer.train(task)
 
         # We have 10 samples, batch size is 5. Each epoch is done in two steps.

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -69,7 +69,7 @@ class TestFineTuningTask(unittest.TestCase):
         pre_train_config = self._get_pre_train_config(head_num_classes=1000)
         args = get_test_args()
         pre_train_task = build_task(pre_train_config, args)
-        trainer = LocalTrainer(use_gpu=False)
+        trainer = LocalTrainer()
         trainer.train(pre_train_task)
         checkpoint = get_checkpoint_dict(pre_train_task, args)
 

--- a/test/trainer_test.py
+++ b/test/trainer_test.py
@@ -64,8 +64,8 @@ class TestClassyTrainer(unittest.TestCase):
             },
         }
 
-    def test_cpu_training(self):
-        """Checks we can train a small MLP model on a CPU."""
+    def test_training(self):
+        """Checks we can train a small MLP model."""
         config = self._get_config()
         task = (
             ClassificationTask()
@@ -82,7 +82,7 @@ class TestClassyTrainer(unittest.TestCase):
 
         self.assertTrue(task is not None)
 
-        trainer = LocalTrainer(use_gpu=False)
+        trainer = LocalTrainer()
         trainer.train(task)
         accuracy = task.meters[0].value["top_1"]
         self.assertAlmostEqual(accuracy, 1.0)


### PR DESCRIPTION
Summary:
Updated the tests to use the gpu, if available. Removed unused args from `get_test_args`.

`ClassyTask.set_classy_state()` doesn't work properly when we copy from gpu to cpu or vice-versa. So I haven't updated `generic_util_test` and `state_classy_state_test`. Will figure out how to handle those situations in the next diff.

Differential Revision: D18137853

