### PR TITLE
Remove ClassyModel.validate

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -163,9 +163,6 @@ class ClassyModel(nn.Module):
             outputs.update(blk.head_outputs)
         return outputs
 
-    def validate(self, dataset_output_shape):
-        raise NotImplementedError
-
     def get_optimizer_params(self, bn_weight_decay=False):
         """
         Function to return dict of params with "keys" from

--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -250,6 +250,3 @@ class DenseNet(ClassyModel):
     @property
     def model_depth(self):
         return sum(self.num_blocks)
-
-    def validate(self, dataset_output_shape):
-        return self.input_shape == dataset_output_shape

--- a/classy_vision/models/mlp.py
+++ b/classy_vision/models/mlp.py
@@ -88,6 +88,3 @@ class MLP(ClassyModel):
     @property
     def model_depth(self):
         return self._model_depth
-
-    def validate(self, dataset_output_shape):
-        return self.input_shape == dataset_output_shape

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -397,6 +397,3 @@ class ResNeXt(ClassyModel):
     @property
     def model_depth(self):
         return sum(self.num_blocks)
-
-    def validate(self, dataset_output_shape):
-        return self.input_shape == dataset_output_shape

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -286,12 +286,6 @@ class ResNeXt3DBase(ClassyModel):
     def input_key(self):
         return self._input_key
 
-    def validate(self, dataset_output_shape):
-        # video model input shape can vary from video to video at testing time.
-        # Thus, comparing it with dataset_output_shape will have varying results
-        # We skip validation and simply return True
-        return True
-
 
 @register_model("resnext3d")
 class ResNeXt3D(ResNeXt3DBase):


### PR DESCRIPTION
Summary:
This method is not being called anywhere, and we're requiring people to
implement it when they inherit from ClassyModel. Kill it.

Differential Revision: D18427652

