### PR TITLE
extend resnext3d to support r2d model training and weight inflation. Extend oss trainer to support finetuning

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -21,7 +21,7 @@ from classy_vision.hooks import (
     TimeMetricsHook,
     VisdomHook,
 )
-from classy_vision.tasks import build_task
+from classy_vision.tasks import FineTuningTask, build_task
 from classy_vision.trainer import DistributedTrainer
 from torchvision import set_video_backend
 
@@ -38,8 +38,16 @@ def main(args):
 
     # Load checkpoint, if available
     checkpoint = load_checkpoint(args.checkpoint_folder, args.device)
-
     task.set_checkpoint(checkpoint)
+
+    pretrained_checkpoint = load_checkpoint(
+        args.pretrained_checkpoint_folder, args.device
+    )
+    if pretrained_checkpoint is not None:
+        assert isinstance(
+            task, FineTuningTask
+        ), "Can only use a pretrained checkpoint for fine tuning tasks"
+        task.set_pretrained_checkpoint(pretrained_checkpoint)
 
     hooks = [
         LossLrMeterLoggingHook(args.log_freq),

--- a/classy_vision/generic/opts.py
+++ b/classy_vision/generic/opts.py
@@ -41,6 +41,16 @@ def add_generic_args(parser):
                         latest epoch checkpoint is at checkpoint.torch""",
     )
     parser.add_argument(
+        "--pretrained_checkpoint_folder",
+        default="",
+        type=str,
+        help="""folder to use for pre-trained checkpoints:
+                        epochal checkpoints are stored as model_<epoch>.torch,
+                        latest epoch checkpoint is at checkpoint.torch,
+                        checkpoint is used for fine-tuning task, and it will
+                        not resume training from the checkpoint""",
+    )
+    parser.add_argument(
         "--checkpoint_period",
         default=1,
         type=int,
@@ -105,7 +115,7 @@ def add_generic_args(parser):
         help="Logging frequency for LossLrMeterLoggingHook (default 5)",
     )
     parser.add_argument(
-        "--video-backend",
+        "--video_backend",
         default="pyav",
         type=str,
         help="torchvision video decoder backend (pyav or video_reader). Default pyav",

--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -56,9 +56,12 @@ class ClassyModel(nn.Module):
             model_state_dict = copy.deepcopy(model_state_dict)
         return model_state_dict
 
-    def set_classy_state(self, state):
+    def load_head_states(self, state):
         for block, head_states in state["model"]["heads"].items():
             self._attachable_blocks[block].load_head_states(head_states)
+
+    def set_classy_state(self, state):
+        self.load_head_states(state)
 
         current_state = self.state_dict()
         current_state.update(state["model"]["trunk"])

--- a/configs/glore_i3d50_kinetics400_classy_config.json
+++ b/configs/glore_i3d50_kinetics400_classy_config.json
@@ -1,5 +1,5 @@
 {
-  "name": "classy_vision",
+  "name": "classification_task",
   "num_epochs": 80,
   "loss": {
     "name": "CrossEntropyLoss"

--- a/configs/r3d34_hmdb51_classy_config.json
+++ b/configs/r3d34_hmdb51_classy_config.json
@@ -1,5 +1,5 @@
 {
-  "name": "classy_vision",
+  "name": "classification_task",
   "num_epochs": 300,
   "loss": {
     "name": "CrossEntropyLoss"

--- a/configs/r3d34_synthetic_video_classy_config.json
+++ b/configs/r3d34_synthetic_video_classy_config.json
@@ -1,5 +1,5 @@
 {
-    "name": "classy_vision",
+    "name": "classification_task",
     "num_epochs": 2,
     "loss": {
         "name": "CrossEntropyLoss"

--- a/configs/r3d34_ucf101_classy_config.json
+++ b/configs/r3d34_ucf101_classy_config.json
@@ -1,5 +1,5 @@
 {
-    "name": "classy_vision",
+    "name": "classification_task",
     "num_epochs": 300,
     "loss": {
         "name": "CrossEntropyLoss"
@@ -125,7 +125,7 @@
         "num_classes": 101,
         "heads": [
             {
-                "name": "resnext3d_basic_head",
+                "name": "fully_convolutional_linear",
                 "unique_id": "default_head",
                 "pool_size": [
                     4,

--- a/configs/sf_i3d50_kinetics400_classy_config.json
+++ b/configs/sf_i3d50_kinetics400_classy_config.json
@@ -1,5 +1,5 @@
 {
-  "name": "classy_vision",
+  "name": "classification_task",
   "num_epochs": 80,
   "loss": {
     "name": "CrossEntropyLoss"
@@ -130,7 +130,7 @@
         "pool_size": [
           8,
           7,
-              7
+          7
         ],
         "activation_func": "softmax",
         "num_classes": 400,

--- a/test/models_resnext3d_test.py
+++ b/test/models_resnext3d_test.py
@@ -6,6 +6,7 @@
 
 import copy
 import unittest
+from test.generic.utils import compare_model_state
 
 import torch
 from classy_vision.models import ClassyModel, build_model
@@ -108,3 +109,128 @@ class TestResNeXt3D(unittest.TestCase):
                 out = model(split_config["input"])
 
                 self.assertEqual(out.size(), (self.batchsize, num_classes))
+
+    def test_set_classy_state_plain(self):
+        # We use the same model architecture to save and load a model state.
+        # This is a plain use case of `set_classy_state` method
+        for model_config in self.model_configs:
+            model = build_model(model_config)
+            model_state = model.get_classy_state()
+
+            model2 = build_model(model_config)
+            model2.set_classy_state(model_state)
+            model2_state = model2.get_classy_state()
+            compare_model_state(self, model_state, model2_state)
+
+    def _get_model_config_weight_inflation(self):
+        model_2d_config = {
+            "name": "resnext3d",
+            "frames_per_clip": 1,
+            "input_planes": 3,
+            "clip_crop_size": 224,
+            "skip_transformation_type": "postactivated_shortcut",
+            "residual_transformation_type": "postactivated_bottleneck_transformation",
+            "num_blocks": [3, 4, 6, 3],
+            "stem_name": "resnext3d_stem",
+            "stem_planes": 64,
+            "stem_temporal_kernel": 1,
+            "stem_spatial_kernel": 7,
+            "stem_maxpool": True,
+            "stage_planes": 256,
+            "stage_temporal_kernel_basis": [[1], [1], [1], [1]],
+            "temporal_conv_1x1": [True, True, True, True],
+            "stage_temporal_stride": [1, 1, 1, 1],
+            "stage_spatial_stride": [1, 2, 2, 2],
+            "num_groups": 1,
+            "width_per_group": 64,
+            "num_classes": 1000,
+            "zero_init_residual_transform": True,
+            "heads": [
+                {
+                    "name": "fully_convolutional_linear",
+                    "unique_id": "default_head",
+                    "pool_size": [1, 7, 7],
+                    "activation_func": "softmax",
+                    "num_classes": 1000,
+                    "fork_block": "pathway1-stage5-block3",
+                    "in_plane": 2048,
+                    "use_dropout": False,
+                }
+            ],
+        }
+
+        model_3d_config = {
+            "name": "resnext3d",
+            "frames_per_clip": 8,
+            "input_planes": 3,
+            "clip_crop_size": 224,
+            "skip_transformation_type": "postactivated_shortcut",
+            "residual_transformation_type": "postactivated_bottleneck_transformation",
+            "num_blocks": [3, 4, 6, 3],
+            "input_key": "video",
+            "stem_name": "resnext3d_stem",
+            "stem_planes": 64,
+            "stem_temporal_kernel": 5,
+            "stem_spatial_kernel": 7,
+            "stem_maxpool": True,
+            "stage_planes": 256,
+            "stage_temporal_kernel_basis": [[3], [3, 1], [3, 1], [1, 3]],
+            "temporal_conv_1x1": [True, True, True, True],
+            "stage_temporal_stride": [1, 1, 1, 1],
+            "stage_spatial_stride": [1, 2, 2, 2],
+            "num_groups": 1,
+            "width_per_group": 64,
+            "num_classes": 1000,
+            "freeze_trunk": False,
+            "zero_init_residual_transform": True,
+            "heads": [
+                {
+                    "name": "fully_convolutional_linear",
+                    "unique_id": "default_head",
+                    "pool_size": [8, 7, 7],
+                    "activation_func": "softmax",
+                    "num_classes": 1000,
+                    "fork_block": "pathway1-stage5-block3",
+                    "in_plane": 2048,
+                    "use_dropout": True,
+                }
+            ],
+        }
+        return model_2d_config, model_3d_config
+
+    def test_set_classy_state_weight_inflation(self):
+        # Get model state from a 2D ResNet model, inflate the 2D conv weights,
+        # and use them to initialize 3D conv weights. This is an advanced use of
+        # `set_classy_state` method.
+        model_2d_config, model_3d_config = self._get_model_config_weight_inflation()
+        model_2d = build_model(model_2d_config)
+        model_2d_state = model_2d.get_classy_state()
+
+        model_3d = build_model(model_3d_config)
+        model_3d.set_classy_state(model_2d_state)
+        model_3d_state = model_3d.get_classy_state()
+
+        for name, weight_2d in model_2d_state["model"]["trunk"].items():
+            weight_3d = model_3d_state["model"]["trunk"][name]
+            if weight_2d.dim() == 5:
+                # inflation only applies to conv weights
+                self.assertEqual(weight_3d.dim(), 5)
+                if weight_2d.shape[2] == 1 and weight_3d.shape[2] > 1:
+                    weight_2d_inflated = (
+                        weight_2d.repeat(1, 1, weight_3d.shape[2], 1, 1)
+                        / weight_3d.shape[2]
+                    )
+                    self.assertTrue(torch.equal(weight_3d, weight_2d_inflated))
+
+    def test_set_classy_state_weight_inflation_inconsistent_kernel_size(self):
+        # Get model state from a 2D ResNet model, inflate the 2D conv weights,
+        # and use them to initialize 3D conv weights.
+        model_2d_config, model_3d_config = self._get_model_config_weight_inflation()
+        # Modify conv kernel size in the stem layer of 2D model to 5, which is
+        # inconsistent with the kernel size 7 used in 3D model.
+        model_2d_config["stem_spatial_kernel"] = 5
+        model_2d = build_model(model_2d_config)
+        model_2d_state = model_2d.get_classy_state()
+        model_3d = build_model(model_3d_config)
+        with self.assertRaises(AssertionError):
+            model_3d.set_classy_state(model_2d_state)


### PR DESCRIPTION
Summary:
- Inflating weights of 2D conv, where are pre-trained on ImageNet, along temporal dimension to initialize 3D conv is first used in Kinetics modeling paper (https://arxiv.org/abs/1705.07750). We implement such weight inflation in this diff.
- To get a perfect (actually identity) mapping from 2D conv weight tensor to 3D conv weight tensor, we extend `ResNeXt3D` model to support the 2D resnet model training on ImageNet.
- After weight inflation to initialize 3D conv, we fine-tune the video model. Naturally, it is viewed as a fine-tuning task as opposed to `classification_task`. We extend OSS trainer to support fine-tuning task. It is related to the initial `finetuning task` diff D18008366.
- Update configs to reflect recent code refactoring in D18103181 and D18056099

Reviewed By: vreis

Differential Revision: D18164596

