### PR TITLE
add sync_state to video_accuracy meter

### DIFF
--- a/classy_vision/meters/video_accuracy_meter.py
+++ b/classy_vision/meters/video_accuracy_meter.py
@@ -51,6 +51,9 @@ class VideoAccuracyMeter(ClassyMeter):
     def value(self):
         return self._accuracy_meter.value
 
+    def sync_state(self):
+        self._accuracy_meter.sync_state()
+
     def get_classy_state(self):
         """Contains the states of the meter.
         """

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -547,8 +547,6 @@ class ClassificationTask(ClassyTask):
                 * local_variables["target"].size(0)
             )
 
-            self.run_hooks(local_variables, ClassyHookFunctions.on_loss.name)
-
             model_output_cpu = model_output.cpu() if use_gpu else model_output
 
             # Update meters
@@ -557,6 +555,9 @@ class ClassificationTask(ClassyTask):
                     meter.update(
                         model_output_cpu, target.detach().cpu(), is_train=self.train
                     )
+            # After both loss and meters are updated, we run hooks. Among hooks,
+            # `LossLrMeterLoggingHook` will log both loss and meter status
+            self.run_hooks(local_variables, ClassyHookFunctions.on_loss.name)
 
         num_samples_in_step = self.get_global_batchsize()
         self.num_samples_this_phase += num_samples_in_step

--- a/test/meters_video_accuracy_meter_test.py
+++ b/test/meters_video_accuracy_meter_test.py
@@ -145,11 +145,63 @@ class TestVideoAccuracyMeter(ClassificationMeterTest):
                 dtype=torch.float,
             ),
         ]
-        # Class 0 is the correct class for sample 1, class 2 for sample 2, etc
+        # Class 2 is the correct class for sample 1, class 0 for sample 2, etc
         targets = [torch.tensor([0, 0, 1, 1, 2, 2]), torch.tensor([0, 0, 1, 1, 2, 2])]
         # Value for second update
         expected_value = {"top_1": 1 / 3.0, "top_2": 3 / 3.0}
 
         self.meter_get_set_classy_state_test(
             meters, model_outputs, targets, expected_value, is_train=False
+        )
+
+    def test_meter_distributed(self):
+        # Meter0 will execute on one process, Meter1 on the other
+        meters = [
+            VideoAccuracyMeter(
+                topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+            ),
+            VideoAccuracyMeter(
+                topk=[1, 2], clips_per_video_train=1, clips_per_video_test=2
+            ),
+        ]
+
+        # Batchsize = 3, num classes = 3, score is a value in {1, 2,
+        # 3}...3 is the highest score
+        model_outputs = [
+            torch.tensor(
+                [[1, 2, 3], [1, 1, 3], [2, 2, 1], [3, 2, 1], [2, 2, 2], [2, 3, 1]],
+                dtype=torch.float,
+            ),  # Meter 0
+            torch.tensor(
+                [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+                dtype=torch.float,
+            ),  # Meter 1
+            torch.tensor(
+                [[1, 2, 3], [1, 1, 3], [2, 2, 1], [3, 2, 1], [2, 2, 2], [2, 3, 1]],
+                dtype=torch.float,
+            ),  # Meter 0
+            torch.tensor(
+                [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
+                dtype=torch.float,
+            ),  # Meter 1
+        ]
+
+        # For meter 0, class 2 is the correct class for sample 1, class 0 for sample 2,
+        # etc
+        targets = [
+            torch.tensor([0, 0, 1, 1, 2, 2]),  # Meter 0
+            torch.tensor([0, 0, 1, 1, 2, 2]),  # Meter 1
+            torch.tensor([0, 0, 1, 1, 2, 2]),  # Meter 0
+            torch.tensor([0, 0, 1, 1, 2, 2]),  # Meter 1
+        ]
+
+        # In first two updates there are 3 correct top-2, 5 correct in top 2
+        # The same occurs in the second two updates and is added to first
+        expected_values = [
+            {"top_1": 1 / 6.0, "top_2": 4 / 6.0},  # After one update to each meter
+            {"top_1": 2 / 12.0, "top_2": 8 / 12.0},  # After two updates to each meter
+        ]
+
+        self.meter_distributed_test(
+            meters, model_outputs, targets, expected_values, is_train=False
         )


### PR DESCRIPTION
Summary:
Changes
- add `sync_state` method to `video_accuracy` meter. Otherwise, meter value is not consistent between gpus. Also add an unit test for synced `video_accuracy` meter.

- We use `LossLrMeterLoggingHook` to log meters. We should run this hook after meters are updated. We fix this in `train_step` of `ClassificationTask`

Differential Revision: D18648197

