### PR TITLE
Create a loss that deals with multiple outputs by using the first output only

### DIFF
--- a/classy_vision/losses/__init__.py
+++ b/classy_vision/losses/__init__.py
@@ -98,6 +98,7 @@ import_all_modules(FILE_ROOT, "classy_vision.losses")
 
 from .barron_loss import BarronLoss  # isort:skip
 from .label_smoothing_loss import LabelSmoothingCrossEntropyLoss  # isort:skip
+from .multi_output_first_value_loss import MultiOutputFirstValueLoss  # isort:skip
 from .multi_output_sum_loss import MultiOutputSumLoss  # isort:skip
 from .soft_target_cross_entropy_loss import SoftTargetCrossEntropyLoss  # isort:skip
 from .sum_arbitrary_loss import SumArbitraryLoss  # isort:skip
@@ -107,6 +108,7 @@ __all__ = [
     "BarronLoss",
     "ClassyLoss",
     "LabelSmoothingCrossEntropyLoss",
+    "MultiOutputFirstValueLoss",
     "MultiOutputSumLoss",
     "SoftTargetCrossEntropyLoss",
     "SumArbitraryLoss",

--- a/classy_vision/losses/multi_output_first_value_loss.py
+++ b/classy_vision/losses/multi_output_first_value_loss.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Dict
+
+import torch
+
+from . import ClassyLoss, build_loss, register_loss
+
+
+@register_loss("multi_output_first_value_loss")
+class MultiOutputFirstValueLoss(ClassyLoss):
+    """
+    Applies the provided loss to the first of outputs (or single output).
+    """
+
+    def __init__(self, loss, main_output_name="data") -> None:
+        super().__init__()
+
+        self._loss = loss
+        self._main_output_name = main_output_name
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "MultiOutputFirstValueLoss":
+        """Instantiates a MultiOutputFirstValueLoss from a configuration.
+
+        Args:
+            config: A configuration for a MultiOutpuSumLoss.
+                See :func:`__init__` for parameters expected in the config.
+
+        Returns:
+            A MultiOutputFirstValueLoss instance.
+        """
+        assert (
+            type(config["loss"]) == dict
+        ), "loss must be a dict containing a configuration for a registered loss"
+        return cls(
+            loss=build_loss(config["loss"]),
+            main_output_name=config.get("main_output_name", "data"),
+        )
+
+    def forward(self, output, target):
+        if torch.is_tensor(output):
+            output = [output]
+
+        assert isinstance(
+            output, (list, tuple, dict)
+        ), "Model output must be a list of a tuple for MultiOutputFirstValueLoss"
+
+        if isinstance(output, dict):
+            assert self._main_output_name in output, (
+                "%s must be among model outputs" % self._main_output_name
+            )
+            output = output[self._main_output_name]
+        else:
+            output = output[0]
+
+        return self._loss(output, target)

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -684,6 +684,8 @@ class ClassificationTask(ClassyTask):
         return self.loss(model_output, sample["target"])
 
     def update_meters(self, model_output, sample):
+        if isinstance(model_output, dict):
+            model_output = model_output["data"]
         target = sample["target"].detach().cpu()
         model_output = model_output.detach().cpu()
 


### PR DESCRIPTION
Summary:
We need FAIM model to output attention weights as well, so we can use them for localizations. For instance, we can save the to hive with WriteToHiveHook and evaluate.

However classy vision passes model output directly to loss function, which in most cases assumes a single output:  https://fburl.com/diffusion/68zqh9m6

To get around this, we need a loss that just takes the first output from the model.

Differential Revision: D19582685

