### PR TITLE
Move hook calls to task

### DIFF
--- a/classy_vision/hooks/__init__.py
+++ b/classy_vision/hooks/__init__.py
@@ -8,17 +8,23 @@ from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
 
-from .checkpoint_hook import CheckpointHook
-from .classy_hook import ClassyHook, ClassyHookFunctions
-from .exponential_moving_average_model_hook import ExponentialMovingAverageModelHook
-from .loss_lr_meter_logging_hook import LossLrMeterLoggingHook
-from .model_complexity_hook import ModelComplexityHook
-from .model_tensorboard_hook import ModelTensorboardHook
-from .profiler_hook import ProfilerHook
-from .progress_bar_hook import ProgressBarHook
-from .tensorboard_plot_hook import TensorboardPlotHook
-from .time_metrics_hook import TimeMetricsHook
-from .visdom_hook import VisdomHook
+
+# The order of imports matters here because of a circular dependency. constants
+# must come before any hook
+from .constants import ClassyHookFunctions  # isort:skip
+from .checkpoint_hook import CheckpointHook  # isort:skip
+from .classy_hook import ClassyHook  # isort:skip
+from .exponential_moving_average_model_hook import (  # isort:skip
+    ExponentialMovingAverageModelHook,
+)
+from .loss_lr_meter_logging_hook import LossLrMeterLoggingHook  # isort:skip
+from .model_complexity_hook import ModelComplexityHook  # isort:skip
+from .model_tensorboard_hook import ModelTensorboardHook  # isort:skip
+from .profiler_hook import ProfilerHook  # isort:skip
+from .progress_bar_hook import ProgressBarHook  # isort:skip
+from .tensorboard_plot_hook import TensorboardPlotHook  # isort:skip
+from .time_metrics_hook import TimeMetricsHook  # isort:skip
+from .visdom_hook import VisdomHook  # isort:skip
 
 
 __all__ = [

--- a/classy_vision/hooks/classy_hook.py
+++ b/classy_vision/hooks/classy_hook.py
@@ -5,24 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from abc import ABC, abstractmethod
-from enum import Enum, auto
 from typing import Any, Dict
 
 from classy_vision import tasks
-
-
-class ClassyHookFunctions(Enum):
-    """
-    Enumeration of all the hook functions in the ClassyHook class.
-    """
-
-    on_start = auto()
-    on_phase_start = auto()
-    on_forward = auto()
-    on_loss_and_meter = auto()
-    on_update = auto()
-    on_phase_end = auto()
-    on_end = auto()
 
 
 class ClassyHookState:

--- a/classy_vision/hooks/constants.py
+++ b/classy_vision/hooks/constants.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum, auto
+
+
+class ClassyHookFunctions(Enum):
+    """
+    Enumeration of all the hook functions in the ClassyHook class.
+    """
+
+    on_start = auto()
+    on_phase_start = auto()
+    on_forward = auto()
+    on_loss_and_meter = auto()
+    on_update = auto()
+    on_phase_end = auto()
+    on_end = auto()

--- a/classy_vision/tasks/classy_task.py
+++ b/classy_vision/tasks/classy_task.py
@@ -36,17 +36,6 @@ class ClassyTask(ABC):
         """
         raise NotImplementedError()
 
-    @abstractmethod
-    def init_distributed_data_parallel_model(self) -> None:
-        """
-        Initialize
-        `torch.nn.parallel.distributed.DistributedDataParallel <https://pytorch.org/
-        docs/stable/nn.html#distributeddataparallel>`_.
-
-        Needed for distributed training. This is where a model should be wrapped by DDP.
-        """
-        pass
-
     @property
     @abstractmethod
     def where(self) -> float:
@@ -55,16 +44,6 @@ class ClassyTask(ABC):
 
         Returns:
             A float in [0, 1) which tells the training progress.
-        """
-        pass
-
-    @abstractmethod
-    def advance_phase(self) -> None:
-        """
-        Advance the task a phase.
-
-        Called when one phase of reading from
-        :class:`classy_vision.dataset.ClassyDataset` is over.
         """
         pass
 
@@ -117,7 +96,7 @@ class ClassyTask(ABC):
         Prepares the task for training.
 
         Will be called by the :class:`classy_vision.trainer.ClassyTrainer` to
-        prepare the task.
+        prepare the task, before on_start is called.
 
         Args:
             num_dataloader_workers: Number of workers to create for the dataloaders
@@ -138,6 +117,42 @@ class ClassyTask(ABC):
             use_gpu: True if training on GPUs, False otherwise
             local_variables: Local variables created in the function. Can be passed to
                 custom :class:`classy_vision.hooks.ClassyHook`.
+        """
+        pass
+
+    @abstractmethod
+    def on_start(self, local_variables):
+        """
+        Start training.
+
+        Called by :class:`classy_vision.trainer.ClassyTrainer` before training starts.
+        """
+        pass
+
+    @abstractmethod
+    def on_phase_start(self, local_variables):
+        """
+        Epoch start.
+
+        Called by :class:`classy_vision.trainer.ClassyTrainer` before each epoch starts.
+        """
+        pass
+
+    @abstractmethod
+    def on_phase_end(self, local_variables):
+        """
+        Epoch end.
+
+        Called by :class:`classy_vision.trainer.ClassyTrainer` after each epoch ends.
+        """
+        pass
+
+    @abstractmethod
+    def on_end(self, local_variables):
+        """
+        Training end.
+
+        Called by :class:`classy_vision.trainer.ClassyTrainer` after training ends.
         """
         pass
 


### PR DESCRIPTION
Summary:
This cleans up the interface between ClassyTrainer and ClassyTask. It was
always weird to have things like "advance_phase" or "run_hooks" in ClassyTask,
now thats hidden within ClassificationTask.

Now the trainer simply notifies the task on the beginning/end of each epoch
and start/end training.

Differential Revision: D19739096

