### PR TITLE
add FullyConvolutionalLinearHead to classy_vision.heads

### DIFF
--- a/classy_vision/heads/__init__.py
+++ b/classy_vision/heads/__init__.py
@@ -74,12 +74,14 @@ def build_head(config):
 import_all_modules(FILE_ROOT, "classy_vision.heads")
 
 from .fully_connected_head import FullyConnectedHead  # isort:skip
+from .fully_convolutional_linear_head import FullyConvolutionalLinearHead  # isort:skip
 from .identity_head import IdentityHead  # isort:skip
 
 
 __all__ = [
     "ClassyHead",
     "FullyConnectedHead",
+    "FullyConvolutionalLinearHead",
     "IdentityHead",
     "build_head",
     "register_head",


### PR DESCRIPTION
Summary: `FullyConvolutionalLinearHead` head is the most common type of head used in video model. Expose it in `classy_vision.heads`.  We will later use `from classy_vision.heads import FullyConvolutionalLinearHead` in video classification tutorial.

Differential Revision: D18500549

