### PR TITLE
Update torchvision dependency and remove pillow pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Classy Vision is beta software. The project is under active development and our 
 ## Installation
 
 #### Installation Requirements
-Make sure you have an up-to-date installation of PyTorch (1.3.1), Python (3.6) and torchvision (1.4). If you want to use GPUs, then a CUDA installation (10.1) is also required.
+Make sure you have an up-to-date installation of PyTorch (1.4), Python (3.6) and torchvision (0.5). If you want to use GPUs, then a CUDA installation (10.1) is also required.
 
 #### Installing the latest stable release
 To install Classy Vision via pip:
@@ -27,7 +27,7 @@ pip install classy_vision
 
 To install Classy Vision via conda:
 ```bash
-conda install -c conda-forge classy_vision 
+conda install -c conda-forge classy_vision
 ```
 
 #### Manual install of latest commit on master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-torch>=1.3.1
-torchvision>=0.4.2
-Pillow==6.2.0
+torch>=1.4
+torchvision>=0.5


### PR DESCRIPTION
Summary:
Update `torchvision` dependency to `>= 0.5` and remove pinned `Pillow` version.
We shouldn't need to do this for future versions, needed it this time because of the incompatibility issue with `Pillow 7.0.0` and `torchvision 0.4.2`.

Differential Revision: D19430860

