### PR TITLE
Make accuracy meter consistent with one-hot targets

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -720,6 +720,28 @@ def convert_to_one_hot(targets, classes):
     return one_hot_targets
 
 
+def maybe_convert_to_one_hot(target, model_output):
+    """
+    This function infers whether target is integer or 0/1 encoded
+    and converts it to 0/1 encoding if necessary.
+    """
+    target_shape_list = list(target.size())
+
+    if len(target_shape_list) == 1 or (
+        len(target_shape_list) == 2 and target_shape_list[1] == 1
+    ):
+        target = convert_to_one_hot(target.view(-1, 1), model_output.shape[1])
+
+    assert (target.shape == model_output.shape) and (
+        torch.min(target.eq(0) + target.eq(1)) == 1
+    ), (
+        "Target must be one-hot/multi-label encoded and of the "
+        "same shape as model_output."
+    )
+
+    return target
+
+
 def bind_method_to_class(method, cls):
     """
     Binds an already bound method to the provided class.

--- a/classy_vision/meters/precision_meter.py
+++ b/classy_vision/meters/precision_meter.py
@@ -8,7 +8,7 @@ from typing import Any, Dict
 
 import torch
 from classy_vision.generic.distributed_util import all_reduce_sum
-from classy_vision.generic.util import convert_to_one_hot, is_pos_int
+from classy_vision.generic.util import is_pos_int, maybe_convert_to_one_hot
 from classy_vision.meters import ClassyMeter
 
 from . import register_meter
@@ -21,24 +21,16 @@ class PrecisionAtKMeter(ClassyMeter):
     image classification task. Note, ties are resolved randomly.
     """
 
-    def __init__(self, topk, target_is_one_hot=True, num_classes=-1):
+    def __init__(self, topk):
         """
         args:
             topk: list of int `k` values.
-            target_is_one_hot: boolean, if class labels are one-hot encoded.
-            num_classes: int, number of classes.
         """
         assert isinstance(topk, list), "topk must be a list"
         assert len(topk) > 0, "topk list should have at least one element"
         assert [is_pos_int(x) for x in topk], "each value in topk must be >= 1"
-        if not target_is_one_hot:
-            assert (
-                type(num_classes) == int and num_classes > 0
-            ), "num_classes must be positive integer"
 
         self._topk = topk
-        self._target_is_one_hot = target_is_one_hot
-        self._num_classes = num_classes
 
         # _total_* variables store running, in-sync totals for the
         # metrics. These should not be communicated / summed.
@@ -65,11 +57,7 @@ class PrecisionAtKMeter(ClassyMeter):
         Returns:
             A PrecisionAtKMeter instance.
         """
-        return cls(
-            topk=config["topk"],
-            target_is_one_hot=config.get("target_is_one_hot", True),
-            num_classes=config.get("num_classes", -1),
-        )
+        return cls(topk=config["topk"])
 
     @property
     def name(self):
@@ -147,29 +135,19 @@ class PrecisionAtKMeter(ClassyMeter):
         args:
             model_output: tensor of shape (B, C) where each value is
                           either logit or class probability.
-            target:       tensor of shape (B, C), one-hot encoded
-                          or integer encoded or tensor of shape (B),
-                          integer encoded.
-            Note: For binary classification, C=2.
-                  For integer encoded target, C=1.
+            target:       tensor of shape (B, C), which is one-hot /
+                          multi-label encoded, or tensor of shape (B) /
+                          (B, 1), integer encoded
         """
-        target_shape_list = list(target.size())
-
-        if self._target_is_one_hot is False:
-            assert len(target_shape_list) == 1 or (
-                len(target_shape_list) == 2 and target_shape_list[1] == 1
-            ), "Integer encoded target must be single labeled"
-            target = convert_to_one_hot(target.view(-1, 1), self._num_classes)
-
-        assert (
-            torch.min(target.eq(0) + target.eq(1)) == 1
-        ), "Target must be one-hot encoded vector"
-
         # Due to dummy samples, in some corner cases, the whole batch could
         # be dummy samples, in that case we want to not update meters on that
         # process
         if model_output.shape[0] == 0:
             return
