### PR TITLE
Fix website on mobile

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -63,6 +63,8 @@ html body {
 .splashLogo {
   display: block;
   margin: 0 auto;
+  max-width: 100%;
+  max-height: 100%;
   height: 278px;
   width: 500px;
 }


### PR DESCRIPTION
Our logo is set to 500px so it breaks the layout on small screens. This
fixes it.