### PR TITLE
Remove default transform from synthetic images

### DIFF
--- a/classy_vision/configs/resnet50_synthetic_image_classy_config.json
+++ b/classy_vision/configs/resnet50_synthetic_image_classy_config.json
@@ -13,7 +13,15 @@
             "num_samples": 2000,
             "seed": 0,
             "batchsize_per_replica": 32,
-            "use_shuffle": true
+            "use_shuffle": true,
+            "transforms": [{
+                "name": "apply_transform_to_key",
+                "transforms": [
+                    {"name": "ToTensor"},
+                    {"name": "Normalize", "mean": [0.485, 0.456, 0.406], "std": [0.229, 0.224, 0.225]}
+                ],
+                "key": "input"
+            }]
         },
         "test": {
             "name": "synthetic_image",
@@ -23,7 +31,15 @@
             "num_samples": 2000,
             "seed": 1,
             "batchsize_per_replica": 32,
-            "use_shuffle": false
+            "use_shuffle": false,
+            "transforms": [{
+                "name": "apply_transform_to_key",
+                "transforms": [
+                    {"name": "ToTensor"},
+                    {"name": "Normalize", "mean": [0.485, 0.456, 0.406], "std": [0.229, 0.224, 0.225]}
+                ],
+                "key": "input"
+              }]
         }
     },
     "meters": {

--- a/classy_vision/dataset/classy_synthetic_image.py
+++ b/classy_vision/dataset/classy_synthetic_image.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-
+import logging
 from typing import Any, Callable, Dict, List, Optional
 
 import torchvision.transforms as transforms
@@ -12,6 +12,7 @@ import torchvision.transforms as transforms
 from . import register_dataset
 from .classy_dataset import ClassyDataset
 from .core import RandomImageBinaryClassDataset
+from .transforms import build_transforms
 from .transforms.util import ImagenetConstants, build_field_transform_default_imagenet
 
 
@@ -78,17 +79,18 @@ class SyntheticImageDataset(ClassyDataset):
             shuffle,
             num_samples,
         ) = cls.parse_config(config)
-        default_transform = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=ImagenetConstants.MEAN, std=ImagenetConstants.STD
-                ),
-            ]
-        )
-        transform = build_field_transform_default_imagenet(
-            transform_config, default_transform=default_transform
-        )
+
+        try:
+            transform = build_transforms(transform_config)
+        except Exception:
+            logging.error(
+                "We recently changed transform behavior"
+                " do you need to update your config?"
+                " See resnet50_synthetic_image_classy_config.json"
+                " as an example."
+            )
+            raise
+
         return cls(
             batchsize_per_replica,
             shuffle,

--- a/classy_vision/hydra/config/resnet50_synthetic.yaml
+++ b/classy_vision/hydra/config/resnet50_synthetic.yaml
@@ -13,6 +13,15 @@ config:
       seed: 0
       batchsize_per_replica: 32
       use_shuffle: true
+      transforms:
+        - name: apply_transform_to_key
+          transforms:
+            - name: ToTensor
+            - name: Normalize
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
+          key: input
+
     test:
       name: synthetic_image
       split: val
@@ -22,6 +31,15 @@ config:
       seed: 1
       batchsize_per_replica: 32
       use_shuffle: false
+      transforms:
+        - name: apply_transform_to_key
+          transforms:
+            - name: ToTensor
+            - name: Normalize
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
+          key: input
+
   meters:
     accuracy:
       topk: [1, 5]

--- a/classy_vision/hydra/dataset/synthetic_image.yaml
+++ b/classy_vision/hydra/dataset/synthetic_image.yaml
@@ -9,6 +9,14 @@ config:
       seed: 0
       batchsize_per_replica: 32
       use_shuffle: true
+      transforms:
+        - name: apply_transform_to_key
+          transforms:
+            - name: ToTensor
+            - name: Normalize
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
+          key: input
     test:
       name: synthetic_image
       split: val
@@ -18,3 +26,11 @@ config:
       seed: 1
       batchsize_per_replica: 32
       use_shuffle: false
+      transforms:
+        - name: apply_transform_to_key
+          transforms:
+            - name: ToTensor
+            - name: Normalize
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
+          key: input

--- a/test/dataset_image_path_dataset_test.py
+++ b/test/dataset_image_path_dataset_test.py
@@ -26,7 +26,13 @@ class TestImageDataset(unittest.TestCase):
             "num_samples": 100,
             "batchsize_per_replica": 1,
             "use_shuffle": False,
-            "transforms": [{"name": "ToTensor"}],
+            "transforms": [
+                {
+                    "name": "apply_transform_to_key",
+                    "transforms": [{"name": "ToTensor"}],
+                    "key": "input",
+                }
+            ],
         }
         dataset = build_dataset(config)
         return dataset

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -22,6 +22,20 @@ def get_test_task_config(head_num_classes=1000):
                 "seed": 0,
                 "batchsize_per_replica": 32,
                 "use_shuffle": True,
