### PR TITLE
Make models immutable for inference and pass state explicitly

### DIFF
--- a/classy_vision/models/classy_block.py
+++ b/classy_vision/models/classy_block.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Dict
+
 import torch
 import torch.nn as nn
 
@@ -12,23 +14,30 @@ class ClassyBlock(nn.Module):
     """
     This is a thin wrapper for head execution, which records the output of
     wrapped module for executing the heads forked from this module.
+
+    `block_outs` is received as the argument and gets returned with the current block name
+    appended. Note, that we can't always rely on just modifying argument in place as it
+    doesn't work on TorchScript/Python boundary.
     """
 
     def __init__(self, name, module):
         super().__init__()
         self.name = name
-        self.output = torch.zeros(0)
         self._module = module
-        self._should_cache_output = False
 
-    def set_cache_output(self, should_cache_output: bool = True):
-        """
-        Whether to cache the output of wrapped module for head execution.
-        """
-        self._should_cache_output = should_cache_output
-
-    def forward(self, input):
+    def forward(self, input, block_outs: Dict[str, torch.Tensor]):
         output = self._module(input)
-        if self._should_cache_output:
-            self.output = output
-        return output
+        assert self.name not in block_outs
+        block_outs[self.name] = output
+        return output, block_outs
+
+
+class BlockSequential(nn.Sequential):
+    """
+    Like nn.Sequential but for ClassyBlocks - it passes through additional argument `block_outs`
+    """
+
+    def forward(self, input, block_outs: Dict[str, torch.Tensor]):
+        for module in self:
+            input, block_outs = module(input, block_outs)
+        return input, block_outs

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 from classy_vision.generic.util import is_pos_int
 
 from . import register_model
+from .classy_block import BlockSequential
 from .classy_model import ClassyModel
 
 
@@ -288,8 +289,8 @@ class ResNeXt(ClassyModel):
                 reduction=reduction,
                 final_bn_relu=final_bn_relu or (idx != (len(out_planes) - 1)),
             )
-            blocks.append(nn.Sequential(*new_block))
-        self.blocks = nn.Sequential(*blocks)
+            blocks.append(BlockSequential(*new_block))
+        self.blocks = BlockSequential(*blocks)
 
         self.out_planes = out_planes[-1]
         self._num_classes = out_planes
@@ -380,12 +381,12 @@ class ResNeXt(ClassyModel):
 
         # evaluate all residual blocks:
         # TODO: (kaizh) T43794289 exit early if there is no block that has heads
-        self.blocks(out)
+        _, block_outs = self.blocks(out, {})
 
         # By default the classification layer is implemented as one head on top
         # of the last block. The head is automatically computed right after the
         # last block.
-        head_outputs = self.execute_heads()
+        head_outputs = self.execute_heads(block_outs)
         if len(head_outputs) == 0:
             raise Exception("Expecting at least one head that generates output")
         elif len(head_outputs) == 1:

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from classy_vision.generic.util import is_pos_int, is_pos_int_list
 
 from . import register_model
+from .classy_block import BlockSequential
 from .classy_model import ClassyModel, ClassyModelEvaluationMode
 from .resnext3d_stage import ResStage
 from .resnext3d_stem import R2Plus1DStem, ResNeXt3DStem
@@ -247,9 +248,9 @@ class ResNeXt3DBase(ClassyModel):
                 x = torch.unsqueeze(x, 2)
 
         out = self.stem([x])
-        out = self.stages(out)
+        out, block_outs = self.stages(out, {})
 
-        head_outputs = self.execute_heads()
+        head_outputs = self.execute_heads(block_outs)
         if len(head_outputs) == 0:
             raise Exception("Expecting at least one head that generates output")
         elif len(head_outputs) == 1:
@@ -406,7 +407,7 @@ class ResNeXt3D(ResNeXt3DBase):
             )
             stages.append(stage)
 
-        self.stages = nn.Sequential(*stages)
+        self.stages = BlockSequential(*stages)
         self._init_parameter(zero_init_residual_transform)
 
     @classmethod

--- a/test/classy_block_test.py
+++ b/test/classy_block_test.py
@@ -31,16 +31,17 @@ class TestClassyBlock(unittest.TestCase):
             )
 
         def forward(self, x):
-            out = self.layer1(x)
-            return self.layer2(out)
+            block_outs = {}
+            out, block_outs = self.layer1(x, block_outs)
+            return self.layer2(out, block_outs)
 
     def test_head_execution(self):
         model = self.DummyTestModel()
         head = self.DummyTestHead()
         model.set_heads({"dummy_block2": {head.unique_id: head}})
         input = torch.randn(1, 2)
-        output = model(input)
-        head_output = model.execute_heads()
+        output, block_outs = model(input)
+        head_output = model.execute_heads(block_outs)
         self.assertTrue(torch.allclose(head(output), head_output["head_id"]))
 
     def test_duplicated_head_ids(self):
@@ -65,8 +66,8 @@ class TestClassyBlock(unittest.TestCase):
         )
         model.set_heads({"dummy_block2": {head.unique_id: head}})
         input = torch.randn(1, 2)
-        model(input)
-        head_outputs = model.execute_heads()
+        _, block_outs = model(input)
+        head_outputs = model.execute_heads(block_outs)
         self.assertEqual(len(head_outputs), 1, "should have output for one head")
 
         # remove all heads

--- a/test/models_resnext_test.py
+++ b/test/models_resnext_test.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pickle
 import unittest
 from test.generic.utils import compare_model_state
 
@@ -65,10 +66,18 @@ class TestResnext(unittest.TestCase):
         """
         model = build_model(model_config)
 
+        model.eval()  # eval mode to make sure batchnorm stats don't change
+
         # Verify forward pass works
         input = torch.ones([1, 3, 32, 32])
+        ser_before = pickle.dumps(model)
         output = model.forward(input)
+        ser_after = pickle.dumps(model)
+
         self.assertEqual(output.size(), (1, 1000))
+        # Ensure that execution of the forward pass is stateless - i.e. we don't
+        # set any attributes
+        self.assertEqual(ser_before, ser_after)
 
         # Verify get_set_state
         new_model = build_model(model_config)


### PR DESCRIPTION
Summary:
Usual prediction setup assumes that there's a single instance of nn.Module (scripted) and it gets invoked from multiple threads concurrently to serve prediction requests. It means that the execution of the model can't modify the module itself.

ClassyVision used to save the intermediate block outputs in module attributes violating the above assumption. This diff tries to fix it by passing the block states explicitly.

Differential Revision: D19207155

