### PR TITLE
Fix DDP training with checkpoint_folder

### DIFF
--- a/classy_vision/generic/opts.py
+++ b/classy_vision/generic/opts.py
@@ -139,7 +139,7 @@ def check_generic_args(args):
 
     # create checkpoint folder if it does not exist:
     if args.checkpoint_folder != "" and not os.path.exists(args.checkpoint_folder):
-        os.makedirs(args.checkpoint_folder)
+        os.makedirs(args.checkpoint_folder, exist_ok=True)
         assert os.path.exists(args.checkpoint_folder), (
             "could not create folder %s" % args.checkpoint_folder
         )


### PR DESCRIPTION
When running classyvision in a distributed setup on OSS with `checkpoint_folder`, I've met the following problem:
```
 45 0: Traceback (most recent call last):
 46 0:     os.makedirs(args.checkpoint_folder)
 47 0:   File "/private/home/fmassa/.conda/envs/classyvision/lib/python3.7/os.py", line 221, in makedirs
 48 0:   File "classy_train.py", line 129, in <module>
 49 0:     os.makedirs(args.checkpoint_folder)
 50 0:   File "/private/home/fmassa/.conda/envs/classyvision/lib/python3.7/os.py", line 221, in makedirs
 51 0:     args = parse_train_arguments()
 52 0:   File "/private/home/fmassa/github/ClassyVision/classy_vision/generic/opts.py", line 198, in parse_train_arguments
 53 0:     os.makedirs(args.checkpoint_folder)
 54 0:   File "/private/home/fmassa/.conda/envs/classyvision/lib/python3.7/os.py", line 221, in makedirs
 55 0:     args = parse_train_arguments()
 56 0:   File "/private/home/fmassa/github/ClassyVision/classy_vision/generic/opts.py", line 198, in parse_train_arguments
 57 0:     args = check_generic_args(args)
 58 0:   File "/private/home/fmassa/github/ClassyVision/classy_vision/generic/opts.py", line 142, in check_generic_args
 59 0:     args = check_generic_args(args)
 60 0:   File "/private/home/fmassa/github/ClassyVision/classy_vision/generic/opts.py", line 142, in check_generic_args
 61 0:     os.makedirs(args.checkpoint_folder)
 62 0:   File "/private/home/fmassa/.conda/envs/classyvision/lib/python3.7/os.py", line 221, in makedirs
 63 0:     os.makedirs(args.checkpoint_folder)
 64 0:   File "/private/home/fmassa/.conda/envs/classyvision/lib/python3.7/os.py", line 221, in makedirs
 65 0:     mkdir(name, mode)
 66 0:     mkdir(name, mode)    FileExistsError
 67 0: mkdir(name, mode)
 68 0: mkdir(name, mode):
 69 0: [Errno 17] File exists: '/checkpoint/fmassa/jobs/classification_logs/classyvision_19798061'    FileExistsError
 70 0: mkdir(name, mode)FileExistsError    mkdir(name, mode)
```
This error is due to the fact that each individual python process is trying to create a folder at the same time.
By default, [`os.makedirs` raises a `FileExistError`](https://docs.python.org/3/library/os.html#os.makedirs) if the folder already exists, which is more likely to happen when the number of GPUs (== python processes) increases.

One option is to pass `exist_ok=True` to `os.makedirs`, which is Python 3-only (but that's fine given that ClassyVision is also Python 3-only).