### PR TITLE
Do not apply weight decay to SyncBatchNorm by default

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -179,7 +179,8 @@ class ClassyModel(nn.Module):
                     if params.requires_grad:
                         regularized_params.append(params)
             elif not bn_weight_decay and isinstance(
-                module, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d)
+                module,
+                (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm),
             ):
                 for params in module.parameters():
                     if params.requires_grad:


### PR DESCRIPTION
Summary: I realised dursing my sync batch norm training that I we apply weight decay to SyncBatchNorm, fixing that in this diff.

Reviewed By: vreis

Differential Revision: D18328475

