### PR TITLE
LR schedulers to use Composite Scheduler for Warmup

### DIFF
--- a/classy_vision/optim/param_scheduler/composite_scheduler.py
+++ b/classy_vision/optim/param_scheduler/composite_scheduler.py
@@ -30,7 +30,7 @@ class CompositeParamScheduler(ClassyParamScheduler):
     would if it were the only scheduler. Default is 'fixed' for all schedulers.
 
     Example:
-      interval = "step"
+      update_interval = "step"
       schedulers = [
         {"name": "constant", "value": 0.42},
         {"name": "cosine_decay", "start_lr": 0.42, "end_lr": 0.0001}
@@ -98,6 +98,11 @@ class CompositeParamScheduler(ClassyParamScheduler):
             interval_scaling = [cls.IntervalScaling.RESCALED] * len(
                 config["schedulers"]
             )
+        if "num_epochs" in config:  # Propogate value to intermediate schedulers
+            config["schedulers"] = [
+                dict(schedule, **{"num_epochs": config["num_epochs"]})
+                for schedule in config["schedulers"]
+            ]
         return cls(
             schedulers=[
                 build_param_scheduler(scheduler) for scheduler in config["schedulers"]

--- a/classy_vision/optim/param_scheduler/cosine_scheduler.py
+++ b/classy_vision/optim/param_scheduler/cosine_scheduler.py
@@ -24,24 +24,10 @@ class CosineParamScheduler(ClassyParamScheduler):
       end_lr: 0.0001
     """
 
-    class Warmup(NamedTuple):
-        length: float  # normalizaed length in [0, 1)
-        init_lr: float
-
-    def __init__(self, start_lr: float, end_lr: float, warmup: Optional[Warmup] = None):
+    def __init__(self, start_lr: float, end_lr: float):
         super().__init__()
         self._start_lr = start_lr
         self._end_lr = end_lr
-        self._warmup = warmup
-        if self._warmup:
-            assert (
-                warmup.length >= 0 and warmup.length < 1
-            ), "warmup length can be in [0, 1)"
-            if warmup.length <= self.WHERE_EPSILON:
-                logging.warning(
-                    "warmup length is too small and might cause numerical instability"
-                )
-            self._warmup_init_lr = warmup.init_lr
 
     @classmethod
     def from_config(cls, config):
@@ -49,26 +35,9 @@ class CosineParamScheduler(ClassyParamScheduler):
             "start_lr" in config and "end_lr" in config
         ), "Cosine scheduler requires a start_lr and a end_lr"
 
-        warmup = None
-        if "warmup" in config:
-            assert isinstance(config["warmup"], dict), "Warmup must be a dict"
-            for name in ["init_lr", "length"]:
-                assert name in config["warmup"], "warmup requires parameter: %s" % name
-            warmup = cls.Warmup(**config["warmup"])
-
-        return cls(start_lr=config["start_lr"], end_lr=config["end_lr"], warmup=warmup)
+        return cls(start_lr=config["start_lr"], end_lr=config["end_lr"])
 
     def __call__(self, where: float):
-        warmup_length = self._warmup.length if self._warmup is not None else 0
-        if (
-            self._warmup is not None
-            and where < self._warmup.length + self.WHERE_EPSILON
-        ):
-            # interpolate between init_lr and start_lr value
-            warmup_progress = where / self._warmup.length
-            lr = self._start_lr * warmup_progress
-            lr += self._warmup_init_lr * (1 - warmup_progress)
-            return lr
         return self._end_lr + 0.5 * (self._start_lr - self._end_lr) * (
-            1 + math.cos(math.pi * (where - warmup_length) / (1 - warmup_length))
+            1 + math.cos(math.pi * where)
         )

--- a/classy_vision/optim/param_scheduler/step_scheduler.py
+++ b/classy_vision/optim/param_scheduler/step_scheduler.py
@@ -24,23 +24,10 @@ class StepParamScheduler(ClassyParamScheduler):
     epochs 30-59, 0.001 for epoch 60-89, 0.0001 for epochs 90-119.
     """
 
-    class Warmup(NamedTuple):
-        epochs: Union[int, float]
-        init_lr: float
-
-    def __init__(
-        self,
-        num_epochs: Union[int, float],
-        values: List[float],
-        warmup: Optional[Warmup] = None,
-    ):
+    def __init__(self, num_epochs: Union[int, float], values: List[float]):
         super().__init__()
 
         self._param_schedule = values
-        self._warmup = warmup
-        if warmup is not None:
-            self._warmup_init_lr = warmup.init_lr
-            self._warmup_len = warmup.epochs / num_epochs
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]):
@@ -51,24 +38,8 @@ class StepParamScheduler(ClassyParamScheduler):
         ), "Step scheduler requires a list of at least one param value"
         assert config["num_epochs"] > 0, "Num epochs must be greater than 0"
 
