### PR TITLE
Remove args from build_task

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -433,14 +433,14 @@ def input_args_to_dict(input_args):
     """
     Converts arguments parsed through argparse or named tuples to dicts
     """
-    assert isinstance(input_args, argparse.Namespace) or hasattr(
-        input_args, "_asdict"
-    ), f"Unexpected input_args of type: {type(input_args)}"
-    if isinstance(input_args, argparse.Namespace):
-        input_args = vars(input_args)
-    else:
-        input_args = input_args._asdict()
-    return input_args
+    if isinstance(input_args, dict):
+        return input_args
+    elif isinstance(input_args, argparse.Namespace):
+        return vars(input_args)
+    elif hasattr(input_args, "_asdict"):
+        return input_args._asdict()
+
+    raise RuntimeError(f"Unexpected input_args of type: {type(input_args)}")
 
 
 def get_checkpoint_dict(task, input_args):

--- a/classy_vision/tasks/__init__.py
+++ b/classy_vision/tasks/__init__.py
@@ -18,10 +18,7 @@ TASK_REGISTRY = {}
 TASK_CLASS_NAMES = set()
 
 
-def build_task(config, args, **kwargs):
-    # allow some command-line options to override configuration:
-    if "test_only" not in config:
-        config["test_only"] = args.test_only
+def build_task(config):
     return TASK_REGISTRY[config["name"]].from_config(config)
 
 

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -110,7 +110,7 @@ class ClassificationTask(ClassyTask):
         for split in splits:
             datasets[split] = build_dataset(config["dataset"][split])
         loss = build_loss(config["loss"])
-        test_only = config["test_only"]
+        test_only = config.get("test_only", False)
         meters = build_meters(config.get("meters", {}))
         model = build_model(config["model"])
         # put model in eval mode in case any hooks modify model states, it'll

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -116,14 +116,9 @@ def get_fast_test_task_config(head_num_classes=1000):
     }
 
 
-def get_test_args():
-    return Arguments(test_only=False)
-
-
 def get_test_classy_task():
     config = get_test_task_config()
-    args = get_test_args()
-    task = build_task(config, args)
+    task = build_task(config)
     return task
 
 
@@ -261,6 +256,5 @@ def get_test_video_task_config():
 
 def get_test_classy_video_task():
     config = get_test_video_task_config()
-    args = get_test_args()
-    task = build_task(config, args)
+    task = build_task(config)
     return task

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -9,7 +9,7 @@ import typing
 import unittest
 import unittest.mock as mock
 from pathlib import Path
-from test.generic.config_utils import get_fast_test_task_config, get_test_args
+from test.generic.config_utils import get_fast_test_task_config
 from test.generic.utils import compare_model_state, compare_states
 
 import classy_vision.generic.util as util
@@ -365,9 +365,8 @@ class TestUpdateStateFunctions(unittest.TestCase):
         checkpoint
         """
         config = get_fast_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
-        task_2 = build_task(config, args)
+        task = build_task(config)
+        task_2 = build_task(config)
         task_2.prepare()
         trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
@@ -380,12 +379,11 @@ class TestUpdateStateFunctions(unittest.TestCase):
         checkpoint
         """
         config = get_fast_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         trainer = LocalTrainer(use_gpu=False)
         trainer.train(task)
         for reset_heads in [False, True]:
-            task_2 = build_task(config, args)
+            task_2 = build_task(config)
             update_classy_model(
                 task_2.model, task.model.get_classy_state(deep_copy=True), reset_heads
             )

--- a/test/hooks_checkpoint_hook_test.py
+++ b/test/hooks_checkpoint_hook_test.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 
 from classy_vision.generic.util import load_checkpoint
 from classy_vision.hooks import CheckpointHook
@@ -28,8 +28,7 @@ class TestCheckpointHook(unittest.TestCase):
         right phase_type and only if the checkpoint directory exists.
         """
         config = get_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         task.prepare()
 
         local_variables = {}
@@ -37,7 +36,7 @@ class TestCheckpointHook(unittest.TestCase):
         device = "cpu"
 
         # create a checkpoint hook
-        checkpoint_hook = CheckpointHook(checkpoint_folder, args, phase_types=["train"])
+        checkpoint_hook = CheckpointHook(checkpoint_folder, {}, phase_types=["train"])
 
         # checkpoint directory doesn't exist
         # call the on start function
@@ -71,7 +70,7 @@ class TestCheckpointHook(unittest.TestCase):
             self.assertIn(key, checkpoint)
         # not testing for equality of classy_state_dict, that is tested in
         # a separate test
-        self.assertDictEqual(checkpoint["input_args"], args._asdict())
+        self.assertDictEqual(checkpoint["input_args"], {})
         self.assertDictEqual(checkpoint["config"], task.get_config())
 
     def test_checkpoint_period(self) -> None:
@@ -79,8 +78,7 @@ class TestCheckpointHook(unittest.TestCase):
         Test that the checkpoint_period works as expected.
         """
         config = get_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         task.prepare()
 
         local_variables = {}
