### PR TITLE
Code refactoring

### DIFF
--- a/classy_vision/dataset/classy_synthetic_video.py
+++ b/classy_vision/dataset/classy_synthetic_video.py
@@ -62,15 +62,6 @@ class SyntheticVideoClassificationDataset(ClassyVideoDataset):
             clips_per_video,
         )
 
-    def _get_sampler(self, epoch):
-        world_size = get_world_size()
-        rank = get_rank()
-        sampler = DistributedSampler(
-            self, num_replicas=world_size, rank=rank, shuffle=self.shuffle
-        )
-        sampler.set_epoch(epoch)
-        return sampler
-
     @classmethod
     def from_config(cls, config):
         split = config["split"]
@@ -104,3 +95,16 @@ class SyntheticVideoClassificationDataset(ClassyVideoDataset):
             audio_samples,
             clips_per_video,
         )
+
+    @property
+    def video_clips(self):
+        raise NotImplementedError()
+
+    def _get_sampler(self, epoch):
+        world_size = get_world_size()
+        rank = get_rank()
+        sampler = DistributedSampler(
+            self, num_replicas=world_size, rank=rank, shuffle=self.shuffle
+        )
+        sampler.set_epoch(epoch)
+        return sampler

--- a/classy_vision/dataset/classy_video_dataset.py
+++ b/classy_vision/dataset/classy_video_dataset.py
@@ -116,20 +116,20 @@ class ClassyVideoDataset(ClassyDataset):
         except ValueError:
             logging.warn(f"Fail to save metadata to file: {filepath}")
 
+    @property
+    def video_clips(self):
+        return self.dataset.video_clips
+
     def _get_sampler(self, epoch):
         if self.split == "train":
             # For video model training, we don't necessarily want to use all possible
             # clips in the video in one training epoch. More often, we randomly
             # sample at most N clips per training video. In practice, N is often 1
-            clip_sampler = RandomClipSampler(
-                self.dataset.video_clips, self.clips_per_video
-            )
+            clip_sampler = RandomClipSampler(self.video_clips, self.clips_per_video)
         else:
             # For video model testing, we sample N evenly spaced clips per test
             # video. We will simply average predictions over them
-            clip_sampler = UniformClipSampler(
-                self.dataset.video_clips, self.clips_per_video
-            )
+            clip_sampler = UniformClipSampler(self.video_clips, self.clips_per_video)
         world_size = get_world_size()
         rank = get_rank()
         sampler = DistributedSampler(
@@ -138,7 +138,6 @@ class ClassyVideoDataset(ClassyDataset):
             rank=rank,
             shuffle=self.shuffle,
             group_size=self.clips_per_video,
-            num_samples=self.num_samples,
         )
         sampler.set_epoch(epoch)
         return sampler

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -117,7 +117,7 @@ class ResNeXt3D(ClassyModel):
         stages = []
         for s in range(num_stages):
             stage = ResStage(
-                s + 2,  # stem is viewed as stage 1, and following stages start from 2
+                s + 1,  # stem is viewed as stage 0, and following stages start from 1
                 [in_planes[s]],
                 [out_planes[s]],
                 [inner_planes[s]],
@@ -130,8 +130,8 @@ class ResNeXt3D(ClassyModel):
                 skip_transformation_type,
                 residual_transformation_type,
                 block_callback=self.build_attachable_block,
-                disable_pre_activation=True if s == 0 else False,
-                final_stage=True if s == (num_stages - 1) else False,
+                disable_pre_activation=(s == 0),
+                final_stage=(s == (num_stages - 1)),
             )
             stages.append(stage)
 

--- a/configs/glore_i3d50_kinetics400_classy_config.json
+++ b/configs/glore_i3d50_kinetics400_classy_config.json
@@ -134,7 +134,7 @@
         ],
         "activation_func": "softmax",
         "num_classes": 400,
