### PR TITLE
Update torchvision versioning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-torch==1.3.1
-torchvision==0.4.2
+torch>=1.3.1
+torchvision>=0.4.2


### PR DESCRIPTION
Summary:
We are hitting an issue where torchvision current release is broken with the current version of PIL. So in OSS land, users with 0.4.2 who update their PIL version will have Classy Vision break if torchvision is included in a file.

Torchvision will fix this next week, but then we will need our requirements to be updated. Should we use >= for our requirements rather than pinning to a specific torchvision version rather than updating with each torchvision release?

RFC since the original diff (D18450381) undid the ">=" for pytorch and mentions pinning to 0.4.2, but the reasoning expressed in the diff seems to indicate that the goal was to get off torchvision nightly builds.

For more details on PILLOW issue, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#700-unreleased and https://github.com/pytorch/vision/issues/1712 and https://github.com/pytorch/vision/issues/1718

Reviewed By: vreis

Differential Revision: D19279771

