### PR TITLE
Small fix on Ray tutorial

### DIFF
--- a/tutorials/ray_aws.ipynb
+++ b/tutorials/ray_aws.ipynb
@@ -155,7 +155,7 @@
    "source": [
     "That will give you an SSH session into the head node, which coordinates all the worker nodes in Ray. In our example configuration file, the head node is a CPU-only machine, and the workers all have GPUs.\n",
     "\n",
-    "Both the head node and the worker nodes will have the same EFS volume mounted, so we'll use that to send code from the head to the workers. The following commands are meant to run on the head node (e.g. in the terminal prompt you got from `ray attach`). Let's start a project:"
+    "Both the head node and the worker nodes will have the same EFS volume mounted, so we'll use that to send code from the head to the workers. The following commands are meant to run on the head node (e.g. in the terminal prompt you got from `ray attach`). Let's start a project in the EFS folder:"
    ]
   },
   {
@@ -164,6 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "$ cd efs\n",
     "$ classy-project my_project"
    ]
   },


### PR DESCRIPTION
Add a `cd` command to the tutorial so we create the classy project in
the EFS volume.