### PR TITLE
Fix MANIFEST file to include requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 graft classy_vision/templates
 graft classy_vision/configs
 include classy_train.py
+include requirements.txt
 recursive-include classy_vision/hydra *.yaml


### PR DESCRIPTION
The source distribution did not contain `requirements.txt`, which meant installing from the source downloaded from pypi wasn't possible.

Test Plan:
```bash
python setup.py sdist
cd dist/
tar -zxvf classy_vision-0.1.0.tar.gz
cd classy_vision-0.1.0
pip install .
```
