### PR TITLE
Execute heads after trunk with caching

### DIFF
--- a/classy_vision/models/classy_block.py
+++ b/classy_vision/models/classy_block.py
@@ -4,63 +4,31 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import copy
-
+import torch
 import torch.nn as nn
-from classy_vision.heads import ClassyHead
 
 
 class ClassyBlock(nn.Module):
+    """
+    This is a thin wrapper for head execution, which records the output of
+    wrapped module for executing the heads forked from this module.
+    """
+
     def __init__(self, name, module):
         super().__init__()
-        self._name = name
+        self.name = name
+        self.output = torch.zeros(0)
         self._module = module
-        self._heads = nn.ModuleDict()
-        self._head_outputs = {}
+        self._should_cache_output = False
 
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def head_outputs(self):
-        return copy.copy(self._head_outputs)
-
-    def load_head_states(self, head_states):
+    def set_cache_output(self, should_cache_output: bool = True):
         """
-        load state dict for all the heads
-        Args:
-            head_states (dict): mapping between head id and state dict
+        Whether to cache the output of wrapped module for head execution.
         """
-        assert (
-            len(head_states) == 0 or len(self._heads) != 0
-        ), "Expect the heads to be constructed before loading the states"
-
-        for head_id, head_state in head_states.items():
-            self._heads[head_id].load_state_dict(head_state)
-
-    def set_heads(self, heads):
-        """
-        attach heads to current block.
-        Args:
-            heads (list): a list of ClassyHead
-        """
-        if not all(isinstance(x, ClassyHead) for x in heads):
-            raise ValueError("Head must extend ClassyHead")
-
-        self._clear_heads()
-        for head in heads:
-            self._heads[head.unique_id] = head
-
-    def get_heads(self):
-        return dict(self._heads)
-
-    def _clear_heads(self):
-        self._heads = nn.ModuleDict()
-        self._head_outputs = {}
+        self._should_cache_output = should_cache_output
 
     def forward(self, input):
         output = self._module(input)
-        for head in self._heads.values():
-            self._head_outputs[head.unique_id] = head(output)
+        if self._should_cache_output:
+            self.output = output
         return output

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -375,11 +375,11 @@ class ResNeXt(ClassyModel):
         # By default the classification layer is implemented as one head on top
         # of the last block. The head is automatically computed right after the
         # last block.
-        head_outputs = tuple(self.head_outputs.values())
+        head_outputs = self.execute_heads()
         if len(head_outputs) == 0:
             raise Exception("Expecting at least one head that generates output")
         elif len(head_outputs) == 1:
-            return head_outputs[0]
+            return list(head_outputs.values())[0]
         else:
             return head_outputs
 

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -245,11 +245,11 @@ class ResNeXt3DBase(ClassyModel):
         out = self.stem([x])
         out = self.stages(out)
 
-        head_outputs = tuple(self.head_outputs.values())
+        head_outputs = self.execute_heads()
         if len(head_outputs) == 0:
             raise Exception("Expecting at least one head that generates output")
         elif len(head_outputs) == 1:
-            return head_outputs[0]
+            return list(head_outputs.values())[0]
         else:
             return head_outputs
 

--- a/test/classy_block_test.py
+++ b/test/classy_block_test.py
@@ -40,8 +40,8 @@ class TestClassyBlock(unittest.TestCase):
         model.set_heads({"dummy_block2": {head.unique_id: head}})
         input = torch.randn(1, 2)
         output = model(input)
-        head_output = model.head_outputs["head_id"]
-        self.assertTrue(torch.allclose(head(output), head_output))
+        head_output = model.execute_heads()
+        self.assertTrue(torch.allclose(head(output), head_output["head_id"]))
 
     def test_duplicated_head_ids(self):
         model = self.DummyTestModel()
@@ -64,12 +64,11 @@ class TestClassyBlock(unittest.TestCase):
             len(model.get_heads()), 0, "heads should be empty before set_heads"
         )
         model.set_heads({"dummy_block2": {head.unique_id: head}})
-        self.assertEqual(len(model.head_outputs), 0, "head outputs should be empty")
         input = torch.randn(1, 2)
         model(input)
-        self.assertEqual(len(model.head_outputs), 1, "should have output for one head")
+        head_outputs = model.execute_heads()
+        self.assertEqual(len(head_outputs), 1, "should have output for one head")
 
         # remove all heads
         model.set_heads({})
         self.assertEqual(len(model.get_heads()), 0, "heads should be empty")
-        self.assertEqual(len(model.head_outputs), 0, "head outputs should be empty")


### PR DESCRIPTION
Summary:
Currently we are executing heads right after the forked block is executed, the input of the head would just be the output of the block. When we need extra input for a particular head, we would need to pass the input from the beginning of the network.
This diff changes the head execution to happen after whole trunk execution: after the forked block is executed, we save the output of the block if there is heads on it, later we iterate through all the heads and feed corresponding block output to it. This allows us to pass arbitrary extra input to the head.

Differential Revision: D18442933

