### PR TITLE
Remove split from classy dataset

### DIFF
--- a/classy_vision/dataset/classy_cifar.py
+++ b/classy_vision/dataset/classy_cifar.py
@@ -34,7 +34,7 @@ class CIFARDataset(ClassyDataset):
             dataset = CIFAR100(root=root, train=(split == "train"), download=download)
 
         super().__init__(
-            dataset, split, batchsize_per_replica, shuffle, transform, num_samples
+            dataset, batchsize_per_replica, shuffle, transform, num_samples
         )
 
     @classmethod

--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -30,7 +30,6 @@ class ClassyDataset:
     def __init__(
         self,
         dataset: Sequence,
-        split: Optional[str],
         batchsize_per_replica: int,
         shuffle: bool,
         transform: Optional[Union[ClassyTransform, Callable]],
@@ -40,7 +39,6 @@ class ClassyDataset:
         Constructor for a ClassyDataset.
 
         Args:
-            split: Split of dataset to use ("train", "test")
             batchsize_per_replica: Positive integer indicating batch size for each
                 replica
             shuffle: Whether we should shuffle between epochs
@@ -58,7 +56,6 @@ class ClassyDataset:
         ), "num_samples must be a positive int or None"
 
         # Assignments:
-        self.split = split
         self.batchsize_per_replica = batchsize_per_replica
         self.shuffle = shuffle
         self.transform = transform

--- a/classy_vision/dataset/classy_imagenet.py
+++ b/classy_vision/dataset/classy_imagenet.py
@@ -25,7 +25,7 @@ class ImageNetDataset(ClassyDataset):
     ):
         dataset = ImageNet(root=root, split=split, download=download)
         super().__init__(
-            dataset, split, batchsize_per_replica, shuffle, transform, num_samples
+            dataset, batchsize_per_replica, shuffle, transform, num_samples
         )
 
     @classmethod

--- a/classy_vision/dataset/classy_synthetic_image.py
+++ b/classy_vision/dataset/classy_synthetic_image.py
@@ -34,7 +34,6 @@ class SyntheticImageDataset(ClassyDataset):
         crop_size: int,
         class_ratio: float,
         seed: int,
-        split: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -53,7 +52,7 @@ class SyntheticImageDataset(ClassyDataset):
             crop_size, class_ratio, num_samples, seed
         )
         super().__init__(
-            dataset, split, batchsize_per_replica, shuffle, transform, num_samples
+            dataset, batchsize_per_replica, shuffle, transform, num_samples
         )
 
     @classmethod
@@ -68,7 +67,6 @@ class SyntheticImageDataset(ClassyDataset):
             A SyntheticImageDataset instance.
         """
         assert all(key in config for key in ["crop_size", "class_ratio", "seed"])
-        split = config.get("split")
         crop_size = config["crop_size"]
         class_ratio = config["class_ratio"]
         seed = config["seed"]
@@ -97,5 +95,4 @@ class SyntheticImageDataset(ClassyDataset):
             crop_size,
             class_ratio,
             seed,
-            split=split,
         )

--- a/classy_vision/dataset/classy_video_dataset.py
+++ b/classy_vision/dataset/classy_video_dataset.py
@@ -89,10 +89,11 @@ class ClassyVideoDataset(ClassyDataset):
 
         """
         super(ClassyVideoDataset, self).__init__(
-            dataset, split, batchsize_per_replica, shuffle, transform, num_samples
+            dataset, batchsize_per_replica, shuffle, transform, num_samples
         )
         # Assignments:
         self.clips_per_video = clips_per_video
+        self.split = split
 
     @classmethod
     def parse_config(cls, config: Dict[str, Any]):

--- a/classy_vision/dataset/image_path_dataset.py
+++ b/classy_vision/dataset/image_path_dataset.py
@@ -53,7 +53,6 @@ class ImagePathDataset(ClassyDataset):
         num_samples: Optional[int],
         image_paths: Union[str, List[str]],
         targets: Optional[List[Any]] = None,
