### PR TITLE
Add distributed_backend option to classy_train.py

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -56,7 +56,7 @@ from classy_vision.hooks import (
     VisdomHook,
 )
 from classy_vision.tasks import FineTuningTask, build_task
-from classy_vision.trainer import DistributedTrainer
+from classy_vision.trainer import DistributedTrainer, LocalTrainer
 from torchvision import set_video_backend
 
 
@@ -117,9 +117,11 @@ def main(args, config):
     if args.device is not None:
         use_gpu = args.device == "gpu"
 
-    trainer = DistributedTrainer(
-        use_gpu=use_gpu, num_dataloader_workers=args.num_workers
-    )
+    trainer_class = {"none": LocalTrainer, "ddp": DistributedTrainer}[
+        args.distributed_backend
+    ]
+
+    trainer = trainer_class(use_gpu=use_gpu, num_dataloader_workers=args.num_workers)
     trainer.train(task)
 
 

--- a/classy_vision/generic/opts.py
+++ b/classy_vision/generic/opts.py
@@ -113,6 +113,13 @@ def add_generic_args(parser):
         type=str,
         help="torchvision video decoder backend (pyav or video_reader). Default pyav",
     )
+    parser.add_argument(
+        "--distributed_backend",
+        default="none",
+        type=str,
+        help="""Distributed backend: either 'none' (for non-distributed runs)
+             or 'ddp' (for distributed runs). Default none.""",
+    )
 
     return parser
 


### PR DESCRIPTION
I'm hitting hangs on my mac when launch classy_train.py lots of times.
Sometimes it also fails to allocate a port, which is completely
pointless since I'm not doing distributed training. Allow users to
control what trainer to use via command line flag.