### PR TITLE
Make lr_scheduler public and allow specifying UpdateInterval type from config

### DIFF
--- a/classy_vision/optim/classy_optimizer.py
+++ b/classy_vision/optim/classy_optimizer.py
@@ -14,8 +14,8 @@ class ClassyOptimizer:
         """
         Classy Optimizer constructor.
         """
-        self._lr_scheduler = lr_scheduler
-        self.lr = self._lr_scheduler(0)
+        self.lr_scheduler = lr_scheduler
+        self.lr = self.lr_scheduler(0)
         self._optimizer = None
         self.optimizer_params = None
 
@@ -117,25 +117,25 @@ class ClassyOptimizer:
         loss.backward()
 
     def update_schedule_on_epoch(self, where):
-        assert self._lr_scheduler.update_interval in [
+        assert self.lr_scheduler.update_interval in [
             UpdateInterval.EPOCH,
             UpdateInterval.STEP,
         ]
 
-        if self._lr_scheduler.update_interval == UpdateInterval.EPOCH:
+        if self.lr_scheduler.update_interval == UpdateInterval.EPOCH:
             self._update_schedule(where)
 
     def update_schedule_on_step(self, where):
-        assert self._lr_scheduler.update_interval in [
+        assert self.lr_scheduler.update_interval in [
             UpdateInterval.EPOCH,
             UpdateInterval.STEP,
         ]
 
-        if self._lr_scheduler.update_interval == UpdateInterval.STEP:
+        if self.lr_scheduler.update_interval == UpdateInterval.STEP:
             self._update_schedule(where)
 
     def _update_schedule(self, where):
-        self.lr = self._lr_scheduler(where)
+        self.lr = self.lr_scheduler(where)
         for group in self.optimizer.param_groups:
             group.update(self.parameters)
 

--- a/classy_vision/optim/param_scheduler/classy_vision_param_scheduler.py
+++ b/classy_vision/optim/param_scheduler/classy_vision_param_scheduler.py
@@ -16,8 +16,15 @@ class ClassyParamScheduler(object):
     # To be used for comparisons with where
     WHERE_EPSILON = 1e-6
 
-    def __init__(self):
-        self.update_interval = UpdateInterval.EPOCH
+    def __init__(self, update_interval="epoch"):
+        assert update_interval in [
+            "epoch",
+            "step",
+        ], f"Unknown update_interval: {update_interval}"
+        if update_interval == "epoch":
+            self.update_interval = UpdateInterval.EPOCH
+        else:
+            self.update_interval = UpdateInterval.STEP
 
     def __call__(self, where: float):
         """

--- a/classy_vision/optim/param_scheduler/constant_scheduler.py
+++ b/classy_vision/optim/param_scheduler/constant_scheduler.py
@@ -13,14 +13,17 @@ class ConstantParamScheduler(ClassyParamScheduler):
     Returns a constant value for a optimizer param.
     """
 
-    def __init__(self, value: float):
-        super().__init__()
+    def __init__(self, value: float, update_interval: str):
+        super().__init__(update_interval)
         self._value = value
 
     @classmethod
     def from_config(cls, config):
         assert "value" in config
-        return cls(value=config["value"])
+        update_interval = "epoch"
+        if "update_interval" in config:
+            update_interval = config["update_interval"]
+        return cls(value=config["value"], update_interval=update_interval)
 
     def __call__(self, where: float):
         if where >= 1.0:

--- a/classy_vision/optim/param_scheduler/cosine_scheduler.py
+++ b/classy_vision/optim/param_scheduler/cosine_scheduler.py
@@ -28,8 +28,14 @@ class CosineParamScheduler(ClassyParamScheduler):
         length: float  # normalizaed length in [0, 1)
         init_lr: float
 
-    def __init__(self, start_lr: float, end_lr: float, warmup: Optional[Warmup] = None):
-        super().__init__()
+    def __init__(
+        self,
+        start_lr: float,
+        end_lr: float,
+        update_interval: str,
+        warmup: Optional[Warmup] = None,
+    ):
+        super().__init__(update_interval)
         self._start_lr = start_lr
         self._end_lr = end_lr
         self._warmup = warmup
@@ -55,8 +61,15 @@ class CosineParamScheduler(ClassyParamScheduler):
             for name in ["init_lr", "length"]:
                 assert name in config["warmup"], "warmup requires parameter: %s" % name
             warmup = cls.Warmup(**config["warmup"])
-
-        return cls(start_lr=config["start_lr"], end_lr=config["end_lr"], warmup=warmup)
+        update_interval = "epoch"
+        if "update_interval" in config:
+            update_interval = config["update_interval"]
+        return cls(
+            start_lr=config["start_lr"],
+            end_lr=config["end_lr"],
+            update_interval=update_interval,
+            warmup=warmup,
+        )
 
     def __call__(self, where: float):
         warmup_length = self._warmup.length if self._warmup is not None else 0

--- a/classy_vision/optim/param_scheduler/multi_step_scheduler.py
+++ b/classy_vision/optim/param_scheduler/multi_step_scheduler.py
@@ -38,10 +38,11 @@ class MultiStepParamScheduler(ClassyParamScheduler):
         self,
         values,
         num_epochs: int,
+        update_interval: str,
         warmup: Warmup = None,
         milestones: Optional[List[int]] = None,
     ):
-        super().__init__()
+        super().__init__(update_interval)
         self._param_schedule = values
         self._num_epochs = num_epochs
         self._milestones = milestones
@@ -99,10 +100,13 @@ class MultiStepParamScheduler(ClassyParamScheduler):
             for name in ["init_lr", "epochs"]:
                 assert name in config["warmup"], "warmup requires parameter: %s" % name
             warmup = cls.Warmup(**config["warmup"])
-
+        update_interval = "epoch"
+        if "update_interval" in config:
+            update_interval = config["update_interval"]
         return cls(
             values=config["values"],
             num_epochs=config["num_epochs"],
+            update_interval=update_interval,
             warmup=warmup,
             milestones=milestones,
         )

--- a/classy_vision/optim/param_scheduler/polynomial_decay_scheduler.py
+++ b/classy_vision/optim/param_scheduler/polynomial_decay_scheduler.py
@@ -21,8 +21,8 @@ class PolynomialDecayParamScheduler(ClassyParamScheduler):
     so on.
     """
 
-    def __init__(self, base_lr, power):
-        super().__init__()
+    def __init__(self, base_lr, power, update_interval: str):
+        super().__init__(update_interval)
 
         self._base_lr = base_lr
         self._power = power
@@ -32,7 +32,14 @@ class PolynomialDecayParamScheduler(ClassyParamScheduler):
         assert (
             "base_lr" in config and "power" in config
         ), "Polynomial decay scheduler requires a base lr and a power of decay"
-        return cls(base_lr=config["base_lr"], power=config["power"])
+        update_interval = "epoch"
+        if "update_interval" in config:
+            update_interval = config["update_interval"]
+        return cls(
+            base_lr=config["base_lr"],
+            power=config["power"],
+            update_interval=update_interval,
+        )
 
     def __call__(self, where: float):
         return self._base_lr * (1 - where) ** self._power

--- a/classy_vision/optim/param_scheduler/step_scheduler.py
+++ b/classy_vision/optim/param_scheduler/step_scheduler.py
@@ -32,9 +32,10 @@ class StepParamScheduler(ClassyParamScheduler):
         self,
         num_epochs: Union[int, float],
         values: List[float],
+        update_interval: str,
         warmup: Optional[Warmup] = None,
     ):
-        super().__init__()
+        super().__init__(update_interval)
 
         self._param_schedule = values
         self._warmup = warmup
@@ -58,8 +59,14 @@ class StepParamScheduler(ClassyParamScheduler):
                 assert name in config["warmup"], "warmup requires parameter: %s" % name
             warmup = cls.Warmup(**config["warmup"])
 
+        update_interval = "epoch"
+        if "update_interval" in config:
+            update_interval = config["update_interval"]
         return cls(
-            num_epochs=config["num_epochs"], values=config["values"], warmup=warmup
+            num_epochs=config["num_epochs"],
+            values=config["values"],
+            update_interval=update_interval,
+            warmup=warmup,
         )
 
     def __call__(self, where: float):

--- a/classy_vision/optim/param_scheduler/step_with_fixed_gamma_scheduler.py
+++ b/classy_vision/optim/param_scheduler/step_with_fixed_gamma_scheduler.py
@@ -47,17 +47,22 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
                 "epochs" in config["warmup"] and "init_lr" in config["warmup"]
             ), "warmup config requires two keys: 'epoch' and 'init_lr'"
             warmup = StepParamScheduler.Warmup(**config["warmup"])
-
+        update_interval = "epoch"
+        if "update_interval" in config:
+            update_interval = config["update_interval"]
         return cls(
             base_lr=config["base_lr"],
             num_decays=config["num_decays"],
             gamma=config["gamma"],
             num_epochs=config["num_epochs"],
+            update_interval=update_interval,
             warmup=warmup,
         )
 
-    def __init__(self, base_lr, num_decays, gamma, num_epochs, warmup=None):
-        super().__init__()
+    def __init__(
+        self, base_lr, num_decays, gamma, num_epochs, update_interval, warmup=None
+    ):
+        super().__init__(update_interval)
 
         self.base_lr = base_lr
         self.num_decays = num_decays

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -92,7 +92,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
 
         mock = Mock(side_effect=scheduler_mock)
         mock.update_interval = UpdateInterval.EPOCH
-        task.optimizer._lr_scheduler = mock
+        task.optimizer.lr_scheduler = mock
 
         trainer = LocalTrainer()
         trainer.train(task)
@@ -110,7 +110,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
 
         mock = Mock(side_effect=scheduler_mock)
         mock.update_interval = UpdateInterval.STEP
-        task.optimizer._lr_scheduler = mock
+        task.optimizer.lr_scheduler = mock
 
         trainer = LocalTrainer()
         trainer.train(task)


### PR DESCRIPTION
Summary:
1. I have a use case where I want to be able to set the value of the update_interval type. Currently, it's hardcoded as EPOCH. The diff allows taking it from config and default is set to epoch
2. Make the lr_scheduler public (discussed with Vinicius)
3. In case of update_interval type = STEP, `task.where` should allow 1.0 value as after the final step, we go to update and where is `1.0`

Differential Revision: D18177796

