### PR TITLE
fix resnext3d_block to enable model_complexity_hook to compute resnext3d model complexity

### DIFF
--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -50,7 +50,7 @@ class ModelComplexityHook(ClassyHook):
         except NotImplementedError:
             logging.warning(
                 """Model contains unsupported modules:
-            Could not compute FLOPs for model forward pass"""
+            Could not compute FLOPs for model forward pass. Exception:""", exc_info=True
             )
         logging.info(
             "Number of parameters in model: %d" % count_params(task.base_model)


### PR DESCRIPTION
Summary:
`PostactivatedShortcutTransformation` module does not contain any child module when it represents identity mapping. In such case, it is considered as leaf module by `ModelComplexityHook`. However, it is not handled by `_layer_flops()` in `profiler.py`.

This breaks  `ModelComplexityHook` to compute video model complexity. We fix it in the diff.

Differential Revision: D18368224