-        split: Optional[str] = None,
     ):
         """Constructor for ImagePathDataset.
 
@@ -69,8 +68,6 @@ class ImagePathDataset(ClassyDataset):
                 be used to specify a target for each path (must be same length
                 as list of file paths). If no targets are needed or image_paths is
                 a directory, then targets should be None.
-            split: Split of dataset ("train", "test")
-
         """
         # TODO(@mannatsingh): we should be able to call build_dataset() to create
         # datasets from this class.
@@ -81,7 +78,7 @@ class ImagePathDataset(ClassyDataset):
         )
         dataset, preproc_transform = _load_dataset(image_paths, targets)
         super().__init__(
-            dataset, split, batchsize_per_replica, shuffle, transform, num_samples
+            dataset, batchsize_per_replica, shuffle, transform, num_samples
         )
         # Some of the base datasets from _load_dataset have different
         # sample formats, the preproc_transform should map them all to
@@ -110,7 +107,6 @@ class ImagePathDataset(ClassyDataset):
             targets: Optional list of targets for dataset.
                 See :func:`__init__` for more details
         """
-        split = config.get("split")
         (
             transform_config,
             batchsize_per_replica,
@@ -126,5 +122,4 @@ class ImagePathDataset(ClassyDataset):
             num_samples,
             image_paths,
             targets=targets,
-            split=split,
         )

--- a/classy_vision/hub/classy_hub_interface.py
+++ b/classy_vision/hub/classy_hub_interface.py
@@ -130,7 +130,6 @@ class ClassyHubInterface:
             num_samples,
             image_paths,
             targets=targets,
-            split=phase_type,
         )
 
     @staticmethod

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -63,7 +63,6 @@ class TestDataset(classy_dataset.ClassyDataset):
         dataset = ListDataset(input_tensors, target_tensors, loader=lambda x: x)
         super().__init__(
             dataset=dataset,
-            split=None,
             batchsize_per_replica=batchsize_per_replica,
             shuffle=shuffle,
             transform=transform,
@@ -88,7 +87,6 @@ class OtherTestDataset(classy_dataset.ClassyDataset):
         dataset = ListDataset(input_tensors, target_tensors, loader=lambda x: x)
         super().__init__(
             dataset=dataset,
-            split=None,
             batchsize_per_replica=batchsize_per_replica,
             shuffle=False,
             transform=None,

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -15,7 +15,6 @@ def get_test_task_config(head_num_classes=1000):
         "dataset": {
             "train": {
                 "name": "synthetic_image",
-                "split": "train",
                 "crop_size": 224,
                 "class_ratio": 0.5,
                 "num_samples": 2000,
@@ -25,7 +24,6 @@ def get_test_task_config(head_num_classes=1000):
             },
             "test": {
                 "name": "synthetic_image",
-                "split": "test",
                 "crop_size": 224,
                 "class_ratio": 0.5,
                 "num_samples": 2000,
@@ -68,7 +66,6 @@ def get_fast_test_task_config(head_num_classes=1000):
         "dataset": {
             "train": {
                 "name": "synthetic_image",
-                "split": "train",
                 "crop_size": 20,
                 "class_ratio": 0.5,
                 "num_samples": 10,
@@ -78,7 +75,6 @@ def get_fast_test_task_config(head_num_classes=1000):
             },
             "test": {
                 "name": "synthetic_image",
-                "split": "test",
                 "crop_size": 20,
                 "class_ratio": 0.5,
                 "num_samples": 10,
@@ -121,7 +117,6 @@ def get_test_mlp_task_config():
         "dataset": {
             "train": {
                 "name": "synthetic_image",
-                "split": "train",
                 "num_classes": 2,
                 "crop_size": 20,
                 "class_ratio": 0.5,
@@ -133,7 +128,6 @@ def get_test_mlp_task_config():
             },
             "test": {
                 "name": "synthetic_image",
-                "split": "test",
                 "num_classes": 2,
                 "crop_size": 20,
                 "class_ratio": 0.5,


### PR DESCRIPTION
Summary:
In writing the tutorial for the dataset, we realized that we don't need the split argument.

This diff removes it from classy dataset (though several down stream datasets still use a split argument).

Differential Revision: D18777326

