### PR TITLE
Rename num_workers to num_dataloader_workers

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -216,10 +216,10 @@ class ClassificationTask(ClassyTask):
             for split in self.datasets.keys()
         }
 
-    def prepare(self, num_workers=0, pin_memory=False, use_gpu=False):
+    def prepare(self, num_dataloader_workers=0, pin_memory=False, use_gpu=False):
         self.phases = self._build_phases()
         self.dataloaders = self.build_dataloaders(
-            num_workers=num_workers, pin_memory=pin_memory
+            num_workers=num_dataloader_workers, pin_memory=pin_memory
         )
 
         if use_gpu:

--- a/classy_vision/tasks/classy_task.py
+++ b/classy_vision/tasks/classy_task.py
@@ -50,7 +50,7 @@ class ClassyTask(ABC):
         pass
 
     @abstractmethod
-    def prepare(self, num_workers=0, pin_memory=False, use_gpu=False):
+    def prepare(self, num_dataloader_workers=0, pin_memory=False, use_gpu=False):
         """
         Prepares the task for training.
         """

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -55,12 +55,15 @@ class FineTuningTask(ClassificationTask):
             self.optimizer.update_schedule_on_epoch(self.where)
 
     def prepare(
-        self, num_workers: int = 0, pin_memory: bool = False, use_gpu: bool = False
+        self,
+        num_dataloader_workers: int = 0,
+        pin_memory: bool = False,
+        use_gpu: bool = False,
     ) -> None:
         assert (
             self.pretrained_checkpoint is not None
         ), "Need a pretrained checkpoint for fine tuning"
-        super().prepare(num_workers, pin_memory, use_gpu)
+        super().prepare(num_dataloader_workers, pin_memory, use_gpu)
         if self.checkpoint is None:
             # no checkpoint exists, load the model's state from the pretrained
             # checkpoint

--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -13,11 +13,11 @@ from classy_vision.tasks import ClassyTask
 
 
 class ClassyTrainer:
-    def __init__(self, use_gpu=None, num_workers=0):
+    def __init__(self, use_gpu=None, num_dataloader_workers=0):
         if use_gpu is None:
             use_gpu = torch.cuda.is_available()
         self.use_gpu = use_gpu
-        self.num_workers = num_workers
+        self.num_dataloader_workers = num_dataloader_workers
 
     def train(self, task: ClassyTask):
         """
@@ -26,7 +26,9 @@ class ClassyTrainer:
 
         pin_memory = self.use_gpu and torch.cuda.device_count() > 1
         task.prepare(
-            num_workers=self.num_workers, pin_memory=pin_memory, use_gpu=self.use_gpu
+            num_dataloader_workers=self.num_dataloader_workers,
+            pin_memory=pin_memory,
+            use_gpu=self.use_gpu,
         )
         assert isinstance(task, ClassyTask)
 

--- a/classy_vision/trainer/distributed_trainer.py
+++ b/classy_vision/trainer/distributed_trainer.py
@@ -45,8 +45,8 @@ def _init_distributed(use_gpu):
 
 
 class DistributedTrainer(ClassyTrainer):
-    def __init__(self, use_gpu=None, num_workers=0):
-        super().__init__(use_gpu=use_gpu, num_workers=num_workers)
+    def __init__(self, use_gpu=None, num_dataloader_workers=0):
+        super().__init__(use_gpu=use_gpu, num_dataloader_workers=num_dataloader_workers)
         _init_env_vars()
         _init_distributed(self.use_gpu)
         logging.info(

--- a/classy_vision/trainer/local_trainer.py
+++ b/classy_vision/trainer/local_trainer.py
@@ -12,8 +12,8 @@ from .classy_trainer import ClassyTrainer
 
 
 class LocalTrainer(ClassyTrainer):
-    def __init__(self, use_gpu=None, num_workers=0):
-        super().__init__(use_gpu=use_gpu, num_workers=num_workers)
+    def __init__(self, use_gpu=None, num_dataloader_workers=0):
+        super().__init__(use_gpu=use_gpu, num_dataloader_workers=num_dataloader_workers)
         if self.use_gpu:
             logging.info("Using GPU, CUDA device index: {}".format(0))
             set_cuda_device_index(0)

--- a/test/tasks_classy_vision_task_test.py
+++ b/test/tasks_classy_vision_task_test.py
@@ -35,8 +35,8 @@ class TestClassificationTask(unittest.TestCase):
             dataset = build_dataset(config["dataset"][split])
             task.set_dataset(dataset, split)
 
-        task.prepare(num_workers=1, pin_memory=False)
+        task.prepare(num_dataloader_workers=1, pin_memory=False)
 
         args = get_test_args()
         task = build_task(config, args)
-        task.prepare(num_workers=1, pin_memory=False)
+        task.prepare(num_dataloader_workers=1, pin_memory=False)


### PR DESCRIPTION
Summary:
Creating a DistributedTrainer(num_workers=3) does not mean we'll train in 3
machines. It means we'll use 3 processes to load the data on a single machine.
That's very confusing, so rename num_workers.

Differential Revision: D18093160

