### PR TITLE
Remove get_config from tasks

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-import os
 
 import torch
 from classy_vision.generic.opts import parse_train_arguments
@@ -32,7 +31,7 @@ def main(args):
     set_video_backend(args.video_backend)
 
     # Loads config, sets up task
-    config = load_json(args.config)
+    config = load_json(args.config_file)
 
     task = build_task(config)
 
@@ -64,9 +63,13 @@ def main(args):
         except ImportError:
             logging.warning("tensorboardX not installed, skipping tensorboard hooks")
     if args.checkpoint_folder != "":
+        args_dict = vars(args)
+        args_dict["config"] = config
         hooks.append(
             CheckpointHook(
-                args.checkpoint_folder, args, checkpoint_period=args.checkpoint_period
+                args.checkpoint_folder,
+                args_dict,
+                checkpoint_period=args.checkpoint_period,
             )
         )
     if args.profiler:

--- a/classy_vision/dataset/__init__.py
+++ b/classy_vision/dataset/__init__.py
@@ -18,9 +18,7 @@ DATASET_CLASS_NAMES = set()
 
 
 def build_dataset(config, *args, **kwargs):
-    instance = DATASET_REGISTRY[config["name"]].from_config(config, *args, **kwargs)
-    instance._config_DO_NOT_USE = config
-    return instance
+    return DATASET_REGISTRY[config["name"]].from_config(config, *args, **kwargs)
 
 
 def get_available_splits(dataset_name):

--- a/classy_vision/generic/opts.py
+++ b/classy_vision/generic/opts.py
@@ -7,7 +7,6 @@
 import argparse
 import os
 
-import classy_vision.generic.visualize as visualize
 import torch
 import torchvision
 from classy_vision.generic.util import is_pos_int
@@ -18,7 +17,7 @@ def add_generic_args(parser):
     Adds generic command-line arguments for convnet training / testing to parser.
     """
     parser.add_argument(
-        "--config", default="", type=str, help="path to config file for model"
+        "--config_file", default="", type=str, help="path to config file for model"
     )
     parser.add_argument(
         "--device",

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -429,27 +429,11 @@ def compute_pr_curves(class_hist, total_hist):
     return {"prec": final_prec, "recall": final_recall, "ap": final_ap}
 
 
-def input_args_to_dict(input_args):
-    """
-    Converts arguments parsed through argparse or named tuples to dicts
-    """
-    if isinstance(input_args, dict):
-        return input_args
-    elif isinstance(input_args, argparse.Namespace):
-        return vars(input_args)
-    elif hasattr(input_args, "_asdict"):
-        return input_args._asdict()
-
-    raise RuntimeError(f"Unexpected input_args of type: {type(input_args)}")
-
-
 def get_checkpoint_dict(task, input_args):
-    input_args = input_args_to_dict(input_args)
-    return {
-        "input_args": input_args,
-        "config": task.get_config(),
-        "classy_state_dict": task.get_classy_state(),
-    }
+    assert isinstance(
+        input_args, dict
+    ), f"Unexpected input_args of type: {type(input_args)}"
+    return {"input_args": input_args, "classy_state_dict": task.get_classy_state()}
 
 
 # function that tries to load a checkpoint:

--- a/classy_vision/hooks/visdom_hook.py
+++ b/classy_vision/hooks/visdom_hook.py
@@ -61,7 +61,6 @@ class VisdomHook(ClassyHook):
         """
         phase_type = task.phase_type
         metrics = self.metrics
-        config = task.get_config()
         batches = len(task.losses)
 
         if batches == 0:
@@ -99,8 +98,8 @@ class VisdomHook(ClassyHook):
         # update learning curve visualizations:
         phase_type = "train" if task.train else "test"
         title = "%s-%s-%d" % (
-            config["dataset"][phase_type]["name"],
-            config["model"]["name"],
+            phase_type,
+            task.base_model.__class__.__name__,
             task.base_model.model_depth,
         )
         title += self.title_suffix

--- a/classy_vision/losses/__init__.py
+++ b/classy_vision/losses/__init__.py
@@ -28,9 +28,7 @@ def build_loss(config):
     assert "name" in config, f"name not provided for loss: {config}"
     name = config["name"]
     if name in LOSS_REGISTRY:
-        instance = LOSS_REGISTRY[name].from_config(config)
-        instance._config_DO_NOT_USE = config
-        return instance
+        return LOSS_REGISTRY[name].from_config(config)
 
     # the name should be available in torch.nn.modules.loss
     assert hasattr(torch_losses, name), (
@@ -43,9 +41,7 @@ def build_loss(config):
         # if we are passing weights, we need to change the weights from a list
         # to a tensor
         args["weight"] = torch.tensor(args["weight"], dtype=torch.float)
-    instance = getattr(torch_losses, name)(**args)
-    instance._config_DO_NOT_USE = config
-    return instance
+    return getattr(torch_losses, name)(**args)
 
 
 def register_loss(name):

--- a/classy_vision/meters/__init__.py
+++ b/classy_vision/meters/__init__.py
@@ -18,9 +18,7 @@ METER_REGISTRY = {}
 
 
 def build_meter(config):
-    instance = METER_REGISTRY[config["name"]].from_config(config)
-    instance._config_DO_NOT_USE = config
-    return instance
+    return METER_REGISTRY[config["name"]].from_config(config)
 
 
 def build_meters(config):

--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -75,7 +75,6 @@ def build_model(config):
             head = build_head(updated_config)
             heads[fork_block][head.unique_id] = head
         model.set_heads(heads)
-    model._config_DO_NOT_USE = config
     return model
 
 

--- a/classy_vision/optim/__init__.py
+++ b/classy_vision/optim/__init__.py
@@ -19,9 +19,7 @@ OPTIMIZER_CLASS_NAMES = set()
 
 
 def build_optimizer(config):
-    instance = OPTIMIZER_REGISTRY[config["name"]].from_config(config)
-    instance._config_DO_NOT_USE = config
-    return instance
+    return OPTIMIZER_REGISTRY[config["name"]].from_config(config)
 
 
 def register_optimizer(name):

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -153,20 +153,6 @@ class ClassificationTask(ClassyTask):
     def get_data_iterator(self):
         return self.data_iterator
 
-    def get_config(self):
-        return {
-            "loss": self.loss._config_DO_NOT_USE,
-            "dataset": {
-                split: dataset._config_DO_NOT_USE
-                for split, dataset in self.datasets.items()
-            },
-            "meters": [meter._config_DO_NOT_USE for meter in self.meters],
-            "model": self.base_model._config_DO_NOT_USE,
-            "num_epochs": self.num_epochs,
-            "optimizer": self.optimizer._config_DO_NOT_USE,
-            "test_only": self.test_only,
-        }
-
     def get_total_training_phases(self):
         """
         Returns the total number of "train" phases in the list of execution

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -330,27 +330,6 @@ class TestUtilMethods(unittest.TestCase):
         torch.manual_seed(1)
         self.assertTrue(torch.equal(torch.randn(10), random_tensor_2))
 
-    def test_input_args_to_dict(self):
-        args_dict = {"a": 1, "b": "1234", "c": [1, 2, 3]}
-
-        # test argparse.Namespace
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--a", type=int)
-        parser.add_argument("--b")
-        parser.add_argument("--c", nargs="*", type=int)
-        input_args = ["--a", "1", "--b", "1234", "--c", "1", "2", "3"]
-        input_args = parser.parse_args(input_args)
-        self.assertDictEqual(args_dict, util.input_args_to_dict(input_args))
-
-        # test typing.NamedTuple
-        class Args(typing.NamedTuple):
-            a: int
-            b: str
-            c: typing.List[int]
-
-        input_args = Args(**args_dict)
-        self.assertDictEqual(args_dict, util.input_args_to_dict(input_args))
-
 
 class TestUpdateStateFunctions(unittest.TestCase):
     def _compare_states(self, state_1, state_2, check_heads=True):

--- a/test/hooks_checkpoint_hook_test.py
+++ b/test/hooks_checkpoint_hook_test.py
@@ -34,9 +34,12 @@ class TestCheckpointHook(unittest.TestCase):
         local_variables = {}
         checkpoint_folder = self.base_dir + "/checkpoint_end_test/"
         device = "cpu"
+        input_args = {"foo": "bar"}
 
         # create a checkpoint hook
-        checkpoint_hook = CheckpointHook(checkpoint_folder, {}, phase_types=["train"])
+        checkpoint_hook = CheckpointHook(
+            checkpoint_folder, input_args, phase_types=["train"]
+        )
 
         # checkpoint directory doesn't exist
         # call the on start function
@@ -66,12 +69,11 @@ class TestCheckpointHook(unittest.TestCase):
         # model should be checkpointed. load and compare
         checkpoint = load_checkpoint(checkpoint_folder, device)
         self.assertIsNotNone(checkpoint)
-        for key in ["input_args", "config", "classy_state_dict"]:
+        for key in ["input_args", "classy_state_dict"]:
             self.assertIn(key, checkpoint)
         # not testing for equality of classy_state_dict, that is tested in
         # a separate test
-        self.assertDictEqual(checkpoint["input_args"], {})
-        self.assertDictEqual(checkpoint["config"], task.get_config())
+        self.assertDictEqual(checkpoint["input_args"], input_args)
 
     def test_checkpoint_period(self) -> None:
         """


### PR DESCRIPTION
Summary:
Removed `task.get_config()` from all the tasks. Since we had added the `config_DO_NOT_USE` attributes just for this function, removed them from all the builders.
To still pass the config, we now use the `input_args` in the checkpoint.

Updated the oss parser arg `config` to `config_file` and set the `config` as a separate arg.

Differential Revision: D18211199