@@ -92,7 +90,7 @@ class TestCheckpointHook(unittest.TestCase):
             # create a checkpoint hook
             checkpoint_hook = CheckpointHook(
                 checkpoint_folder,
-                args,
+                {},
                 phase_types=phase_types,
                 checkpoint_period=checkpoint_period,
             )

--- a/test/hooks_loss_lr_meter_logging_hook_test.py
+++ b/test/hooks_loss_lr_meter_logging_hook_test.py
@@ -7,7 +7,7 @@
 import unittest
 import unittest.mock as mock
 from itertools import product
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 
 from classy_vision.hooks import LossLrMeterLoggingHook
 from classy_vision.tasks import build_task
@@ -27,8 +27,7 @@ class TestLossLrMeterLoggingHook(unittest.TestCase):
         config = get_test_task_config()
         config["dataset"]["train"]["batchsize_per_replica"] = 2
         config["dataset"]["test"]["batchsize_per_replica"] = 5
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         task.prepare()
 
         losses = [1.2, 2.3, 3.4, 4.5]

--- a/test/hub_classy_hub_interface_test.py
+++ b/test/hub_classy_hub_interface_test.py
@@ -7,7 +7,7 @@
 import shutil
 import tempfile
 import unittest
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 
 import torch
 from classy_vision.dataset.transforms import ClassyTransform
@@ -59,8 +59,7 @@ class TestClassyHubInterface(unittest.TestCase):
 
     def test_from_task(self):
         config = get_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         hub_interface = ClassyHubInterface.from_task(task)
 
         self.assertIsInstance(hub_interface.task, ClassyTask)

--- a/test/manual/hooks_tensorboard_plot_hook_test.py
+++ b/test/manual/hooks_tensorboard_plot_hook_test.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 import unittest.mock as mock
 from itertools import product
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 
 from classy_vision.hooks import TensorboardPlotHook
 from classy_vision.tasks import build_task
@@ -40,8 +40,7 @@ class TestTensorboardPlotHook(unittest.TestCase):
             config = get_test_task_config()
             config["dataset"]["train"]["batchsize_per_replica"] = 2
             config["dataset"]["test"]["batchsize_per_replica"] = 5
-            args = get_test_args()
-            task = build_task(config, args)
+            task = build_task(config)
             task.prepare()
             task.phase_idx = phase_idx
             task.train = train

--- a/test/manual/hooks_visdom_hook_test.py
+++ b/test/manual/hooks_visdom_hook_test.py
@@ -8,7 +8,7 @@ import copy
 import unittest
 import unittest.mock as mock
 from itertools import product
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 
 from classy_vision.hooks import VisdomHook
 from classy_vision.tasks import build_task
@@ -33,8 +33,7 @@ class TestVisdomHook(unittest.TestCase):
         config = get_test_task_config()
         config["dataset"]["train"]["batchsize_per_replica"] = 2
         config["dataset"]["test"]["batchsize_per_replica"] = 5
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         task.prepare()
 
         losses = [1.2, 2.3, 1.23, 2.33]

--- a/test/models_classy_model_wrapper_test.py
+++ b/test/models_classy_model_wrapper_test.py
@@ -6,7 +6,7 @@
 
 import copy
 import unittest
-from test.generic.config_utils import get_fast_test_task_config, get_test_args
+from test.generic.config_utils import get_fast_test_task_config
 
 import torch
 import torch.nn as nn
@@ -78,8 +78,7 @@ class TestClassyModelWrapper(unittest.TestCase):
         classy_model = ClassyModelWrapper(model)
 
         config = get_fast_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         task.set_model(classy_model)
         trainer = LocalTrainer()
         trainer.train(task)

--- a/test/state_classy_state_test.py
+++ b/test/state_classy_state_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 from test.generic.utils import compare_model_state, compare_samples, compare_states
 
 from classy_vision.hooks import LossLrMeterLoggingHook
@@ -31,9 +31,8 @@ class TestClassyState(unittest.TestCase):
         # use a batchsize of 1 for faster testing
         for split in ["train", "test"]:
             config["dataset"][split]["batchsize_per_replica"] = 1
