### PR TITLE
Internally datasets use split, externally tasks use phase_type (in ["train", "test"]) (#36)

### DIFF
--- a/classy_vision/hub/classy_hub_interface.py
+++ b/classy_vision/hub/classy_hub_interface.py
@@ -89,7 +89,7 @@ class ClassyHubInterface:
         shuffle: bool = True,
         transform: Optional[Callable] = None,
         num_samples: Optional[int] = None,
-        split: str = "train",
+        phase_type: str = "train",
     ) -> ClassyDataset:
         """Create a ClassyDataset which reads images from image_paths.
 
@@ -106,22 +106,22 @@ class ClassyHubInterface:
             batchsize_per_replica: Minibatch size per replica (i.e. samples per GPU)
             shuffle: If true, data is shuffled between epochs
             transform: Transform to apply to sample. If left as None, the dataset's
-                split is used to determine the transform to apply. The transform for the
-                split is searched for in self.task, falling back to imagenet
-                transformations if it is not found there.
+                phase_type is used to determine the transform to apply. The transform
+                for the phase_type is searched for in self.task, falling back to
+                imagenet transformations if it is not found there.
             num_samples: If specified, limits the number of samples returned by
                 the dataset
-            split: String specifying the split of data used, e.g. "train" or "test"
+            phase_type: String specifying the phase_type, e.g. "train" or "test"
         """
         if transform is None:
-            if self.task is not None and split in self.task.datasets:
-                # use the transform from the dataset for the split
-                dataset = self.task.datasets[split]
+            if self.task is not None and phase_type in self.task.datasets:
+                # use the transform from the dataset for the phase_type
+                dataset = self.task.datasets[phase_type]
                 transform = dataset.transform
                 assert transform is not None, "Cannot infer transform from the task"
             else:
                 transform = build_field_transform_default_imagenet(
-                    config=None, split=split
+                    config=None, split=phase_type
                 )
         return ImagePathDataset(
             batchsize_per_replica,
@@ -130,7 +130,7 @@ class ClassyHubInterface:
             num_samples,
             image_paths,
             targets=targets,
-            split=split,
+            split=phase_type,
         )
 
     @staticmethod

--- a/test/hub_classy_hub_interface_test.py
+++ b/test/hub_classy_hub_interface_test.py
@@ -36,7 +36,9 @@ class TestClassyHubInterface(unittest.TestCase):
         shutil.rmtree(self.base_dir)
 
     def _test_predict_and_extract_features(self, hub_interface: ClassyHubInterface):
-        dataset = hub_interface.create_image_dataset([self.image_path], split="test")
+        dataset = hub_interface.create_image_dataset(
+            [self.image_path], phase_type="test"
+        )
         data_iterator = hub_interface.get_data_iterator(dataset)
         input = next(data_iterator)
         # set the model to eval mode
@@ -69,11 +71,13 @@ class TestClassyHubInterface(unittest.TestCase):
         self._test_predict_and_extract_features(hub_interface)
 
         # test that the correct transform is picked up
-        split = "test"
+        phase_type = "test"
         test_transform = TestTransform()
-        task.datasets[split].transform = test_transform
+        task.datasets[phase_type].transform = test_transform
         hub_interface = ClassyHubInterface.from_task(task)
-        dataset = hub_interface.create_image_dataset([self.image_path], split=split)
+        dataset = hub_interface.create_image_dataset(
+            [self.image_path], phase_type=phase_type
+        )
         self.assertIsInstance(dataset.transform, TestTransform)
 
     def test_from_model(self):

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -74,9 +74,9 @@ class TestParamSchedulerIntegration(unittest.TestCase):
             .set_model(build_model(config["model"]))
             .set_optimizer(build_optimizer(config["optimizer"]))
         )
-        for split in ["train", "test"]:
-            dataset = build_dataset(config["dataset"][split])
-            task.set_dataset(dataset, split)
+        for phase_type in ["train", "test"]:
+            dataset = build_dataset(config["dataset"][phase_type])
+            task.set_dataset(dataset, phase_type)
 
         self.assertTrue(task is not None)
         return task

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -43,9 +43,9 @@ class TestClassificationTask(unittest.TestCase):
             .set_model(build_model(config["model"]))
             .set_optimizer(build_optimizer(config["optimizer"]))
         )
-        for split in ["train", "test"]:
-            dataset = build_dataset(config["dataset"][split])
-            task.set_dataset(dataset, split)
+        for phase_type in ["train", "test"]:
+            dataset = build_dataset(config["dataset"][phase_type])
+            task.set_dataset(dataset, phase_type)
 
         task.prepare(num_dataloader_workers=1, pin_memory=False)
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/ClassyVision/pull/36

We actually have two separate concepts in our code, but they are currently named similarly. This diff makes an attempt to separate the concepts into two different terms:

phase_type: Used by task to determine the type of phase being currently run
split: Used by dataset to specify a subset (split) of the data

One concept is a dataset split. It should be internal to a dataset and defines a section of a cohesive piece of data (for example, a dataset might be split into 10 sections and cross-validation used for training.

The second concept is that of phase type. As we train with the classification task, we alternate between train and test phases. In training we need to store the auto-grad information...but during testing all we need to do is a forward pass and we often use a different data set for testing.

They are entangled because the "test phase" often uses the "test split" (or "train phase" / "train split"), but this is not required and many datasets use different settings (imagenet has a standard practice of using the "val split" for the test phase).

Differential Revision: D18455247

