### PR TITLE
Fix empty cell

### DIFF
--- a/tutorials/classy_dataset.ipynb
+++ b/tutorials/classy_dataset.ipynb
@@ -551,13 +551,6 @@
     "\n",
     "For more details on how to use the dataset for training, please see [Getting started](https://classyvision.ai/tutorials/getting_started)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
THere was an extra, empty, cell in the dataset tutorial. This PR removes it.