### PR TITLE
Add license to MANIFEST.in, bump master to v0.3.0.dev

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ graft classy_vision/templates
 graft classy_vision/configs
 include classy_train.py
 include requirements.txt
+include LICENSE
 recursive-include classy_vision/hydra *.yaml

--- a/classy_vision/__init__.py
+++ b/classy_vision/__init__.py
@@ -4,4 +4,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.2.0.dev"
+__version__ = "0.3.0.dev"


### PR DESCRIPTION
Test plan:
```
python setup.py sdist
cd dist/
tar -zxvf classy_vision-0.3.0.dev0.tar.gz
cd classy_vision-0.3.0.dev0
ls
less classy_vision/__init__.py
```