### PR TITLE
Circle CI linter fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ version: 2
 # Environments to run the jobs in
 # -------------------------------------------------------------------------------------
 cpu: &cpu
-  docker:
+  environment:
+    TERM: xterm
   machine:
     image: default
   resource_class: medium
@@ -16,6 +17,7 @@ cpu: &cpu
 gpu: &gpu
   environment:
     CUDA_VERSION: "10.1"
+    TERM: xterm
   machine:
     image: default
   resource_class: gpu.medium  # Tesla M60

--- a/scripts/check_formatting.sh
+++ b/scripts/check_formatting.sh
@@ -6,8 +6,29 @@
 
 cd "$(dirname "$0")/.." || exit 1
 
+GIT_URL_1="https://github.com/facebookresearch/ClassyVision.git"
+GIT_URL_2="git@github.com:facebookresearch/ClassyVision.git"
+
+UPSTREAM_URL="$(git config remote.upstream.url)"
+
+if [ -z "$UPSTREAM_URL" ]
+then
+    echo "Setting upstream remote to $GIT_URL_1"
+    git remote add upstream "$GIT_URL_1"
+elif [ "$UPSTREAM_URL" != "$GIT_URL_1" ] && \
+     [ "$UPSTREAM_URL" != "$GIT_URL_2" ]
+then
+    echo "upstream remote set to $UPSTREAM_URL."
+    echo "Please delete the upstream remote or set it to $GIT_URL_1 to use this script."
+    exit 1
+fi
+
+# fetch upstream
+git fetch upstream
+
+CHANGED_FILES="$(git diff --name-only upstream/master | grep '\.py$' | tr '\n' ' ')"
+
 CMD="black"
-CHANGED_FILES="$(git diff --name-only master | grep '\.py$' | tr '\n' ' ')"
 
 while getopts bs opt; do
   case $opt in


### PR DESCRIPTION
Summary:
Although D18937929 fixed `check_formatting.sh` locally, it still didn't work on circleci -
- `git diff` didn't work on circleci since `$TERM` wasn't set and used to return an empty string. Set `$TERM` in the environment for cpu and gpu tests.
- circleci sets `master` to point to the local branch instead of `origin/master`. Even if this wasn't an issue, the diffs would run between a user's diff branch and `master`. Made it so that we instead fetch `upstream/master` and compare against that.

Differential Revision: D18976874

