### PR TITLE
Fix script to check formatting

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -59,6 +59,7 @@ from classy_vision.tasks import FineTuningTask, build_task
 from classy_vision.trainer import DistributedTrainer, LocalTrainer
 from torchvision import set_image_backend, set_video_backend
 
+imprt a
 
 def main(args, config):
     # Global flags

--- a/classy_train.py
+++ b/classy_train.py
@@ -59,7 +59,6 @@ from classy_vision.tasks import FineTuningTask, build_task
 from classy_vision.trainer import DistributedTrainer, LocalTrainer
 from torchvision import set_image_backend, set_video_backend
 
-imprt a
 
 def main(args, config):
     # Global flags

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -4,7 +4,11 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cd $(dirname "$0")/..
+if [ ! $(cd $(dirname "$0")/..) ]
+then
+    echo "Cannot cd to root dir"
+    exit 1
+fi
 
 CMD="black"
 CHANGED_FILES="$(git diff --name-only master | grep '\.py$' | tr '\n' ' ')"

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-if [ ! $(cd $(dirname "$0")/..) ]
+if [ ! "cd $(dirname $0)/.." ]
 then
     echo "Cannot cd to root dir"
     exit 1

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -7,7 +7,7 @@
 set -e
 
 CMD="black"
-CHANGED_FILES="$(git diff --name-only master... | grep '\.py$' | tr '\n' ' ')"
+CHANGED_FILES="$(git diff --name-only  | grep '\.py$' | tr '\n' ' ')"
 
 while getopts bs opt; do
   case $opt in

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -29,18 +29,18 @@ if [ "$CHANGED_FILES" != "" ]
 then
     if [ "$CMD" = "black" ]
     then
-	if [ ! "$(black --version)" ]
-	then
+        if [ ! "$(black --version)" ]
+        then
             echo "Please install black."
-	    exit 1
-	fi
-	cmd="black --check $CHANGED_FILES"
+            exit 1
+        fi
+        cmd="black --check $CHANGED_FILES"
     else
-	if [ ! "$(isort --version)" ]
-	then
+        if [ ! "$(isort --version)" ]
+        then
             echo "Please install isort."
-	    exit 1
-	fi
+            exit 1
+        fi
         cmd="isort $CHANGED_FILES -c"
     fi
     echo "Running command \"$cmd\""

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cd $(dirname $0)/.. || exit 1
+cd "$(dirname "$0")/.." || exit 1
 
 CMD="black"
 CHANGED_FILES="$(git diff --name-only master | grep '\.py$' | tr '\n' ' ')"

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -4,10 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -e
+cd $(dirname "$0")/..
 
 CMD="black"
-CHANGED_FILES="$(git diff --name-only  | grep '\.py$' | tr '\n' ' ')"
+CHANGED_FILES="$(git diff --name-only master | grep '\.py$' | tr '\n' ' ')"
 
 while getopts bs opt; do
   case $opt in
@@ -29,15 +29,21 @@ if [ "$CHANGED_FILES" != "" ]
 then
     if [ "$CMD" = "black" ]
     then
-        command -v black >/dev/null || \
-            ( echo "Please install black." && false )
-        # only output if something needs to change
-        black --check "$CHANGED_FILES"
+	if [ ! "$(black --version)" ]
+	then
+            echo "Please install black."
+	    exit 1
+	fi
+	cmd="black --check $CHANGED_FILES"
     else
-        isort -v | grep 'VERSION' >/dev/null || \
-            ( echo "Please install isort." && false )
-
-        # output number of files with incorrectly sorted imports
-        isort "$CHANGED_FILES" -c | grep -c 'ERROR'
+	if [ ! "$(isort --version)" ]
+	then
+            echo "Please install isort."
+	    exit 1
+	fi
+        cmd="isort $CHANGED_FILES -c"
     fi
 fi
+
+echo "Running command \"$cmd\""
+($cmd)

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -43,7 +43,9 @@ then
 	fi
         cmd="isort $CHANGED_FILES -c"
     fi
+    echo "Running command \"$cmd\""
+    ($cmd)
+else
+    echo "No changes made to any Python files. Nothing to do."
 fi
 
-echo "Running command \"$cmd\""
-($cmd)

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -4,11 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-if [ ! "cd $(dirname $0)/.." ]
-then
-    echo "Cannot cd to root dir"
-    exit 1
-fi
+cd $(dirname $0)/.. || exit 1
 
 CMD="black"
 CHANGED_FILES="$(git diff --name-only master | grep '\.py$' | tr '\n' ' ')"


### PR DESCRIPTION
The formatting checks weren't running since no files were being passed to the linters. This PR fixes that. Tested running the script locally.

I noticed that the black linter still doesn't work completely - it misses fixing multiple imports on one line, for instance. Considering that out of scope for this change.