### PR TITLE
Calculate activations to estimate model complexity

### DIFF
--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -242,7 +242,7 @@ def get_test_mlp_task_config():
 
 def get_test_model_configs():
     return [
-        # resnet 101
+        # resnet 50
         {
             "name": "resnet",
             "num_blocks": [3, 4, 6, 3],
@@ -257,10 +257,25 @@ def get_test_model_configs():
                 }
             ],
         },
-        # resnext 101 32-4d
+        # resnet 101
+        {
+            "name": "resnet",
+            "num_blocks": [3, 4, 23, 3],
+            "small_input": False,
+            "heads": [
+                {
+                    "name": "fully_connected",
+                    "unique_id": "default_head",
+                    "num_classes": 1000,
+                    "fork_block": "block3-2",
+                    "in_plane": 2048,
+                }
+            ],
+        },
+        # resnext 101 32x4d
         {
             "name": "resnext",
-            "num_blocks": [3, 4, 6, 3],
+            "num_blocks": [3, 4, 23, 3],
             "base_width_and_cardinality": [4, 32],
             "small_input": False,
             "heads": [

--- a/test/generic_profiler_test.py
+++ b/test/generic_profiler_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from test.generic.config_utils import get_test_model_configs
+
+from classy_vision.generic.profiler import (
+    compute_activations,
+    compute_flops,
+    count_params,
+)
+from classy_vision.models import build_model
+
+
+class TestProfilerFunctions(unittest.TestCase):
+    def test_complexity_calculation(self) -> None:
+        model_configs = get_test_model_configs()
+        # make sure there are three configs returned
+        self.assertEqual(len(model_configs), 3)
+
+        # expected values which allow minor deviations from model changes
+        # we only test at the 10^6 scale
+        expected_m_flops = [4122, 7850, 8034]
+        expected_m_params = [25, 44, 44]
+        expected_m_activations = [11, 16, 21]
+
+        for model_config, m_flops, m_params, m_activations in zip(
+            model_configs, expected_m_flops, expected_m_params, expected_m_activations
+        ):
+            model = build_model(model_config)
+            self.assertEqual(compute_activations(model) // 10 ** 6, m_activations)
+            self.assertEqual(compute_flops(model) // 10 ** 6, m_flops)
+            self.assertEqual(count_params(model) // 10 ** 6, m_params)

--- a/test/manual/hooks_model_complexity_hook_test.py
+++ b/test/manual/hooks_model_complexity_hook_test.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import re
 import unittest
 from test.generic.config_utils import get_test_classy_task, get_test_model_configs
 
@@ -13,51 +12,21 @@ from classy_vision.models import build_model
 
 
 class TestModelComplexityHook(unittest.TestCase):
-    def test_model_complexity(self) -> None:
-        """
-        Test that the number of parameters and the FLOPs are calcuated correctly.
-        """
+    def test_model_complexity_hook(self) -> None:
         model_configs = get_test_model_configs()
-        expected_mega_flops = [4122, 4274, 106152]
-        expected_params = [25557032, 25028904, 43009448]
-        local_variables = {}
 
         task = get_test_classy_task()
         task.prepare()
 
+        local_variables = {}
+
         # create a model complexity hook
         model_complexity_hook = ModelComplexityHook()
 
-        for model_config, mega_flops, params in zip(
-            model_configs, expected_mega_flops, expected_params
-        ):
+        for model_config in model_configs:
             model = build_model(model_config)
 
             task.base_model = model
 
-            with self.assertLogs() as log_watcher:
+            with self.assertLogs():
                 model_complexity_hook.on_start(task, local_variables)
-
-            # there should be 2 log statements generated
-            self.assertEqual(len(log_watcher.output), 2)
-
-            # first statement - either the MFLOPs or a warning
-            if mega_flops is not None:
-                match = re.search(
-                    r"FLOPs for forward pass: (?P<mega_flops>[-+]?\d*\.\d+|\d+) MFLOPs",
-                    log_watcher.output[0],
-                )
-                self.assertIsNotNone(match)
-                self.assertEqual(mega_flops, float(match.group("mega_flops")))
-            else:
-                self.assertIn(
-                    "Model contains unsupported modules", log_watcher.output[0]
-                )
-
-            # second statement
-            match = re.search(
-                r"Number of parameters in model: (?P<params>[-+]?\d*\.\d+|\d+)",
-                log_watcher.output[1],
-            )
-            self.assertIsNotNone(match)
-            self.assertEqual(params, float(match.group("params")))


### PR DESCRIPTION
Summary:
- Added a `compute_activations` function to `classy_vision.generic.profiler` which calculates the activations for a model. `ModelComplexityHook` prints out the activations as well.
- Removed all the regex grepping in `hooks_model_complexity_hook_test` to check the computed values and instead added a separate test to do that.

Differential Revision: D19526702