+
+        # Convert target to 0/1 encoding if isn't
+        target = maybe_convert_to_one_hot(target, model_output)
+
         _, pred_classes = model_output.topk(
             max(self._topk), dim=1, largest=True, sorted=True
         )

--- a/classy_vision/meters/video_accuracy_meter.py
+++ b/classy_vision/meters/video_accuracy_meter.py
@@ -15,7 +15,7 @@ from .video_meter import VideoMeter
 
 @register_meter("video_accuracy")
 class VideoAccuracyMeter(VideoMeter):
-    """Meter to calculate top-k video-level accuracy for single label
+    """Meter to calculate top-k video-level accuracy for single/multi label
        video classification task.
 
     Video-level accuarcy is computed by averaging clip-level predictions and

--- a/test/meters_precision_meter_test.py
+++ b/test/meters_precision_meter_test.py
@@ -169,7 +169,7 @@ class TestPrecisionAtKMeter(ClassificationMeterTest):
         This test verifies that the meter works as expected on a single
         update + reset + same single update.
         """
-        meter = PrecisionAtKMeter(topk=[1, 2], target_is_one_hot=False, num_classes=3)
+        meter = PrecisionAtKMeter(topk=[1, 2])
 
         # Batchsize = 2, num classes = 3, score is probability of class
         model_outputs = [
@@ -195,7 +195,7 @@ class TestPrecisionAtKMeter(ClassificationMeterTest):
         This test verifies that the meter works as expected on a single
         update + reset + same single update with one dimensional targets.
         """
-        meter = PrecisionAtKMeter(topk=[1, 2], target_is_one_hot=False, num_classes=3)
+        meter = PrecisionAtKMeter(topk=[1, 2])
 
         # Batchsize = 2, num classes = 3, score is probability of class
         model_outputs = [

--- a/test/meters_recall_meter_test.py
+++ b/test/meters_recall_meter_test.py
@@ -170,7 +170,7 @@ class TestRecallAtKMeter(ClassificationMeterTest):
         This test verifies that the meter works as expected on a single
         update + reset + same single update.
         """
-        meter = RecallAtKMeter(topk=[1, 2], target_is_one_hot=False, num_classes=3)
+        meter = RecallAtKMeter(topk=[1, 2])
 
         # Batchsize = 2, num classes = 3, score is probability of class
         model_outputs = [
@@ -191,7 +191,7 @@ class TestRecallAtKMeter(ClassificationMeterTest):
 
         self.meter_update_and_reset_test(meter, model_outputs, targets, expected_value)
 
-    def test_non_onehot_target(self):
+    def test_non_onehot_target_one_dim_target(self):
         """
         This test verifies that the meter works as expected on a single
         update + reset + same single update with one dimensional targets.

--- a/test/meters_video_accuracy_meter_test.py
+++ b/test/meters_video_accuracy_meter_test.py
@@ -99,8 +99,8 @@ class TestVideoAccuracyMeter(ClassificationMeterTest):
             [[3, 2, 1], [3, 1, 2], [1, 2, 2], [1, 2, 3], [2, 2, 2], [1, 3, 2]],
             dtype=torch.float,
         )
-        # Target has 2 dimensions instead of expected 1
-        target = torch.tensor([[0, 1, 2], [0, 1, 2]])
+        # Target has 3 dimensions instead of expected 1 or 2
+        target = torch.tensor([[[0, 1, 2], [0, 1, 2]]])
 
         self.meter_invalid_meter_input_test(meter, model_output, target)
         # Target of clips from the same video is not consistent


### PR DESCRIPTION
Summary:
This diff makes accuracy meter consistent with both class index and one-hot targets. When the targets are single-labeled, this meter works exactly as present. For multi-labeled targets, accuracy at top k considers a sample as correctly classified if it outputs atleast one correct class within top k.

This diff also makes both accuracy and PR meters infer target type (integer or 0/1) and calculate metrics accordingly.

Reviewed By: mannatsingh

Differential Revision: D19388765

