### PR TITLE
Kill references to dummy samples

### DIFF
--- a/classy_vision/meters/accuracy_meter.py
+++ b/classy_vision/meters/accuracy_meter.py
@@ -138,12 +138,6 @@ class AccuracyMeter(ClassyMeter):
                           multi-label encoded, or tensor of shape (B) /
                           (B, 1), integer encoded
         """
-        # Due to dummy samples, in some corner cases, the whole batch could
-        # be dummy samples, in that case we want to not update meters on that
-        # process
-        if model_output.shape[0] == 0:
-            return
-
         # Convert target to 0/1 encoding if isn't
         target = maybe_convert_to_one_hot(target, model_output)
 

--- a/classy_vision/meters/precision_meter.py
+++ b/classy_vision/meters/precision_meter.py
@@ -139,12 +139,6 @@ class PrecisionAtKMeter(ClassyMeter):
                           multi-label encoded, or tensor of shape (B) /
                           (B, 1), integer encoded
         """
-        # Due to dummy samples, in some corner cases, the whole batch could
-        # be dummy samples, in that case we want to not update meters on that
-        # process
-        if model_output.shape[0] == 0:
-            return
-
         # Convert target to 0/1 encoding if isn't
         target = maybe_convert_to_one_hot(target, model_output)
 

--- a/classy_vision/meters/recall_meter.py
+++ b/classy_vision/meters/recall_meter.py
@@ -138,12 +138,6 @@ class RecallAtKMeter(ClassyMeter):
                           multi-label encoded, or tensor of shape (B) /
                           (B, 1), integer encoded
         """
-        # Due to dummy samples, in some corner cases, the whole batch could
-        # be dummy samples, in that case we want to not update meters on that
-        # process
-        if model_output.shape[0] == 0:
-            return
-
         # Convert target to 0/1 encoding if isn't
         target = maybe_convert_to_one_hot(target, model_output)
 

--- a/classy_vision/meters/video_meter.py
+++ b/classy_vision/meters/video_meter.py
@@ -91,12 +91,6 @@ class VideoMeter(ClassyMeter):
             Note: For binary classification, C=2.
         """
         num_clips = len(model_output)
-        if num_clips == 0:
-            # It is possible that a minibatch entirely contains dummy samples
-            # when dataset is sharded. In such case, the effective target and output
-            # can be empty, and we immediately return
-            return
-
         clips_per_video = (
             self._clips_per_video_train if is_train else self._clips_per_video_test
         )

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -648,11 +648,6 @@ class ClassificationTask(ClassyTask):
                 local_variables["output"], local_variables["sample"]
             )
 
-            # NOTE: This performs an all_reduce_mean() on the losses across the
-            # replicas.  The reduce should ideally be weighted by the length of
-            # the targets on each replica. This will only be an issue when
-            # there are dummy samples present (once an epoch) and will only
-            # impact the loss reporting (slightly).
             local_variables["loss"] = local_variables["local_loss"].detach().clone()
             local_variables["loss"] = all_reduce_mean(local_variables["loss"])
 


### PR DESCRIPTION
Summary: We no longer use dummy samples. Kill all the workarounds and references to it.

Reviewed By: mannatsingh

Differential Revision: D19752205

