### PR TITLE
Fix video tutorial

### DIFF
--- a/tutorials/video_classification.ipynb
+++ b/tutorials/video_classification.ipynb
@@ -323,6 +323,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "from classy_vision.trainer import LocalTrainer\n",
     "\n",
@@ -348,9 +349,21 @@
    "bento/extensions/theme/main.css": true
   },
   "kernelspec": {
-   "display_name": "classy_vision_zyan3 (local)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "classy_vision_zyan3_local"
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -4,11 +4,14 @@
       "id": "getting_started",
       "title": "Getting started"
      },{
+      "id": "classy_loss",
+      "title": "Creating a custom loss"
+     },{
+      "id": "video_classification",
+      "title": "How to do video classification"
+     },{
       "id": "fine_tuning",
       "title": "Fine Tuning"
-     },{
-      "id": "classy_loss",
-      "title": "Classy Loss"
      },{
       "id": "wsl_model_predict",
       "title": "WSL Model Predict"


### PR DESCRIPTION
The video tutorial was using an internal kernel, which can't be
converted to HTML -- update it to a regular Jupyter notebook instead.

Also add the tutorial to the json file so that it gets converted by the
script that generates the website.