### PR TITLE
Exponential Moving Average Model Hook

### DIFF
--- a/classy_vision/hooks/__init__.py
+++ b/classy_vision/hooks/__init__.py
@@ -10,6 +10,7 @@ from classy_vision.generic.registry_utils import import_all_modules
 
 from .checkpoint_hook import CheckpointHook
 from .classy_hook import ClassyHook, ClassyHookFunctions
+from .exponential_moving_average_model_hook import ExponentialMovingAverageModelHook
 from .loss_lr_meter_logging_hook import LossLrMeterLoggingHook
 from .model_complexity_hook import ModelComplexityHook
 from .model_tensorboard_hook import ModelTensorboardHook
@@ -24,6 +25,7 @@ __all__ = [
     "CheckpointHook",
     "ClassyHook",
     "ClassyHookFunctions",
+    "ExponentialMovingAverageModelHook",
     "LossLrMeterLoggingHook",
     "TensorboardPlotHook",
     "ModelComplexityHook",

--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+import logging
+from typing import Any, Dict, Iterable, Tuple
+
+import torch
+import torch.nn as nn
+from classy_vision.hooks import ClassyHook
+from classy_vision.tasks import ClassyTask
+
+
+class ExponentialMovingAverageModelHook(ClassyHook):
+    """
+    Hook which keeps a track of the exponential moving average (EMA) of the model's
+    parameters and applies the EMA params to the model during the test phases.
+
+    Saving the state in cpu will save gpu memory, but will make training slower since
+    the model parameters will need to be moved to cpu before the averaging.
+
+    Note: This hooks stores two additional copies of the model's parameters, which will
+        increase memory usage significantly.
+    """
+
+    on_rendezvous = ClassyHook._noop
+    on_sample = ClassyHook._noop
+    on_forward = ClassyHook._noop
+    on_loss = ClassyHook._noop
+    on_backward = ClassyHook._noop
+    on_end = ClassyHook._noop
+
+    def __init__(
+        self, decay: float, consider_bn_buffers: bool = True, device: str = "cpu"
+    ) -> None:
+        """
+        Args:
+            decay: EMA decay factor, should be in [0, 1]. A decay of 0 corresponds to
+                always using the latest value (no EMA) and a decay of 1 corresponds to
+                not updating weights after initialization.
+            consider_bn_buffers: Whether to apply EMA to batch norm buffers
+            device: Device to store the model state.
+        """
+        super().__init__()
+        assert 0 <= decay <= 1, "Decay should be between 0 and 1"
+        assert device in ["cpu", "gpu"], "Device should be one of cpu or gpu"
+        self.decay: int = decay
+        self.consider_bn_buffers = consider_bn_buffers
+        self.device = "cuda" if device == "gpu" else "cpu"
+        self.state.model_state = {}
+        self.state.ema_model_state = {}
+        logging.info(
+            f"{self.__class__.__name__} initialized with a decay of "
+            f"{decay} on device {device}"
+        )
+
+    def get_model_state_iterator(self, model: nn.Module) -> Iterable[Tuple[str, Any]]:
+        """Get an iterator over the model state to apply EMA to."""
+        iterable = model.named_parameters()
+        if self.consider_bn_buffers:
+            # also add batch norm buffers to the list of state params to iterate over
+            buffers_iterable = (
+                (f"{module_name}_buffer_{name}", buffer)
+                for module_name, module in model.named_modules()
+                for name, buffer in module.named_buffers()
+                if isinstance(
+                    module,
+                    (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm),
+                )
+            )
+            iterable = itertools.chain(iterable, buffers_iterable)
+        return iterable
+
+    def _save_current_model_state(self, model: nn.Module, model_state: Dict[str, Any]):
+        """Copy the model's state to the provided dict."""
+        for name, param in self.get_model_state_iterator(model):
+            model_state[name] = param.detach().clone().to(device=self.device)
+
+    def on_start(self, task: ClassyTask, local_variables: Dict[str, Any]) -> None:
+        if self.state.model_state:
+            # loaded state from checkpoint, do not re-initialize, only move the state
+            # to the right device
+            for name in self.state.model_state:
+                self.state.model_state[name] = self.state.model_state[name].to(
+                    device=self.device
+                )
+                self.state.ema_model_state[name] = self.state.ema_model_state[name].to(
+                    device=self.device
+                )
+            return
+        self._save_current_model_state(task.base_model, self.state.model_state)
+        self._save_current_model_state(task.base_model, self.state.ema_model_state)
+
+    def on_phase_start(self, task: ClassyTask, local_variables: Dict[str, Any]) -> None:
+        # restore the right state depending on the phase type
+        self.set_model_state(task, use_ema=not task.train)
+
+    def on_phase_end(self, task: ClassyTask, local_variables: Dict[str, Any]) -> None:
+        if task.train:
+            # save the current model state since this will be overwritten by the ema
+            # state in the test phase
+            self._save_current_model_state(task.base_model, self.state.model_state)
+
+    def on_update(self, task: ClassyTask, local_variables: Dict[str, Any]) -> None:
+        with torch.no_grad():
+            for name, param in self.get_model_state_iterator(task.base_model):
+                self.state.ema_model_state[
+                    name
+                ] = self.decay * self.state.ema_model_state[name] + (
+                    1 - self.decay
+                ) * param.to(
+                    device=self.device
+                )
+
+    def set_model_state(self, task: ClassyTask, use_ema: bool) -> None:
+        """
+        Depending on use_ema, set the appropriate state for the model.
+        """
+        model_state = self.state.ema_model_state if use_ema else self.state.model_state
+        with torch.no_grad():
+            for name, param in self.get_model_state_iterator(task.base_model):
+                param.copy_(model_state[name])

--- a/test/hooks_exponential_moving_average_model_hook_test.py
+++ b/test/hooks_exponential_moving_average_model_hook_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import unittest
+import unittest.mock as mock
+
+import torch
+import torch.nn as nn
+from classy_vision.hooks import ExponentialMovingAverageModelHook
+from classy_vision.models import ClassyModel
+
+
+class TestModel(ClassyModel):
+    def __init__(self):
+        super().__init__(None)
+        self.fc = nn.Linear(10, 10)
+        self.bn = nn.BatchNorm1d(10)
+
+    def init_fc_weight(self):
+        nn.init.zeros_(self.fc.weight)
+
+    def update_fc_weight(self):
+        nn.init.ones_(self.fc.weight)
+
+    def forward(self, x):
+        return self.bn(self.fc(x))
+
+
+class TestExponentialMovingAverageModelHook(unittest.TestCase):
+    def _map_device_string(self, device):
+        return "cuda" if device == "gpu" else "cpu"
+
+    def _test_exponential_moving_average_hook(self, model_device, hook_device):
+        task = mock.MagicMock()
+        model = TestModel().to(device=self._map_device_string(model_device))
+        local_variables = {}
+        task.base_model = model
+        task.train = True
+        decay = 0.5
+        num_updates = 10
+        model.init_fc_weight()
+        exponential_moving_average_hook = ExponentialMovingAverageModelHook(
+            decay=decay, device=hook_device
+        )
+
+        exponential_moving_average_hook.on_start(task, local_variables)
+        exponential_moving_average_hook.on_phase_start(task, local_variables)
+        # set the weights to all ones and simulate 10 updates
+        task.base_model.update_fc_weight()
+        fc_weight = model.fc.weight.clone()
+        for _ in range(num_updates):
+            exponential_moving_average_hook.on_update(task, local_variables)
+        exponential_moving_average_hook.on_phase_end(task, local_variables)
+        # the model weights shouldn't have changed
+        self.assertTrue(torch.allclose(model.fc.weight, fc_weight))
+
+        # simulate a test phase now
+        task.train = False
+        exponential_moving_average_hook.on_phase_start(task, local_variables)
+        exponential_moving_average_hook.on_phase_end(task, local_variables)
+
+        # the model weights should be updated to the ema weights
+        self.assertTrue(
+            torch.allclose(
+                model.fc.weight, fc_weight * (1 - math.pow(1 - decay, num_updates))
+            )
+        )
+
+        # simulate a train phase again
+        task.train = True
+        exponential_moving_average_hook.on_phase_start(task, local_variables)
+
+        # the model weights should be back to the old value
+        self.assertTrue(torch.allclose(model.fc.weight, fc_weight))
+
+    def test_get_model_state_iterator(self):
+        device = "gpu" if torch.cuda.is_available() else "cpu"
+        model = TestModel().to(device=self._map_device_string(device))
+        decay = 0.5
+        # test that we pick up the right parameters in the iterator
+        for consider_bn_buffers in [True, False]:
+            exponential_moving_average_hook = ExponentialMovingAverageModelHook(
+                decay=decay, consider_bn_buffers=consider_bn_buffers, device=device
+            )
+            iterable = exponential_moving_average_hook.get_model_state_iterator(model)
+            fc_found = False
+            bn_found = False
+            bn_buffer_found = False
+            for _, param in iterable:
+                if any(param is item for item in model.fc.parameters()):
+                    fc_found = True
+                if any(param is item for item in model.bn.parameters()):
+                    bn_found = True
+                if any(param is item for item in model.bn.buffers()):
+                    bn_buffer_found = True
+            self.assertTrue(fc_found)
+            self.assertTrue(bn_found)
+            self.assertEqual(bn_buffer_found, consider_bn_buffers)
+
+    def test_exponential_moving_average_hook(self):
+        device = "gpu" if torch.cuda.is_available() else "cpu"
+        self._test_exponential_moving_average_hook(device, device)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "This test needs a gpu to run")
+    def test_mixed_devices(self):
+        """Tests that the hook works when the model and hook's device are different"""
+        self._test_exponential_moving_average_hook("cpu", "gpu")
+        self._test_exponential_moving_average_hook("gpu", "cpu")


### PR DESCRIPTION
Summary:
Added a hook to compute the model ema. For test phases, it updates the model state to the ema state.
It can store its state on the cpu to save memory, or on gpu to save time.

Added a param in the flow trainers, ema_decay. If this is specified, the hook is plugged in. The hook uses the same device as used for training (to avoid adding another param). I'm not sure how we should be handling hook configurations.

Differential Revision: D18375365

