### PR TITLE
Use fvcore PathManager to support other file protocols

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch>=1.4
 torchvision>=0.5
+fvcore


### PR DESCRIPTION
Summary:
For doing file system operations during checkpointing, instead of using `os.` and `os.path.` functions, use `fvcore`'s `PathManager`, which allows defining operations for additional protocols as well.
- fvcore is now a dependency for Classy Vision

Differential Revision: D19645211