-        "fork_block": "pathway1-stage5-block3-relu",
+        "fork_block": "pathway0-stage4-block2-relu",
         "in_plane": 2048,
         "use_dropout": true
       }

--- a/configs/r3d34_hmdb51_classy_config.json
+++ b/configs/r3d34_hmdb51_classy_config.json
@@ -136,7 +136,7 @@
         ],
         "activation_func": "softmax",
         "num_classes": 51,
-        "fork_block": "pathway1-stage5-block3",
+        "fork_block": "pathway0-stage4-block2",
         "in_plane": 512
       }
     ]

--- a/configs/r3d34_synthetic_video_classy_config.json
+++ b/configs/r3d34_synthetic_video_classy_config.json
@@ -63,7 +63,7 @@
             "pool_size": [4, 7, 7],
             "activation_func": "softmax",
             "num_classes": 50,
-            "fork_block": "pathway1-stage5-block2",
+            "fork_block": "pathway0-stage4-block1",
             "in_plane": 512
           }
         ]

--- a/configs/r3d34_ucf101_classy_config.json
+++ b/configs/r3d34_ucf101_classy_config.json
@@ -134,7 +134,7 @@
                 ],
                 "activation_func": "softmax",
                 "num_classes": 101,
-                "fork_block": "pathway1-stage5-block3",
+                "fork_block": "pathway0-stage4-block2",
                 "in_plane": 512
             }
         ]

--- a/configs/sf_i3d50_kinetics400_classy_config.json
+++ b/configs/sf_i3d50_kinetics400_classy_config.json
@@ -134,7 +134,7 @@
         ],
         "activation_func": "softmax",
         "num_classes": 400,
-        "fork_block": "pathway1-stage5-block3",
+        "fork_block": "pathway0-stage4-block2",
         "in_plane": 2048,
         "use_dropout": true
       }

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -274,7 +274,7 @@ def get_test_video_task_config():
                     "pool_size": [8, 7, 7],
                     "activation_func": "softmax",
                     "num_classes": 50,
-                    "fork_block": "pathway1-stage5-block3",
+                    "fork_block": "pathway0-stage4-block2",
                     "in_plane": 512,
                     "use_dropout": True,
                 }

--- a/test/models_resnext3d_test.py
+++ b/test/models_resnext3d_test.py
@@ -58,8 +58,8 @@ class TestResNeXt3D(unittest.TestCase):
 
             block_idx = model_config["num_blocks"][-1]
             # attach the head at the last block
-            model_config["heads"][0]["fork_block"] = (
-                "pathway1-stage5-block%d" % block_idx
+            model_config["heads"][0]["fork_block"] = "pathway0-stage4-block%d" % (
+                block_idx - 1
             )
 
             self.model_configs.append(model_config)
@@ -152,7 +152,7 @@ class TestResNeXt3D(unittest.TestCase):
                     "pool_size": [1, 7, 7],
                     "activation_func": "softmax",
                     "num_classes": 1000,
-                    "fork_block": "pathway1-stage5-block3",
+                    "fork_block": "pathway0-stage4-block2",
                     "in_plane": 2048,
                     "use_dropout": False,
                 }
@@ -190,7 +190,7 @@ class TestResNeXt3D(unittest.TestCase):
                     "pool_size": [8, 7, 7],
                     "activation_func": "softmax",
                     "num_classes": 1000,
-                    "fork_block": "pathway1-stage5-block3",
+                    "fork_block": "pathway0-stage4-block2",
                     "in_plane": 2048,
                     "use_dropout": True,
                 }


### PR DESCRIPTION
Summary:
Make the following changes to refactor video-related code.
- Use `nn.Sequential` to represent the sequential transforms in each pathway of `ResStage`. This can greatly simplify the `forward` pass implementation.
- Change the all indices of pathway, stage, and block to start with 0, which is more consistent
- Add a property `video_clips` to `ClassyVideoDataset`.  This property should be implemented by all child classes.

Differential Revision: D18290108

