### PR TITLE
Pin torchvision to 0.4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ install_dep: &install_dep
         which pip
         pip install --upgrade pip
         pip install --progress-bar off -r requirements.txt
-        pip install --progress-bar off --pre torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
         pip list
 
 run_tests: &run_tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-torch>=1.3.0
+torch==1.3.1
+torchvision==0.4.2


### PR DESCRIPTION
Summary:
We were relying on nightly builds of torchvision because of some video patches
Zhicheng landed. Move to torchvision 0.4.2 now that it's released.

Differential Revision: D18450381

