### PR TITLE
Tolerate Linear layers without bias parameters in profiler

### DIFF
--- a/classy_vision/generic/profiler.py
+++ b/classy_vision/generic/profiler.py
@@ -166,7 +166,7 @@ def _layer_flops(layer, x, _):
     # linear layer:
     elif layer_type in ["Linear"]:
         weight_ops = layer.weight.numel()
-        bias_ops = layer.bias.numel()
+        bias_ops = layer.bias.numel() if layer.bias is not None else 0
         return x.size()[0] * (weight_ops + bias_ops)
 
     # 2D/3D batch normalization:

--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -32,51 +32,53 @@ class ModelComplexityHook(ClassyHook):
         self, task: "tasks.ClassyTask", local_variables: Dict[str, Any]
     ) -> None:
         """Measure number of parameters, FLOPs and activations."""
-        self.num_flops = None
+        self.num_flops = 0
+        self.num_activations = 0
+        self.num_parameters = 0
         try:
-            self.num_flops = compute_flops(
-                task.base_model,
-                input_shape=task.base_model.input_shape,
-                input_key=task.base_model.input_key
-                if hasattr(task.base_model, "input_key")
-                else None,
-            )
-            if self.num_flops is None:
-                logging.info("FLOPs for forward pass: skipped.")
-            else:
-                logging.info(
-                    "FLOPs for forward pass: %d MFLOPs" % (float(self.num_flops) / 1e6)
+            self.num_parameters = count_params(task.base_model)
+            logging.info("Number of parameters in model: %d" % self.num_parameters)
+            try:
+                self.num_flops = compute_flops(
+                    task.base_model,
+                    input_shape=task.base_model.input_shape,
+                    input_key=task.base_model.input_key
+                    if hasattr(task.base_model, "input_key")
+                    else None,
                 )
-        except NotImplementedError:
-            logging.warning(
-                """Model contains unsupported modules:
-            Could not compute FLOPs for model forward pass. Exception:""",
-                exc_info=True,
-            )
-        self.num_activations = None
-        try:
-            self.num_activations = compute_activations(
-                task.base_model,
-                input_shape=task.base_model.input_shape,
-                input_key=task.base_model.input_key
-                if hasattr(task.base_model, "input_key")
-                else None,
-            )
-            logging.info(f"Number of activations in model: {self.num_activations}")
-        except NotImplementedError:
-            logging.info(
-                "Model does not implement input_shape. Skipping activation calculation."
-            )
-        self.num_parameters = count_params(task.base_model)
-        logging.info("Number of parameters in model: %d" % self.num_parameters)
+                if self.num_flops is None:
+                    logging.info("FLOPs for forward pass: skipped.")
+                    self.num_flops = 0
+                else:
+                    logging.info(
+                        "FLOPs for forward pass: %d MFLOPs"
+                        % (float(self.num_flops) / 1e6)
+                    )
+            except NotImplementedError:
+                logging.warning(
+                    """Model contains unsupported modules:
+                Could not compute FLOPs for model forward pass. Exception:""",
+                    exc_info=True,
+                )
+            try:
+                self.num_activations = compute_activations(
+                    task.base_model,
+                    input_shape=task.base_model.input_shape,
+                    input_key=task.base_model.input_key
+                    if hasattr(task.base_model, "input_key")
+                    else None,
+                )
+                logging.info(f"Number of activations in model: {self.num_activations}")
+            except NotImplementedError:
+                logging.info(
+                    "Model does not implement input_shape. Skipping activation calculation."
+                )
+        except Exception:
+            logging.exception("Unexpected failure estimating model complexity.")
 
     def get_summary(self):
         return {
-            "FLOPS(M)": float(self.num_flops) / 1e6
-            if self.num_flops is not None
-            else 0,
-            "num_activations(M)": float(self.num_activations) / 1e6
-            if self.num_activations is not None
-            else 0,
+            "FLOPS(M)": float(self.num_flops) / 1e6,
+            "num_activations(M)": float(self.num_activations) / 1e6,
             "num_parameters(M)": float(self.num_parameters) / 1e6,
         }


### PR DESCRIPTION
Summary: Handle `bias = None` as a registered parameter, as used in `Lienar(..., bias=False)`.

Differential Revision: D19700470

