### PR TITLE
mean average precision meter

### DIFF
--- a/classy_vision/hooks/tensorboard_plot_hook.py
+++ b/classy_vision/hooks/tensorboard_plot_hook.py
@@ -132,7 +132,15 @@ class TensorboardPlotHook(ClassyHook):
                 log.warn(f"Skipping meter {meter.name} with value: {meter.value}")
                 continue
             for name, value in meter.value.items():
-                meter_key = f"{phase_type}_{meter.name}_{name}"
-                self.tb_writer.add_scalar(meter_key, value, global_step=phase_type_idx)
+                if isinstance(value, float):
+                    meter_key = f"{phase_type}_{meter.name}_{name}"
+                    self.tb_writer.add_scalar(
+                        meter_key, value, global_step=phase_type_idx
+                    )
+                else:
+                    log.warn(
+                        f"Skipping meter name {meter.name}_{name} with value: {value}"
+                    )
+                    continue
 
         logging.info(f"Done plotting to Tensorboard")


### PR DESCRIPTION
Summary:
Average Precision (AP) summarizes a precision-recall curve as the weighted mean of precisions achieved at each threshold, with the increase in recall from the previous threshold used as the weight.

See AP formal definition (https://scikit-learn.org/stable/modules/generated/sklearn.metrics.average_precision_score.html).

Mean Average Precision is an average of AP over different classes.

In this diff, we implement Mean Average Precision meter that is useful for multi-label classification task.

Differential Revision: D18715190

