### PR TITLE
Remove perf instrumentation from train_step

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -52,7 +52,6 @@ from classy_vision.hooks import (
     ProfilerHook,
     ProgressBarHook,
     TensorboardPlotHook,
-    TimeMetricsHook,
     VisdomHook,
 )
 from classy_vision.tasks import FineTuningTask, build_task
@@ -107,7 +106,7 @@ def main(args, config):
 
 
 def configure_hooks(args, config):
-    hooks = [LossLrMeterLoggingHook(args.log_freq), TimeMetricsHook()]
+    hooks = [LossLrMeterLoggingHook(args.log_freq)]
 
     # Make a folder to store checkpoints and tensorboard logging outputs
     suffix = datetime.now().isoformat()


### PR DESCRIPTION
Summary:
We have decided this instrumentation makes the code too hard to follow.
Whoever is debugging performance for a given run can instrument the code
themselves. If that turns out to be really common in the future, we can
include a new task that has the instrumentation built-in.

Differential Revision: D19509685

