### PR TITLE
Fix bug in ClassificationTask caused by AMP change

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -248,9 +248,6 @@ class ClassificationTask(ClassyTask):
 
         Warning: apex needs to be installed to utilize this feature.
         """
-        if not apex_available:
-            raise RuntimeError("apex is not installed, cannot enable amp")
-
         if opt_level not in [None, "O0", "O1", "O2", "O3"]:
             raise ValueError(f"Unsupported opt_level: {opt_level}")
 
@@ -259,6 +256,9 @@ class ClassificationTask(ClassyTask):
         if opt_level is None:
             logging.info(f"AMP disabled")
         else:
+            if not apex_available:
+                raise RuntimeError("apex is not installed, cannot enable amp")
+
             logging.info(f"AMP enabled with opt_level {opt_level}")
         return self
 


### PR DESCRIPTION
Summary: Fix bug introduced by the AMP addition which causes ClassificationTask to raise an exception when apex is not installed, even when it is not needed

Differential Revision: D19395156