+                "transforms": [
+                    {
+                        "name": "apply_transform_to_key",
+                        "transforms": [
+                            {"name": "ToTensor"},
+                            {
+                                "name": "Normalize",
+                                "mean": [0.485, 0.456, 0.406],
+                                "std": [0.229, 0.224, 0.225],
+                            },
+                        ],
+                        "key": "input",
+                    }
+                ],
             },
             "test": {
                 "name": "synthetic_image",
@@ -32,6 +46,20 @@ def get_test_task_config(head_num_classes=1000):
                 "seed": 0,
                 "batchsize_per_replica": 32,
                 "use_shuffle": False,
+                "transforms": [
+                    {
+                        "name": "apply_transform_to_key",
+                        "transforms": [
+                            {"name": "ToTensor"},
+                            {
+                                "name": "Normalize",
+                                "mean": [0.485, 0.456, 0.406],
+                                "std": [0.229, 0.224, 0.225],
+                            },
+                        ],
+                        "key": "input",
+                    }
+                ],
             },
         },
         "meters": {"accuracy": {"topk": [1, 5]}},
@@ -75,6 +103,20 @@ def get_fast_test_task_config(head_num_classes=1000):
                 "seed": 0,
                 "batchsize_per_replica": 2,
                 "use_shuffle": False,
+                "transforms": [
+                    {
+                        "name": "apply_transform_to_key",
+                        "transforms": [
+                            {"name": "ToTensor"},
+                            {
+                                "name": "Normalize",
+                                "mean": [0.485, 0.456, 0.406],
+                                "std": [0.229, 0.224, 0.225],
+                            },
+                        ],
+                        "key": "input",
+                    }
+                ],
             },
             "test": {
                 "name": "synthetic_image",
@@ -85,6 +127,20 @@ def get_fast_test_task_config(head_num_classes=1000):
                 "seed": 0,
                 "batchsize_per_replica": 2,
                 "use_shuffle": False,
+                "transforms": [
+                    {
+                        "name": "apply_transform_to_key",
+                        "transforms": [
+                            {"name": "ToTensor"},
+                            {
+                                "name": "Normalize",
+                                "mean": [0.485, 0.456, 0.406],
+                                "std": [0.229, 0.224, 0.225],
+                            },
+                        ],
+                        "key": "input",
+                    }
+                ],
             },
         },
         "model": {
@@ -130,6 +186,20 @@ def get_test_mlp_task_config():
                 "batchsize_per_replica": 3,
                 "use_augmentation": False,
                 "use_shuffle": True,
+                "transforms": [
+                    {
+                        "name": "apply_transform_to_key",
+                        "transforms": [
+                            {"name": "ToTensor"},
+                            {
+                                "name": "Normalize",
+                                "mean": [0.485, 0.456, 0.406],
+                                "std": [0.229, 0.224, 0.225],
+                            },
+                        ],
+                        "key": "input",
+                    }
+                ],
             },
             "test": {
                 "name": "synthetic_image",
@@ -142,6 +212,20 @@ def get_test_mlp_task_config():
                 "batchsize_per_replica": 1,
                 "use_augmentation": False,
                 "use_shuffle": False,
+                "transforms": [
+                    {
+                        "name": "apply_transform_to_key",
+                        "transforms": [
+                            {"name": "ToTensor"},
+                            {
+                                "name": "Normalize",
+                                "mean": [0.485, 0.456, 0.406],
+                                "std": [0.229, 0.224, 0.225],
+                            },
+                        ],
+                        "key": "input",
+                    }
+                ],
             },
         },
         "model": {

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -31,8 +31,21 @@ class TestParamSchedulerIntegration(unittest.TestCase):
                     "num_samples": 10,
                     "seed": 0,
                     "batchsize_per_replica": 5,
-                    "use_augmentation": False,
                     "use_shuffle": True,
+                    "transforms": [
+                        {
+                            "name": "apply_transform_to_key",
+                            "transforms": [
+                                {"name": "ToTensor"},
+                                {
+                                    "name": "Normalize",
+                                    "mean": [0.485, 0.456, 0.406],
+                                    "std": [0.229, 0.224, 0.225],
+                                },
+                            ],
+                            "key": "input",
+                        }
+                    ],
                 },
                 "test": {
                     "name": "synthetic_image",
@@ -43,8 +56,21 @@ class TestParamSchedulerIntegration(unittest.TestCase):
                     "num_samples": 10,
                     "seed": 0,
                     "batchsize_per_replica": 5,
-                    "use_augmentation": False,
                     "use_shuffle": False,
+                    "transforms": [
+                        {
+                            "name": "apply_transform_to_key",
+                            "transforms": [
+                                {"name": "ToTensor"},
+                                {
+                                    "name": "Normalize",
+                                    "mean": [0.485, 0.456, 0.406],
+                                    "std": [0.229, 0.224, 0.225],
+                                },
+                            ],
+                            "key": "input",
+                        }
+                    ],
                 },
             },
             "model": {

--- a/tutorials/fine_tuning.ipynb
+++ b/tutorials/fine_tuning.ipynb
@@ -29,7 +29,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "num_epochs = 4"
@@ -39,12 +41,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will be using synthetic train and test datasets for this example."
+    "We will be using synthetic train and test datasets for this example. The transforms used are from torchvision and are applied to the input value in the sample (rather than the target)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,6 +60,14 @@
     "    \"seed\": 0,\n",
     "    \"use_shuffle\": True,\n",
     "    \"split\": \"train\",\n",
+    "    \"transforms\": [{\n",
+    "        \"name\": \"apply_transform_to_key\",\n",
+    "        \"transforms\": [\n",
+    "            {\"name\": \"ToTensor\"},\n",
+    "            {\"name\": \"Normalize\", \"mean\": [0.485, 0.456, 0.406], \"std\": [0.229, 0.224, 0.225]}\n",
+    "        ],\n",
+    "        \"key\": \"input\"\n",
+    "    }]\n",
     "})\n",
     "test_dataset = SyntheticImageDataset.from_config({\n",
     "    \"batchsize_per_replica\": 32,\n",
@@ -67,6 +77,14 @@
     "    \"seed\": 0,\n",
     "    \"use_shuffle\": False,\n",
     "    \"split\": \"test\",\n",
+    "    \"transforms\": [{\n",
+    "        \"name\": \"apply_transform_to_key\",\n",
+    "        \"transforms\": [\n",
+    "            {\"name\": \"ToTensor\"},\n",
+    "            {\"name\": \"Normalize\", \"mean\": [0.485, 0.456, 0.406], \"std\": [0.229, 0.224, 0.225]}\n",
+    "        ],\n",
+    "        \"key\": \"input\"\n",
+    "    }]\n",
     "})"
    ]
   },
