### PR TITLE
Remove freeze_trunk from missed configs

### DIFF
--- a/configs/glore_i3d50_kinetics400_classy_config.json
+++ b/configs/glore_i3d50_kinetics400_classy_config.json
@@ -122,7 +122,6 @@
     "num_groups": 1,
     "width_per_group": 64,
     "num_classes": 400,
-    "freeze_trunk": false,
     "zero_init_residual_transform": true,
     "heads": [
       {

--- a/configs/r3d34_hmdb51_classy_config.json
+++ b/configs/r3d34_hmdb51_classy_config.json
@@ -125,7 +125,6 @@
     "num_groups": 1,
     "width_per_group": 64,
     "num_classes": 51,
-    "freeze_trunk": false,
     "heads": [
       {
         "name": "fully_convolutional_linear",

--- a/configs/r3d34_synthetic_video_classy_config.json
+++ b/configs/r3d34_synthetic_video_classy_config.json
@@ -56,7 +56,6 @@
         "num_groups": 1,
         "width_per_group": 64,
         "num_classes": 50,
-        "freeze_trunk": false,
         "heads": [
           {
             "name": "fully_convolutional_linear",

--- a/configs/r3d34_ucf101_classy_config.json
+++ b/configs/r3d34_ucf101_classy_config.json
@@ -123,7 +123,6 @@
         "num_groups": 1,
         "width_per_group": 64,
         "num_classes": 101,
-        "freeze_trunk": false,
         "heads": [
             {
                 "name": "resnext3d_basic_head",

--- a/configs/sf_i3d50_kinetics400_classy_config.json
+++ b/configs/sf_i3d50_kinetics400_classy_config.json
@@ -122,7 +122,6 @@
     "num_groups": 1,
     "width_per_group": 64,
     "num_classes": 400,
-    "freeze_trunk": false,
     "zero_init_residual_transform": true,
     "heads": [
       {

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -6,8 +6,6 @@
 
 from classy_vision.tasks import build_task
 
-from .utils import Arguments
-
 
 def get_test_task_config(head_num_classes=1000):
     return {
@@ -227,7 +225,6 @@ def get_test_video_task_config():
             "num_groups": 1,
             "width_per_group": 64,
             "num_classes": 50,
-            "freeze_trunk": False,
             "heads": [
                 {
                     "name": "fully_convolutional_linear",


### PR DESCRIPTION
Summary: Missed removing `freeze_trunk` from the fblearner configs and also some configs were added after that diff containing `freeze_trunk`, removing all of them.

Differential Revision: D18171112