-        args = get_test_args()
-        task = build_task(config, args).set_hooks([LossLrMeterLoggingHook()])
-        task_2 = build_task(config, args).set_hooks([LossLrMeterLoggingHook()])
+        task = build_task(config).set_hooks([LossLrMeterLoggingHook()])
+        task_2 = build_task(config).set_hooks([LossLrMeterLoggingHook()])
 
         task.prepare()
         task_2.prepare()

--- a/test/tasks_classy_vision_task_test.py
+++ b/test/tasks_classy_vision_task_test.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import unittest
-from test.generic.config_utils import get_test_args, get_test_task_config
+from test.generic.config_utils import get_test_task_config
 
 from classy_vision.dataset import build_dataset
 from classy_vision.losses import build_loss
@@ -17,8 +17,7 @@ from classy_vision.tasks import ClassificationTask, build_task
 class TestClassificationTask(unittest.TestCase):
     def test_build_task(self):
         config = get_test_task_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         self.assertTrue(isinstance(task, ClassificationTask))
 
     def test_get_state(self):
@@ -37,6 +36,5 @@ class TestClassificationTask(unittest.TestCase):
 
         task.prepare(num_dataloader_workers=1, pin_memory=False)
 
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         task.prepare(num_dataloader_workers=1, pin_memory=False)

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -6,7 +6,7 @@
 
 import copy
 import unittest
-from test.generic.config_utils import get_fast_test_task_config, get_test_args
+from test.generic.config_utils import get_fast_test_task_config
 from test.generic.utils import compare_model_state
 
 from classy_vision.generic.util import get_checkpoint_dict
@@ -31,20 +31,17 @@ class TestFineTuningTask(unittest.TestCase):
 
     def test_build_task(self):
         config = self._get_fine_tuning_config()
-        args = get_test_args()
-        task = build_task(config, args)
+        task = build_task(config)
         self.assertIsInstance(task, FineTuningTask)
 
     def test_prepare(self):
         pre_train_config = self._get_pre_train_config()
-        args = get_test_args()
-        pre_train_task = build_task(pre_train_config, args)
+        pre_train_task = build_task(pre_train_config)
         pre_train_task.prepare()
-        checkpoint = get_checkpoint_dict(pre_train_task, args)
+        checkpoint = get_checkpoint_dict(pre_train_task, {})
 
         fine_tuning_config = self._get_fine_tuning_config()
-        args = get_test_args()
-        fine_tuning_task = build_task(fine_tuning_config, args)
+        fine_tuning_task = build_task(fine_tuning_config)
         # cannot prepare a fine tuning task without a pre training checkpoint
         with self.assertRaises(Exception):
             fine_tuning_task.prepare()
@@ -54,8 +51,7 @@ class TestFineTuningTask(unittest.TestCase):
 
         # test a fine tuning task with incompatible heads
         fine_tuning_config = self._get_fine_tuning_config(head_num_classes=10)
-        args = get_test_args()
-        fine_tuning_task = build_task(fine_tuning_config, args)
+        fine_tuning_task = build_task(fine_tuning_config)
         fine_tuning_task.set_pretrained_checkpoint(checkpoint)
         # cannot prepare a fine tuning task with a pre training checkpoint which
         # has incompatible heads
@@ -67,18 +63,17 @@ class TestFineTuningTask(unittest.TestCase):
 
     def test_train(self):
         pre_train_config = self._get_pre_train_config(head_num_classes=1000)
-        args = get_test_args()
-        pre_train_task = build_task(pre_train_config, args)
+        pre_train_task = build_task(pre_train_config)
         trainer = LocalTrainer()
         trainer.train(pre_train_task)
-        checkpoint = get_checkpoint_dict(pre_train_task, args)
+        checkpoint = get_checkpoint_dict(pre_train_task, {})
 
         for reset_heads, heads_num_classes in [(False, 1000), (True, 200)]:
             for freeze_trunk in [True, False]:
                 fine_tuning_config = self._get_fine_tuning_config(
                     head_num_classes=heads_num_classes
                 )
-                fine_tuning_task = build_task(fine_tuning_config, args)
+                fine_tuning_task = build_task(fine_tuning_config)
                 fine_tuning_task = (
                     fine_tuning_task.set_pretrained_checkpoint(
                         copy.deepcopy(checkpoint)


### PR DESCRIPTION
Summary:
No other build methods have an `args` parameter, so remove this one for
consistency. Command line script should just override the config themselves if
needed.

Differential Revision: D18095219

