### PR TITLE
Make field transform registered

### DIFF
--- a/classy_vision/dataset/transforms/util.py
+++ b/classy_vision/dataset/transforms/util.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torchvision.transforms as transforms
 
-from . import ClassyTransform, build_transforms, register_transform
+from . import ClassyTransform, build_transform, build_transforms, register_transform
 
 
 class ImagenetConstants:
@@ -29,6 +29,7 @@ class ImagenetConstants:
     RESIZE = 256
 
 
+@register_transform("apply_transform_to_key")
 class ApplyTransformToKey:
     """Serializable class that applies a transform to a key specified field in samples.
     """
@@ -44,6 +45,15 @@ class ApplyTransformToKey:
         """
         self.key: Union[int, str] = key
         self.transform: Callable = transform
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]):
+        if isinstance(config["transform"], list):
+            transform = build_transforms(config["transform"])
+        else:
+            transform = build_transform(config["transform"])
+
+        return cls(transform=transform, key=config["key"])
 
     def __call__(
         self, sample: Union[Tuple[Any], Dict[str, Any]]


### PR DESCRIPTION
Summary:
As titled, this registers the ApplyTransformToKey transform so that users can use it in configs.

For example:

  {
    'name': 'apply_transform_to_key',
    'transform': [{'name': 'my_awesome_transform'}],
    'key': 'input',
  }

Applies my_awesome_transform to only the "input" key of the sample.

  {
    'name': 'apply_transform_to_key',
    'transform': [{'name': 'my_awesome_transform'}],
    'key': 0,
  }

If the sample is a tuple, then this applies the my_awesome_transform to the first entry in the tuple.

Differential Revision: D18605946

