### PR TITLE
Clean up meter state to use get_classy_state

### DIFF
--- a/classy_vision/meters/accuracy_meter.py
+++ b/classy_vision/meters/accuracy_meter.py
@@ -84,8 +84,7 @@ class AccuracyMeter(ClassyMeter):
             for k in self._topk
         }
 
-    @property
-    def meter_state_dict(self):
+    def get_classy_state(self):
         """Contains the states of the meter.
         """
         return {
@@ -97,9 +96,17 @@ class AccuracyMeter(ClassyMeter):
             "curr_correct_predictions_k": self._curr_correct_predictions_k.clone(),
         }
 
-    @meter_state_dict.setter
-    def meter_state_dict(self, state):
-        assert self._topk == state["top_k"], "Incompatible top-k for accuracy!"
+    def set_classy_state(self, state):
+        assert (
+            self.name == state["name"]
+        ), "State name {state_name} does not match meter name {obj_name}".format(
+            state_name=state["name"], obj_name=self.name
+        )
+        assert (
+            self._topk == state["top_k"]
+        ), "top-k of state {state_k} does not match object's top-k {obj_k}".format(
+            state_k=state["top_k"], obj_k=self._topk
+        )
 
         # Restore the state -- correct_predictions and sample_count.
         self.reset()

--- a/classy_vision/meters/classy_meter.py
+++ b/classy_vision/meters/classy_meter.py
@@ -38,21 +38,6 @@ class ClassyMeter(object):
         """
         raise NotImplementedError
 
-    @property
-    def meter_state_dict(self):
-        """Dictionary of states for the meter.
-        """
-        raise NotImplementedError
-
-    @meter_state_dict.setter
-    def meter_state_dict(self, classy_state):
-        """Sets the meter state from classy_state.
-
-        Args:
-            classy_state: State to restore from.
-        """
-        raise NotImplementedError
-
     def sync_state(self):
         """Syncs state with all other meters in distributed training.
 
@@ -91,7 +76,7 @@ class ClassyMeter(object):
     def get_classy_state(self):
         """Gets the state of the ClassyMeter.
         """
-        return self.meter_state_dict
+        raise NotImplementedError
 
     def set_classy_state(self, state):
         """Sets the state of the ClassyMeter.
@@ -99,13 +84,4 @@ class ClassyMeter(object):
         Args:
             state: State of the Meter to restore.
         """
-        # Validate name and existence of mandatory fields (common to all meters).
-        for field in self.meter_state_dict.keys():
-            assert (
-                field in state
-            ), "State does not contain mandatory {0} " "field".format(field)
-        assert self.name == state["name"], "Incompatible meter name!"
-
-        # Assign classy_state to meter_state_dict.
-        # Each meter runs its own assertions and then sets state.
-        self.meter_state_dict = state
+        raise NotImplementedError

--- a/classy_vision/meters/precision_meter.py
+++ b/classy_vision/meters/precision_meter.py
@@ -97,8 +97,7 @@ class PrecisionAtKMeter(ClassyMeter):
             for k in self._topk
         }
 
-    @property
-    def meter_state_dict(self):
+    def get_classy_state(self):
         """Contains the states of the meter.
         """
         return {
@@ -110,9 +109,17 @@ class PrecisionAtKMeter(ClassyMeter):
             "curr_correct_predictions_k": self._curr_correct_predictions_k.clone(),
         }
 
-    @meter_state_dict.setter
-    def meter_state_dict(self, state):
-        assert self._topk == state["top_k"], "Incompatible top-k for precision!"
+    def set_classy_state(self, state):
+        assert (
+            self.name == state["name"]
+        ), "State name {state_name} does not match meter name {obj_name}".format(
+            state_name=state["name"], obj_name=self.name
+        )
+        assert (
+            self._topk == state["top_k"]
+        ), "top-k of state {state_k} does not match object's top-k {obj_k}".format(
+            state_k=state["top_k"], obj_k=self._topk
+        )
 
         # Restore the state -- correct_predictions and sample_count.
         self.reset()

--- a/classy_vision/meters/recall_meter.py
+++ b/classy_vision/meters/recall_meter.py
@@ -96,8 +96,7 @@ class RecallAtKMeter(ClassyMeter):
             for k in self._topk
         }
 
-    @property
-    def meter_state_dict(self):
+    def get_classy_state(self):
         """Contains the states of the meter.
         """
         return {
@@ -109,9 +108,17 @@ class RecallAtKMeter(ClassyMeter):
             "curr_correct_predictions_k": self._curr_correct_predictions_k.clone(),
         }
 
-    @meter_state_dict.setter
-    def meter_state_dict(self, state):
-        assert self._topk == state["top_k"], "Incompatible top-k for recall!"
+    def set_classy_state(self, state):
+        assert (
+            self.name == state["name"]
+        ), "State name {state_name} does not match meter name {obj_name}".format(
+            state_name=state["name"], obj_name=self.name
+        )
+        assert (
+            self._topk == state["top_k"]
+        ), "top-k of state {state_k} does not match object's top-k {obj_k}".format(
+            state_k=state["top_k"], obj_k=self._topk
+        )
 
         # Restore the state -- correct_predictions and correct_targets.
         self.reset()

--- a/classy_vision/meters/video_accuracy_meter.py
+++ b/classy_vision/meters/video_accuracy_meter.py
@@ -51,18 +51,22 @@ class VideoAccuracyMeter(ClassyMeter):
     def value(self):
         return self._accuracy_meter.value
 
-    @property
-    def meter_state_dict(self):
+    def get_classy_state(self):
         """Contains the states of the meter.
         """
-        state_dict = self._accuracy_meter.meter_state_dict
-        state_dict["name"] = "video_accuracy"
-        state_dict["clips_per_video_train"] = self._clips_per_video_train
-        state_dict["clips_per_video_test"] = self._clips_per_video_test
-        return state_dict
+        state = {}
+        state["accuracy_state"] = self._accuracy_meter.get_classy_state()
+        state["name"] = "video_accuracy"
+        state["clips_per_video_train"] = self._clips_per_video_train
+        state["clips_per_video_test"] = self._clips_per_video_test
+        return state
 
-    @meter_state_dict.setter
-    def meter_state_dict(self, state):
+    def set_classy_state(self, state):
+        assert (
+            "video_accuracy" == state["name"]
+        ), "State name {state_name} does not match meter name {obj_name}".format(
+            state_name=state["name"], obj_name=self.name
+        )
         assert (
             self._clips_per_video_train == state["clips_per_video_train"]
         ), "incompatible clips_per_video_train for video accuracy"
@@ -71,7 +75,7 @@ class VideoAccuracyMeter(ClassyMeter):
         ), "incompatible clips_per_video_test for video accuracy"
         # Restore the state -- correct_predictions and sample_count.
         self.reset()
-        self._accuracy_meter.meter_state_dict = state
+        self._accuracy_meter.set_classy_state(state["accuracy_state"])
 
     def __repr__(self):
         return repr({"name": self.name, "value": self._accuracy_meter.value})


### PR DESCRIPTION
Summary: Meter state dict abstraction serves almost same purpose as get_classy_state / set_classy_state. Cleaning this up before OSS by removing the meter_state_dict calls and moving all logic to get / set classy state calls.

Differential Revision: D18162805

