### PR TITLE
Fix assertion in classy_train.py

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -88,7 +88,7 @@ def main(args, config):
     use_gpu = None
     if args.device is not None:
         use_gpu = args.device == "gpu"
-        assert torch.cuda.is_available(), "CUDA is unavailable"
+        assert torch.cuda.is_available() or not use_gpu, "CUDA is unavailable"
 
     # LocalTrainer is used for a single node. DistributedTrainer will setup
     # training to use PyTorch's DistributedDataParallel.


### PR DESCRIPTION
Summary:
CUDA doesn't have to be available when training on CPUs.
Fix assertion introduced by https://github.com/facebookresearch/ClassyVision/pull/332

Differential Revision: D19392454

