### PR TITLE
do not overwrite multiprocessing context to be fork in ClassyVideoDataset

### DIFF
--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -104,9 +104,9 @@ class ClassyDataset:
         return transform_config, batchsize_per_replica, shuffle, num_samples
 
     def __getitem__(self, idx: int):
-        assert idx >= 0 and idx < len(
-            self.dataset
-        ), "Provided idx is outside of dataset range"
+        assert idx >= 0 and idx < len(self.dataset), (
+            "Provided idx (%d) is outside of dataset range" % idx
+        )
         sample = self.dataset[idx]
         if self.transform is None:
             return sample
@@ -163,6 +163,7 @@ class ClassyDataset:
             batch_size=self.batchsize_per_replica,
             num_workers=kwargs.get("num_workers", 0),
             pin_memory=kwargs.get("pin_memory", False),
+            worker_init_fn=kwargs.get("worker_init_fn", None),
             multiprocessing_context=kwargs.get("multiprocessing_context", None),
             sampler=self._get_sampler(epoch=offset_epoch),
         )

--- a/classy_vision/dataset/classy_hmdb51.py
+++ b/classy_vision/dataset/classy_hmdb51.py
@@ -94,7 +94,7 @@ class HMDB51Dataset(ClassyVideoDataset):
             _precomputed_metadata=metadata,
             fold=fold,
             train=(split == "train"),
-            num_workers=torch.get_num_threads(),
+            num_workers=torch.get_num_threads() // 2,  # heuristically use half threads
             _video_width=video_width,
             _video_height=video_height,
             _video_min_dimension=video_min_dimension,

--- a/classy_vision/dataset/classy_kinetics400.py
+++ b/classy_vision/dataset/classy_kinetics400.py
@@ -98,13 +98,14 @@ class Kinetics400Dataset(ClassyVideoDataset):
             frame_rate=frame_rate,
             _precomputed_metadata=metadata,
             extensions=extensions,
-            num_workers=torch.get_num_threads(),
+            num_workers=torch.get_num_threads() // 2,  # heuristically use half threads
             _video_width=video_width,
             _video_height=video_height,
             _video_min_dimension=video_min_dimension,
             _audio_samples=audio_samples,
             _audio_channels=audio_channels,
         )
+
         metadata = dataset.metadata
         if metadata and not os.path.exists(metadata_filepath):
             Kinetics400Dataset.save_metadata(metadata, metadata_filepath)

--- a/classy_vision/dataset/classy_ucf101.py
+++ b/classy_vision/dataset/classy_ucf101.py
@@ -93,7 +93,7 @@ class UCF101Dataset(ClassyVideoDataset):
             _precomputed_metadata=metadata,
             fold=fold,
             train=True if split == "train" else False,
-            num_workers=torch.get_num_threads(),
+            num_workers=torch.get_num_threads() // 2,  # heuristically use half threads
             _video_width=video_width,
             _video_height=video_height,
             _video_min_dimension=video_min_dimension,


### PR DESCRIPTION
Summary:
- We were forced to use `fork` mp context because `VideoClips` class instance uses too many `torch.Tensor` internally, and each `torch.Tensor` requires to use one File Descriptor (FD) when `VideoClips` instance is shared by main process and worker process in the PyTorch dataloader.
OS has a max limit of FD (by default 65K), which is often exceeded in practice.

We fix this issue in `VideoClips` in previous diff D19173248. Therefore, we no longer need to overwrite the mp context to be `fork` in `ClassyVideoDataset`. This avoid duplicating dataset instances, and reduce the CPU memory footprint.

Differential Revision: D19173397

