### PR TITLE
PR Meters fix for common datasets

### DIFF
--- a/classy_vision/meters/recall_meter.py
+++ b/classy_vision/meters/recall_meter.py
@@ -147,16 +147,21 @@ class RecallAtKMeter(ClassyMeter):
             model_output: tensor of shape (B, C) where each value is
                           either logit or class probability.
             target:       tensor of shape (B, C), one-hot encoded
-                          or integer encoded.
+                          or integer encoded or tensor of shape (B),
+                          integer encoded.
 
         Note:
 
             For binary classification, C=2. For integer encoded target, C=1.
         """
 
+        target_shape_list = list(target.size())
+
         if self._target_is_one_hot is False:
-            assert target.shape[1] == 1, "Integer encoded target must be single labeled"
-            target = convert_to_one_hot(target, self._num_classes)
+            assert len(target_shape_list) == 1 or (
+                len(target_shape_list) == 2 and target_shape_list[1] == 1
+            ), "Integer encoded target must be single labeled"
+            target = convert_to_one_hot(target.view(-1, 1), self._num_classes)
 
         assert (
             torch.min(target.eq(0) + target.eq(1)) == 1
@@ -196,8 +201,8 @@ class RecallAtKMeter(ClassyMeter):
             model_output_shape
         )
         assert (
-            len(target_shape) == 2
-        ), "target_shape must be (B, C) \
+            len(target_shape) > 0 and len(target_shape) < 3
+        ), "target_shape must be (B) or (B, C) \
             Found shape {}".format(
             target_shape
         )

--- a/test/meters_recall_meter_test.py
+++ b/test/meters_recall_meter_test.py
@@ -83,8 +83,8 @@ class TestRecallAtKMeter(ClassificationMeterTest):
                 [0.33, 0.33, 0.34],  # top-1: 2, top-2: 2/0/1
             ]
         )
-        # Target shape does not match model shape
-        target = torch.tensor([0, 1, 2])
+        # Target shape is of length 3
+        target = torch.tensor([[[0, 1, 2]]])
 
         self.meter_invalid_meter_input_test(meter, model_output, target)
 
@@ -182,6 +182,32 @@ class TestRecallAtKMeter(ClassificationMeterTest):
         targets = [
             torch.tensor([[1], [1], [1]]),  # [[0, 1, 0], [0, 1, 0], [0, 1, 0]]
             torch.tensor([[0], [1], [2]]),  # [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        ]
+
+        # Note for ties, we select randomly, so we should not use ambiguous ties
+        # First batch has top-1 recall of 2/3.0, top-2 recall of 2/6.0
+        # Second batch has top-1 recall of 1/3.0, top-2 recall of 4/6.0
+        expected_value = {"top_1": 3 / 6.0, "top_2": 6 / 12.0}
+
+        self.meter_update_and_reset_test(meter, model_outputs, targets, expected_value)
+
+    def test_non_onehot_target(self):
+        """
+        This test verifies that the meter works as expected on a single
+        update + reset + same single update with one dimensional targets.
+        """
+        meter = RecallAtKMeter(topk=[1, 2], target_is_one_hot=False, num_classes=3)
+
+        # Batchsize = 2, num classes = 3, score is probability of class
+        model_outputs = [
+            torch.tensor([[0.05, 0.4, 0.05], [0.15, 0.65, 0.2], [0.4, 0.2, 0.4]]),
+            torch.tensor([[0.2, 0.4, 0.4], [0.2, 0.65, 0.15], [0.1, 0.8, 0.1]]),
+        ]
+
+        # One-hot encoding, 1 = positive for class
+        targets = [
+            torch.tensor([1, 1, 1]),  # [[0, 1, 0], [0, 1, 0], [0, 1, 0]]
+            torch.tensor([0, 1, 2]),  # [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         ]
 
         # Note for ties, we select randomly, so we should not use ambiguous ties


### PR DESCRIPTION
Summary: Currently, PR meters expect (B, C) targets only, C being 1 for integer encoded targets. Most of the common datasets like imagenet/cifar 10 have target size (B). This fixes those meters to accept both (B, C) and (B) sized targets.

Differential Revision: D18937173