-        warmup = None
-        if "warmup" in config:
-            assert isinstance(config["warmup"], dict), "Warmup must be a dict"
-            for name in ["init_lr", "epochs"]:
-                assert name in config["warmup"], "warmup requires parameter: %s" % name
-            warmup = cls.Warmup(**config["warmup"])
-
-        return cls(
-            num_epochs=config["num_epochs"], values=config["values"], warmup=warmup
-        )
+        return cls(num_epochs=config["num_epochs"], values=config["values"])
 
     def __call__(self, where: float):
-        if self._warmup and where < self._warmup_len + self.WHERE_EPSILON:
-            # interpolate between init_lr and first lr value
-            warmup_progress = where / self._warmup_len
-            lr = self._param_schedule[0] * warmup_progress
-            lr += self._warmup_init_lr * (1 - warmup_progress)
-            return lr
-
         ind = int((where + self.WHERE_EPSILON) * len(self._param_schedule))
         return self._param_schedule[ind]

--- a/classy_vision/optim/param_scheduler/step_with_fixed_gamma_scheduler.py
+++ b/classy_vision/optim/param_scheduler/step_with_fixed_gamma_scheduler.py
@@ -15,8 +15,6 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
     """
     Decays the param value by gamma at equal number of steps so as to have the
     specified total number of decays.
-    Can also specify an optional warm up period where the lr is gradually
-    ramped up to the initial lr.
 
     Example:
       base_lr: 0.1
@@ -41,22 +39,14 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
                 isinstance(config[key], int) and config[key] > 0
             ), f"{key} must be a positive integer"
 
-        warmup = None
-        if "warmup" in config:
-            assert (
-                "epochs" in config["warmup"] and "init_lr" in config["warmup"]
-            ), "warmup config requires two keys: 'epoch' and 'init_lr'"
-            warmup = StepParamScheduler.Warmup(**config["warmup"])
-
         return cls(
             base_lr=config["base_lr"],
             num_decays=config["num_decays"],
             gamma=config["gamma"],
             num_epochs=config["num_epochs"],
-            warmup=warmup,
         )
 
-    def __init__(self, base_lr, num_decays, gamma, num_epochs, warmup=None):
+    def __init__(self, base_lr, num_decays, gamma, num_epochs):
         super().__init__()
 
         self.base_lr = base_lr
@@ -68,7 +58,7 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
             values.append(values[-1] * gamma)
 
         self._step_param_scheduler = StepParamScheduler(
-            num_epochs=num_epochs, values=values, warmup=warmup
+            num_epochs=num_epochs, values=values
         )
 
         # make this a STEP scheduler

--- a/configs/r3d34_hmdb51_classy_config.json
+++ b/configs/r3d34_hmdb51_classy_config.json
@@ -144,13 +144,22 @@
   "optimizer": {
     "name": "sgd",
     "lr": {
-      "name": "cosine",
-      "start_lr": 0.04,
-      "end_lr": 0.00004,
-      "warmup": {
-        "init_lr": 0.005,
-        "length": 0.13
-      }
+      "name": "composite",
+      "schedulers": [
+        {
+          "name": "linear",
+          "start_lr": 0.005,
+          "end_lr": 0.04
+        },
+        {
+          "name": "cosine",
+          "start_lr": 0.04,
+          "end_lr": 0.00004
+        }
+      ],
+      "update_interval": "epoch",
+      "interval_scaling": ["rescaled", "rescaled"],
+      "lengths": [0.13, 0.87]
     },
     "weight_decay": 0.005,
     "momentum": 0.9,

--- a/configs/r3d34_ucf101_classy_config.json
+++ b/configs/r3d34_ucf101_classy_config.json
@@ -142,13 +142,22 @@
     "optimizer": {
         "name": "sgd",
         "lr": {
-            "name": "cosine",
-            "start_lr": 0.04,
-            "end_lr": 0.00004,
-            "warmup": {
-                "init_lr": 0.005,
-                "length": 0.13
+            "name": "composite",
+            "schedulers": [
+              {
+                "name": "linear",
+                "start_lr": 0.005,
+                "end_lr": 0.04
+              },
+              {
+                "name": "cosine",
+                "start_lr": 0.04,
+                "end_lr": 0.00004
             }
+          ],
+          "lengths": [0.13, 0.87],
+          "update_interval": "epoch",
+          "interval_scaling": ["rescaled", "rescaled"]
         },
         "weight_decay": 0.005,
         "momentum": 0.9,

--- a/test/generic/optim_test_util.py
+++ b/test/generic/optim_test_util.py
@@ -207,9 +207,14 @@ class TestOptimizer(ABC):
         init_lr = 0.01
         warmup_epochs = 0.1
         config["lr"] = {
-            "name": "step",
-            "values": [0.1, 0.01, 0.001],
-            "warmup": {"init_lr": init_lr, "epochs": warmup_epochs},
+            "name": "composite",
+            "schedulers": [
+                {"name": "linear", "start_lr": init_lr, "end_lr": 0.1},
+                {"name": "step", "values": [0.1, 0.01, 0.001]},
+            ],
+            "update_interval": "epoch",
+            "interval_scaling": ["rescaled", "fixed"],
+            "lengths": [warmup_epochs / num_epochs, 1 - warmup_epochs / num_epochs],
         }
 
         opt = build_optimizer(config)

--- a/test/optim_param_scheduler_cosine_test.py
+++ b/test/optim_param_scheduler_cosine_test.py
@@ -20,14 +20,6 @@ class TestCosineScheduler(unittest.TestCase):
     def _get_valid_decay_config_intermediate_values(self):
         return [0.0976, 0.0905, 0.0794, 0.0655, 0.05, 0.0345, 0.0206, 0.0095, 0.0024]
 
-    def _get_valid_config_with_warmup(self):
-        return {
-            "name": "cosine",
-            "start_lr": 0.1,
-            "end_lr": 0.01,
-            "warmup": {"init_lr": 0.01, "length": 0.2},
-        }
-
     def test_invalid_config(self):
         # Invalid num epochs
         config = self._get_valid_decay_config()
@@ -101,30 +93,3 @@ class TestCosineScheduler(unittest.TestCase):
         config = self._get_valid_decay_config()
         scheduler = build_param_scheduler(config)
         self.assertTrue(isinstance(scheduler, CosineParamScheduler))
-
-    def test_build_cosine_scheduler_with_warmup(self):
-        config = self._get_valid_config_with_warmup()
-        scheduler = build_param_scheduler(config)
-        self.assertTrue(isinstance(scheduler, CosineParamScheduler))
-
-    def test_scheduler_with_warmup(self):
-        config = self._get_valid_config_with_warmup()
-
-        scheduler = CosineParamScheduler.from_config(config)
-        schedule = [
-            round(scheduler(epoch_num / self._num_epochs), 4)
-            for epoch_num in range(self._num_epochs)
-        ]
-        expected_schedule = [
-            0.01,
-            0.055,
-            0.1,
-            0.0966,
-            0.0868,
-            0.0722,
-            0.055,
-            0.0378,
-            0.0232,
-            0.0134,
-        ]
-        self.assertEqual(schedule, expected_schedule)

--- a/test/optim_param_scheduler_multi_step_test.py
+++ b/test/optim_param_scheduler_multi_step_test.py
@@ -120,26 +120,6 @@ class TestMultiStepParamScheduler(unittest.TestCase):
         ]
         self._test_config_scheduler(default_config, expected_schedule)
 
-    def test_warmup(self):
-        config = self._get_valid_config()
-        warmup_config = copy.deepcopy(config)
-        warmup_config["warmup"] = {"init_lr": 0.01, "epochs": 3}
-        expected_schedule = [
-            0.01,
-            0.04,
-            0.07,
-            0.1,
-            0.01,
-            0.01,
-            0.001,
-            0.001,
-            0.0001,
-            0.0001,
-            0.0001,
-            0.0001,
-        ]
-        self._test_config_scheduler(warmup_config, expected_schedule)
-
     def test_build_non_equi_step_scheduler(self):
         config = self._get_valid_config()
         scheduler = build_param_scheduler(config)

--- a/test/optim_param_scheduler_step_with_fixed_gamma_test.py
+++ b/test/optim_param_scheduler_step_with_fixed_gamma_test.py
@@ -20,7 +20,6 @@ class TestStepWithFixedGammaScheduler(unittest.TestCase):
         return {
             "name": "step_with_fixed_gamma",
             "base_lr": 1,
-            "warmup": {"init_lr": 0.001, "epochs": 2},
             "gamma": 0.1,
             "num_decays": 3,
             "num_epochs": self._num_epochs,
@@ -28,17 +27,6 @@ class TestStepWithFixedGammaScheduler(unittest.TestCase):
 
     def test_invalid_config(self):
         config = self._get_valid_config()
-
-        # No warmup - shouldn't raise an exception
-        no_warmup_config = copy.deepcopy(config)
-        del no_warmup_config["warmup"]
-        StepWithFixedGammaParamScheduler.from_config(no_warmup_config)
-
-        # Invalid warmup config
-        bad_config = copy.deepcopy(config)
-        bad_config["warmup"] = {"init_lr": 1}
-        with self.assertRaises(AssertionError):
-            StepWithFixedGammaParamScheduler.from_config(bad_config)
 
         # Invalid num epochs
         bad_config = copy.deepcopy(config)
@@ -72,8 +60,8 @@ class TestStepWithFixedGammaScheduler(unittest.TestCase):
             for epoch_num in range(self._num_epochs)
         ]
         expected_schedule = [
-            0.001,
-            0.5005,
+            1,
+            1,
             1,
             0.1,
             0.1,


### PR DESCRIPTION
Summary:
- Removes warmup from all parameter schedulers
- Updates config files that use warmup to use composite scheduler with linear warmup
- Composite scheduler propagates `num_epochs` parameter to intermediate schedulers, (for configs that don't explicitly specify `num_epochs` in the parameter scheduler)
- Updates tests

Reviewed By: vreis

Differential Revision: D18267195

