### PR TITLE
Do not mutate config in build_param_scheduler, update test config in tasks_classification_task_test

### DIFF
--- a/classy_vision/optim/param_scheduler/__init__.py
+++ b/classy_vision/optim/param_scheduler/__init__.py
@@ -21,9 +21,7 @@ PARAM_SCHEDULER_REGISTRY = {}
 
 
 def build_param_scheduler(config):
-    name = config["name"]
-    del config["name"]
-    return PARAM_SCHEDULER_REGISTRY[name].from_config(config)
+    return PARAM_SCHEDULER_REGISTRY[config["name"]].from_config(config)
 
 
 def register_param_scheduler(name):

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -57,7 +57,7 @@ class TestClassificationTask(unittest.TestCase):
         Tests the {set, get}_classy_state methods by running train_steps
         to make sure the train_steps run the same way.
         """
-        config = get_test_task_config()
+        config = get_fast_test_task_config()
         task = build_task(config).set_hooks([LossLrMeterLoggingHook()])
         task_2 = build_task(config).set_hooks([LossLrMeterLoggingHook()])
 


### PR DESCRIPTION
Summary: Fix an issue where we were mutating the config which caused `tasks_classification_task_test` to fail. Also updated the test in `tasks_classification_task_test` to use a faster test configuration so it takes seconds to run instead of minutes.

Differential Revision: D18208475

