### PR TITLE
Remove unused hook methods

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -52,7 +52,6 @@ from classy_vision.hooks import (
     ProfilerHook,
     ProgressBarHook,
     TensorboardPlotHook,
-    TimeMetricsHook,
     VisdomHook,
 )
 from classy_vision.tasks import FineTuningTask, build_task
@@ -107,7 +106,7 @@ def main(args, config):
 
 
 def configure_hooks(args, config):
-    hooks = [LossLrMeterLoggingHook(args.log_freq), TimeMetricsHook()]
+    hooks = [LossLrMeterLoggingHook(args.log_freq)]
 
     # Make a folder to store checkpoints and tensorboard logging outputs
     suffix = datetime.now().isoformat()

--- a/classy_vision/hooks/checkpoint_hook.py
+++ b/classy_vision/hooks/checkpoint_hook.py
@@ -23,12 +23,9 @@ class CheckpointHook(ClassyHook):
     Saves the checkpoints in checkpoint_folder.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_update = ClassyHook._noop
     on_end = ClassyHook._noop
 

--- a/classy_vision/hooks/classy_hook.py
+++ b/classy_vision/hooks/classy_hook.py
@@ -16,13 +16,10 @@ class ClassyHookFunctions(Enum):
     Enumeration of all the hook functions in the ClassyHook class.
     """
 
-    on_rendezvous = auto()
     on_start = auto()
     on_phase_start = auto()
-    on_sample = auto()
     on_forward = auto()
     on_loss_and_meter = auto()
-    on_backward = auto()
     on_update = auto()
     on_phase_end = auto()
     on_end = auto()
@@ -47,8 +44,8 @@ class ClassyHook(ABC):
     Hooks allow to inject behavior at different places of the training loop, which
     are listed below in the chronological order.
 
-        on_start -> on_phase_start -> on_sample -> on_forward -> on_loss_and_meter ->
-            on_backward -> on_update -> on_phase_end -> on_end
+        on_start -> on_phase_start -> on_forward -> on_loss_and_meter ->
+            on_update -> on_phase_end -> on_end
 
     Deriving classes should call ``super().__init__()`` and store any state in
     ``self.state``. Any state added to this property should be serializable.
@@ -83,13 +80,6 @@ class ClassyHook(ABC):
         return cls.__name__
 
     @abstractmethod
-    def on_rendezvous(
-        self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
-    ) -> None:
-        """Called when the trainers rendezvous."""
-        pass
-
-    @abstractmethod
     def on_start(
         self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
     ) -> None:
@@ -104,13 +94,6 @@ class ClassyHook(ABC):
         pass
 
     @abstractmethod
-    def on_sample(
-        self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
-    ) -> None:
-        """Called each time trainer obtained a sample from the dataset."""
-        pass
-
-    @abstractmethod
     def on_forward(
         self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
     ) -> None:
@@ -122,13 +105,6 @@ class ClassyHook(ABC):
         self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
     ) -> None:
         """Called each time after a loss has been computed and meters are updated."""
-        pass
-
-    @abstractmethod
-    def on_backward(
-        self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
-    ) -> None:
-        """Called each time a backward step is performed on the loss."""
         pass
 
     @abstractmethod

--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -27,11 +27,8 @@ class ExponentialMovingAverageModelHook(ClassyHook):
         increase memory usage significantly.
     """
 
-    on_rendezvous = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_end = ClassyHook._noop
 
     def __init__(

--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -17,12 +17,9 @@ class LossLrMeterLoggingHook(ClassyHook):
     Logs the loss, optimizer LR, and meters. Logs at the end of a phase.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_start = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_end = ClassyHook._noop
 
     def __init__(self, log_freq: Optional[int] = None) -> None:

--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -17,12 +17,9 @@ class ModelComplexityHook(ClassyHook):
     Logs the number of paramaters and forward pass FLOPs of the model.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_update = ClassyHook._noop
     on_phase_end = ClassyHook._noop
     on_end = ClassyHook._noop

--- a/classy_vision/hooks/model_tensorboard_hook.py
+++ b/classy_vision/hooks/model_tensorboard_hook.py
@@ -27,12 +27,9 @@ class ModelTensorboardHook(ClassyHook):
     ://www.tensorflow.org/tensorboard`>_.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_update = ClassyHook._noop
     on_phase_end = ClassyHook._noop
     on_end = ClassyHook._noop

--- a/classy_vision/hooks/profiler_hook.py
+++ b/classy_vision/hooks/profiler_hook.py
@@ -18,12 +18,9 @@ class ProfilerHook(ClassyHook):
         the time breakdown in milliseconds of forward/backward pass.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_update = ClassyHook._noop
     on_phase_end = ClassyHook._noop
     on_end = ClassyHook._noop

--- a/classy_vision/hooks/progress_bar_hook.py
+++ b/classy_vision/hooks/progress_bar_hook.py
@@ -24,12 +24,9 @@ class ProgressBarHook(ClassyHook):
     Displays a progress bar to show progress in processing batches.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_end = ClassyHook._noop
 
     def __init__(self) -> None:

--- a/classy_vision/hooks/tensorboard_plot_hook.py
+++ b/classy_vision/hooks/tensorboard_plot_hook.py
@@ -32,11 +32,8 @@ class TensorboardPlotHook(ClassyHook):
     Global steps are counted in terms of the number of samples processed.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
     on_end = ClassyHook._noop
 

--- a/classy_vision/hooks/time_metrics_hook.py
+++ b/classy_vision/hooks/time_metrics_hook.py
@@ -19,11 +19,8 @@ class TimeMetricsHook(ClassyHook):
     Computes and prints performance metrics. Logs at the end of a phase.
     """
 
-    on_rendezvous = ClassyHook._noop
     on_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_update = ClassyHook._noop
     on_end = ClassyHook._noop
 

--- a/classy_vision/hooks/visdom_hook.py
+++ b/classy_vision/hooks/visdom_hook.py
@@ -31,13 +31,10 @@ class VisdomHook(ClassyHook):
 
     """
 
-    on_rendezvous = ClassyHook._noop
     on_start = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_sample = ClassyHook._noop
     on_forward = ClassyHook._noop
     on_loss_and_meter = ClassyHook._noop
-    on_backward = ClassyHook._noop
     on_update = ClassyHook._noop
     on_end = ClassyHook._noop
 

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -620,8 +620,6 @@ class ClassificationTask(ClassyTask):
             + "'target' keys"
         )
 
-        self.run_hooks(local_variables, ClassyHookFunctions.on_sample.name)
-
         # Copy sample to GPU
         local_variables["target"] = local_variables["sample"]["target"]
         if use_gpu:
@@ -674,8 +672,6 @@ class ClassificationTask(ClassyTask):
                     scaled_loss.backward()
             else:
                 self.optimizer.backward(local_variables["local_loss"])
-
-            self.run_hooks(local_variables, ClassyHookFunctions.on_backward.name)
 
             self.optimizer.update_schedule_on_step(self.where)
             self.optimizer.step()


### PR DESCRIPTION
Summary:
There are no hooks that use these methods. My goal is to remove all hook calls
from within train_step, so we can simplify the process of writing new tasks.
Start with these three that are trivial.

Differential Revision: D19520689

