### PR TITLE
Make state functions for ClassyHook consistent

### DIFF
--- a/classy_vision/hooks/classy_hook.py
+++ b/classy_vision/hooks/classy_hook.py
@@ -35,10 +35,10 @@ class ClassyHookState:
     Any serializable data can be stored in the instance's attributes.
     """
 
-    def state_dict(self) -> Dict[str, Any]:
+    def get_classy_state(self) -> Dict[str, Any]:
         return self.__dict__
 
-    def load_state_dict(self, state_dict: Dict[str, Any]):
+    def set_classy_state(self, state_dict: Dict[str, Any]):
         self.__dict__ = state_dict
 
 
@@ -164,8 +164,8 @@ class ClassyHook(ABC):
         """
         pass
 
-    def state_dict(self) -> Dict[str, Any]:
-        return self.state.state_dict()
+    def get_classy_state(self) -> Dict[str, Any]:
+        return self.state.get_classy_state()
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        self.state.load_state_dict(state_dict)
+    def set_classy_state(self, state_dict: Dict[str, Any]) -> None:
+        self.state.set_classy_state(state_dict)

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -277,7 +277,7 @@ class ClassificationTask(ClassyTask):
             "num_updates": self.num_updates,
             "num_samples_this_phase": self.num_samples_this_phase,
             "losses": self.losses,
-            "hooks": {hook.name(): hook.state_dict() for hook in self.hooks},
+            "hooks": {hook.name(): hook.get_classy_state() for hook in self.hooks},
         }
         if deep_copy:
             classy_state_dict = copy.deepcopy(classy_state_dict)
@@ -298,7 +298,7 @@ class ClassificationTask(ClassyTask):
             # we still want to be able to run when new hooks are added or old
             # hooks are removed
             if hook.name() in state["hooks"]:
-                hook.load_state_dict(state["hooks"][hook.name()])
+                hook.set_classy_state(state["hooks"][hook.name()])
             else:
                 logging.warn(f"No state found for hook: {hook.name()}")
         # TODO (mannatsingh): Figure out how to set the state of the dataloaders

--- a/test/hooks_classy_hook_test.py
+++ b/test/hooks_classy_hook_test.py
@@ -32,9 +32,9 @@ class TestClassyHook(unittest.TestCase):
         a = 0
         b = {1: 2, 3: [4]}
         test_hook = TestHook(a, b)
-        state_dict = test_hook.state_dict()
+        state_dict = test_hook.get_classy_state()
         # create a new test_hook and set its state to the old hook's.
         test_hook = TestHook("", 0)
-        test_hook.load_state_dict(state_dict)
+        test_hook.set_classy_state(state_dict)
         self.assertEqual(test_hook.state.a, a)
         self.assertEqual(test_hook.state.b, b)


### PR DESCRIPTION
Summary: `ClassyHook`s are the only class which use a different name for the state get / set functions. Making the names consistent with everywhere else.

Differential Revision: D18398492

