### PR TITLE
composite_scheduler docs fix

### DIFF
--- a/classy_vision/optim/param_scheduler/composite_scheduler.py
+++ b/classy_vision/optim/param_scheduler/composite_scheduler.py
@@ -27,7 +27,7 @@ class CompositeParamScheduler(ClassyParamScheduler):
     scale is 'fixed', the intermidiate scheduler will be run without any rescaling
     of the time. If interval scale is 'rescaled', intermediate scheduler is
     run such that each scheduler will start and end at the same values as it
-    would if it were the only scheduler. Default is 'fixed' for all schedulers.
+    would if it were the only scheduler. Default is 'rescaled' for all schedulers.
 
     Example:
 


### PR DESCRIPTION
Summary: The composite_scheduler docs say that the default value of interval_scaling param is "fixed" for all schedulers. However, according to the code and the test file, it is actually "rescaled" for all schedulers.

Reviewed By: lauragustafson

Differential Revision: D19384586

