### PR TITLE
Remove get_available_splits

### DIFF
--- a/classy_vision/dataset/__init__.py
+++ b/classy_vision/dataset/__init__.py
@@ -27,10 +27,6 @@ def build_dataset(config, *args, **kwargs):
     return DATASET_REGISTRY[config["name"]].from_config(config, *args, **kwargs)
 
 
-def get_available_splits(dataset_name):
-    return DATASET_REGISTRY[dataset_name].get_available_splits()
-
-
 def register_dataset(name):
     """Registers a ClassyDataset subclass.
 

--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -27,10 +27,6 @@ class ClassyDataset:
     ClassyDataset can be used to instantiate datasets from a configuration file as well.
     """
 
-    @classmethod
-    def get_available_splits(cls):
-        return ["train", "test"]
-
     def __init__(
         self,
         dataset: Sequence,

--- a/classy_vision/dataset/classy_synthetic_image.py
+++ b/classy_vision/dataset/classy_synthetic_image.py
@@ -25,10 +25,6 @@ class SyntheticImageDataset(ClassyDataset):
     from, compared to real world datasets.
     """
 
-    @classmethod
-    def get_available_splits(cls) -> List[str]:
-        return ["train", "val", "test"]
-
     def __init__(
         self,
         batchsize_per_replica: int,

--- a/classy_vision/dataset/classy_synthetic_video.py
+++ b/classy_vision/dataset/classy_synthetic_video.py
@@ -27,10 +27,6 @@ class SyntheticVideoDataset(ClassyVideoDataset):
         independent of the video clips.
     """
 
-    @classmethod
-    def get_available_splits(cls) -> List[str]:
-        return ["train", "val", "test"]
-
     def __init__(
         self,
         num_classes: int,

--- a/classy_vision/templates/synthetic/datasets/my_dataset.py
+++ b/classy_vision/templates/synthetic/datasets/my_dataset.py
@@ -11,9 +11,5 @@ from classy_vision.dataset.classy_synthetic_image import SyntheticImageDataset
 
 @register_dataset("my_dataset")
 class MyDataset(SyntheticImageDataset):
-    @classmethod
-    def get_available_splits(cls):
-        return ["train", "test"]
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -11,7 +11,7 @@ from test.generic.utils import compare_batches, compare_samples
 
 import classy_vision.dataset.classy_dataset as classy_dataset
 import torch
-from classy_vision.dataset import build_dataset, get_available_splits, register_dataset
+from classy_vision.dataset import build_dataset, register_dataset
 from classy_vision.dataset.core import ListDataset
 from torch.utils.data import DataLoader
 
@@ -82,10 +82,6 @@ class OtherTestDataset(classy_dataset.ClassyDataset):
     type than TestDataset
     """
 
-    @classmethod
-    def get_available_splits(cls):
-        return ["split0", "split1"]
-
     def __init__(self, samples, batchsize_per_replica=1):
         input_tensors = [sample["input"] for sample in samples]
         target_tensors = [sample["target"] for sample in samples]
@@ -112,16 +108,6 @@ class TestRegistryFunctions(unittest.TestCase):
     def test_build_model(self):
         dataset = build_dataset(DUMMY_CONFIG, DUMMY_SAMPLES_1)
         self.assertTrue(isinstance(dataset, TestDataset))
-
-    def test_get_available_splits(self):
-        # Test default classy splits
-        splits = get_available_splits("test_dataset")
-        self.assertEqual(splits, ["train", "test"])
-
-    def test_get_available_splits_non_default(self):
-        # Test default classy splits
-        splits = get_available_splits("other_test_dataset")
-        self.assertEqual(splits, ["split0", "split1"])
 
 
 class TestClassyDataset(unittest.TestCase):


### PR DESCRIPTION
Summary: Remove get_available_splits. It's only used in one disabled test currently and we want to slim down the API in advance of OSS.

Differential Revision: D18404408

