### PR TITLE
Make base_width_and_cardinality optional for ResNext

### DIFF
--- a/classy_vision/models/resnet.py
+++ b/classy_vision/models/resnet.py
@@ -25,6 +25,6 @@ class ResNet(ResNeXt):
 
     def __init__(self, **kwargs):
         assert (
-            kwargs["base_width_and_cardinality"] is None
+            kwargs.get("base_width_and_cardinality") is None
         ), "base_width_and_cardinality should be None for ResNet"
         super().__init__(**kwargs)


### PR DESCRIPTION
Summary: This is helpful when we try to create a ResNet model from the constructor directly (useful for the examples).

Differential Revision: D18231028

