### PR TITLE
Clear head outputs when reset head

### DIFF
--- a/classy_vision/models/classy_block.py
+++ b/classy_vision/models/classy_block.py
@@ -48,12 +48,16 @@ class ClassyBlock(nn.Module):
         if not all(isinstance(x, ClassyHead) for x in heads):
             raise ValueError("Head must extend ClassyHead")
 
-        self._heads = nn.ModuleDict()
+        self._clear_heads()
         for head in heads:
             self._heads[head.unique_id] = head
 
     def get_heads(self):
         return dict(self._heads)
+
+    def _clear_heads(self):
+        self._heads = nn.ModuleDict()
+        self._head_outputs = {}
 
     def forward(self, input):
         output = self._module(input)

--- a/test/classy_block_test.py
+++ b/test/classy_block_test.py
@@ -56,3 +56,20 @@ class TestClassyBlock(unittest.TestCase):
 
         head2.unique_id = "head_id2"
         model.set_heads(heads)
+
+    def test_set_heads(self):
+        model = self.DummyTestModel()
+        head = self.DummyTestHead()
+        self.assertEqual(
+            len(model.get_heads()), 0, "heads should be empty before set_heads"
+        )
+        model.set_heads({"dummy_block2": {head.unique_id: head}})
+        self.assertEqual(len(model.head_outputs), 0, "head outputs should be empty")
+        input = torch.randn(1, 2)
+        model(input)
+        self.assertEqual(len(model.head_outputs), 1, "should have output for one head")
+
+        # remove all heads
+        model.set_heads({})
+        self.assertEqual(len(model.get_heads()), 0, "heads should be empty")
+        self.assertEqual(len(model.head_outputs), 0, "head outputs should be empty")


### PR DESCRIPTION
Summary: We're using head outputs in ClassyBlock, we should clear the information when we reset the heads.

Differential Revision: D18283939

