### PR TITLE
Update torch.load to be explicit that we're loading from cpu

### DIFF
--- a/classy_vision/trainer/elastic_trainer.py
+++ b/classy_vision/trainer/elastic_trainer.py
@@ -252,9 +252,7 @@ class ElasticTrainer(ClassyTrainer):
             torch.save(checkpoint_state, stream)
 
         def load(self, stream):
-            checkpoint_state = torch.load(
-                stream, map_location=lambda storage, loc: storage
-            )
+            checkpoint_state = torch.load(stream, map_location=torch.device("cpu"))
             state = checkpoint_state["classy_state_dict"]
             self.task.set_classy_state(state)
             if "advance_to_next_phase" in checkpoint_state:


### PR DESCRIPTION
Summary: Just changing the slightly confusing line `map_location=lambda storage, loc: storage` to `map_location=torch.device("cpu")` to be more explicit about what's happening

Differential Revision: D19069837

