### PR TITLE
Add torchvision transform wrapper

### DIFF
--- a/classy_vision/dataset/transforms/util.py
+++ b/classy_vision/dataset/transforms/util.py
@@ -179,6 +179,81 @@ class ImagenetNoAugmentTransform(ClassyTransform):
         return self.transform(img)
 
 
+@register_transform("generic_image_transform")
+class GenericImageTransform(ClassyTransform):
+    """Default transform for images used in the classification task
+
+    This transform does several things. First, it expects a tuple or
+    list input (torchvision datasets supply tuples / lists). Second,
+    it applies a user-provided image transforms to the first entry in
+    the tuple (again, matching the torchvision tuple format). Third,
+    it transforms the tuple to a dict sample with entries "input" and
+    "target".
+
+    The defaults are for the standard imagenet augmentations
+
+    This is just a convenience wrapper to cover the common
+    use-case.. You can get the same behavior by composing torchvision
+    transforms + ApplyTransformToKey + TupleToMap.
+
+    """
+
+    def __init__(
+        self, transform: Optional[Callable] = None, split: Optional[str] = None
+    ):
+        """Constructor for GenericImageTransfrom
+
+        Args:
+            transform: A callable to be applied to the image only
+            split: 'train' or 'test. Only one of the two arguments
+                should be specified
+        """
+        assert (
+            transform is not None or split is not None
+        ), "One of transform / split must be specified"
+        assert (
+            transform is None or split is None
+        ), "Only one of transform / split should be specified"
+        assert split in [None, "train", "test"], (
+            "If specified, split should be either 'train' or 'test', "
+            "instead got {}".format(split)
+        )
+
+        if transform is not None:
+            self._transform = transform
+
+        if split is not None:
+            self._transform = (
+                ImagenetAugmentTransform()
+                if split == "train"
+                else ImagenetNoAugmentTransform()
+            )
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]):
+        transform = None
+        if "transform" in config:
+            transform = build_transforms(config["transform"])
+        split = config.get("split")
+        return cls(transform, split)
+
+    def __call__(self, sample: Tuple[Any]):
+        """Applied transform to sample
+
+        Args:
+            sample: A tuple of length 2
+        """
+        image = sample[0]
+        transformed_image = self._transform(image)
+        new_sample = {"input": transformed_image, "target": sample[1]}
+        # Any additional metadata is just appended under index of tuple
+        if len(sample) > 2:
+            for i in range(2, len(sample)):
+                new_sample[str(i)] = sample[i]
+
+        return new_sample
+
+
 @register_transform("tuple_to_map")
 class TupleToMapTransform(ClassyTransform):
     """A transform which maps image data from tuple to dict.

--- a/test/dataset_transforms_util_test.py
+++ b/test/dataset_transforms_util_test.py
@@ -5,8 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import random
 import unittest
 
+import numpy
 import torch
 import torchvision.transforms as transforms
 from classy_vision.dataset.core.random_image_datasets import (
@@ -15,6 +17,8 @@ from classy_vision.dataset.core.random_image_datasets import (
 )
 from classy_vision.dataset.transforms import build_transforms
 from classy_vision.dataset.transforms.util import (
+    GenericImageTransform,
+    ImagenetAugmentTransform,
     ImagenetNoAugmentTransform,
     build_field_transform_default_imagenet,
 )
@@ -30,9 +34,21 @@ class DatasetTransformsUtilTest(unittest.TestCase):
             sample_type=sample_type,
         )
 
-    def transform_checks(self, sample, transform, expected_transform, key):
+    def transform_checks(
+        self, sample, transform, expected_transform, key, transformed_key=None
+    ):
+        # If transformed key is None, then use key
+        transformed_key = transformed_key if transformed_key is not None else key
         input_image = copy.deepcopy(sample[key])
-        output_image = transform(sample)[key]
+
+        torch.manual_seed(0)
+        numpy.random.seed(0)
+        random.seed(0)
+        output_image = transform(sample)[transformed_key]
+
+        torch.manual_seed(0)
+        numpy.random.seed(0)
+        random.seed(0)
         self.assertTrue(torch.allclose(output_image, expected_transform(input_image)))
 
     def test_build_dict_field_transform_default_imagenet(self):
@@ -104,3 +120,42 @@ class DatasetTransformsUtilTest(unittest.TestCase):
         transform = build_transforms(config)
         sample = dataset[0]
         self.transform_checks(sample, transform, transforms.ToTensor(), "input")
+
+    def test_generic_image_transform(self):
+        dataset = self.get_test_image_dataset(SampleType.TUPLE)
+
+        # Check class constructor
+        transform = GenericImageTransform(transform=transforms.ToTensor())
+        sample = dataset[0]
+        self.transform_checks(sample, transform, transforms.ToTensor(), 0, "input")
+
+        transform = GenericImageTransform(split="train")
+        sample = dataset[0]
+        self.transform_checks(sample, transform, ImagenetAugmentTransform(), 0, "input")
+
+        transform = GenericImageTransform(split="test")
+        sample = dataset[0]
+        self.transform_checks(
+            sample, transform, ImagenetNoAugmentTransform(), 0, "input"
+        )
+
+        # Check from_config constructor / registry
+        config = [
+            {"name": "generic_image_transform", "transform": [{"name": "ToTensor"}]}
+        ]
+        transform = build_transforms(config)
+        sample = dataset[0]
+        self.transform_checks(sample, transform, transforms.ToTensor(), 0, "input")
+
+        # Check with Imagenet defaults
+        config = [{"name": "generic_image_transform", "split": "train"}]
+        transform = build_transforms(config)
+        sample = dataset[0]
+        self.transform_checks(sample, transform, ImagenetAugmentTransform(), 0, "input")
+
+        config = [{"name": "generic_image_transform", "split": "test"}]
+        transform = build_transforms(config)
+        sample = dataset[0]
+        self.transform_checks(
+            sample, transform, ImagenetNoAugmentTransform(), 0, "input"
+        )


### PR DESCRIPTION
Summary:
Generic image transform. This is meant to be an easy default for applying transforms to torchvision datasets. It applies the transform provided to the first entry of a tuple and matches the tuple to a dict with 'input' / 'target' keys.

If no transform is provided, then the split of the data needs to be provided and a default transform (currently standard random flips / crops for imagenet training) is applied.

For example:

  config = [{"name": "generic_image_transform", "split": "train"}]

Should take a sample of the form (image, target) -> {'input': transformed_image, 'target': target}. The transformed_image should have the transform defined by the ImagenetAugment transform or in torchvision terms:

  transforms.Compose(
            [
                transforms.RandomResizedCrop(crop_size),
                transforms.RandomHorizontalFlip(),
                transforms.ToTensor(),
                transforms.Normalize(mean=mean, std=std),
            ]
        )

Differential Revision: D18620458