@@ -80,7 +98,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.models import ResNet\n",
@@ -102,7 +122,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.heads import FullyConnectedHead\n",
@@ -122,7 +144,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "model.set_heads({\"block3-2\": {head.unique_id: head}})"
@@ -138,7 +162,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from torch.nn.modules.loss import CrossEntropyLoss\n",
@@ -156,7 +182,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.optim import build_optimizer\n",
@@ -181,7 +209,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.meters import AccuracyMeter\n",
@@ -199,7 +229,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -219,7 +251,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.hooks import CheckpointHook, LossLrMeterLoggingHook, ProgressBarHook\n",
@@ -240,7 +274,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.tasks import ClassificationTask\n",
@@ -268,7 +304,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.trainer import LocalTrainer\n",
@@ -286,7 +324,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "trainer.train(pretrain_task)"
@@ -302,7 +342,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.generic.util import load_checkpoint\n",
@@ -327,7 +369,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "num_epochs = 1"
@@ -350,7 +394,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.models import ResNet\n",
@@ -372,7 +418,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.heads import FullyConnectedHead\n",
@@ -390,7 +438,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "model.set_heads({\"block3-2\": {head.unique_id: head}})"
@@ -406,7 +456,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.optim import build_optimizer\n",
@@ -433,7 +485,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.meters import AccuracyMeter\n",
@@ -451,7 +505,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -471,7 +527,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.hooks import CheckpointHook, LossLrMeterLoggingHook\n",
@@ -492,7 +550,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from classy_vision.tasks import FineTuningTask\n",
@@ -527,7 +587,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fine_tuning_task.set_freeze_trunk(True)"
@@ -543,7 +605,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fine_tuning_task.set_reset_heads(True)"
@@ -559,7 +623,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "fine_tuning_task.set_pretrained_checkpoint(pretrained_checkpoint)"
@@ -575,7 +641,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "trainer.train(fine_tuning_task)"
@@ -603,9 +671,9 @@
    "bento/extensions/theme/main.css": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Classy Vision",
    "language": "python",
-   "name": "python3"
+   "name": "bento_kernel_classy_vision"
   },
   "language_info": {
    "codemirror_mode": {
@@ -617,7 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5+"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Summary: Match the synthetic image dataset from_config transform API to work on top of build_transforms rather than an invisible apply_transform_to_key / non-transparent default transform.

Differential Revision: D18772557

