### PR TITLE
Add support to attach heads to DenseNets

### DIFF
--- a/classy_vision/configs/imagenet/densenet121_imagenet_classy_config.json
+++ b/classy_vision/configs/imagenet/densenet121_imagenet_classy_config.json
@@ -50,8 +50,17 @@
     "model": {
         "name": "densenet",
         "num_blocks": [6, 12, 24, 16],
-        "num_classes": 1000,
-        "small_input": false
+        "small_input": false,
+        "heads": [
+            {
+                "name": "fully_connected",
+                "unique_id": "default_head",
+                "num_classes": 1000,
+                "fork_block": "trunk_output",
+                "in_plane": 1024,
+                "zero_init_bias": true
+            }
+        ]
     },
     "optimizer": {
         "name": "sgd",

--- a/classy_vision/heads/fully_connected_head.py
+++ b/classy_vision/heads/fully_connected_head.py
@@ -18,7 +18,13 @@ class FullyConnectedHead(ClassyHead):
     layer (:class:`torch.nn.Linear`).
     """
 
-    def __init__(self, unique_id: str, num_classes: int, in_plane: int):
+    def __init__(
+        self,
+        unique_id: str,
+        num_classes: int,
+        in_plane: int,
+        zero_init_bias: bool = False,
+    ):
         """Constructor for FullyConnectedHead
 
         Args:
@@ -37,6 +43,9 @@ class FullyConnectedHead(ClassyHead):
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = None if num_classes is None else nn.Linear(in_plane, num_classes)
 
+        if zero_init_bias:
+            self.fc.bias.data.zero_()
+
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "FullyConnectedHead":
         """Instantiates a FullyConnectedHead from a configuration.
@@ -50,7 +59,12 @@ class FullyConnectedHead(ClassyHead):
         """
         num_classes = config.get("num_classes", None)
         in_plane = config["in_plane"]
-        return cls(config["unique_id"], num_classes, in_plane)
+        return cls(
+            config["unique_id"],
+            num_classes,
+            in_plane,
+            zero_init_bias=config.get("zero_init_bias", False),
+        )
 
     def forward(self, x):
         # perform average pooling:

--- a/test/models_densenet_test.py
+++ b/test/models_densenet_test.py
@@ -15,12 +15,21 @@ MODELS = {
     "small_densenet": {
         "name": "densenet",
         "num_blocks": [1, 1, 1, 1],
-        "num_classes": 1000,
         "init_planes": 4,
         "growth_rate": 32,
         "expansion": 4,
         "final_bn_relu": True,
         "small_input": True,
+        "heads": [
+            {
+                "name": "fully_connected",
+                "unique_id": "default_head",
+                "num_classes": 1000,
+                "fork_block": "trunk_output",
+                "in_plane": 60,
+                "zero_init_bias": True,
+            }
+        ],
     }
 }
 
@@ -49,5 +58,5 @@ class TestDensenet(unittest.TestCase):
 
         compare_model_state(self, state, new_state, check_heads=True)
 
-    def test_small_resnet(self):
+    def test_small_densenet(self):
         self._test_model(MODELS["small_densenet"])


### PR DESCRIPTION
Summary:
Added the following attachable blocks to the `DenseNet` implementation-
Contains the following attachable blocks -
- `block{block_idx}-{idx}`
- `transition-{idx}`
- `trunk_output`

The `trunk_output` block is the final output of the `DenseNet`. This is where a `fully_connected` head will normally be attached.

Differential Revision: D19780372

