### PR TITLE
Fix bug in loading the final train phase checkpoint

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -719,6 +719,10 @@ class ClassificationTask(ClassyTask):
         # Set up pytorch module in train vs eval mode, update optimizer.
         self._set_model_train_mode()
 
+        # Update the optimizer schedule
+        if self.train and self.train_phase_idx >= 0:
+            self.optimizer.update_schedule_on_epoch(self.where)
+
     def done_training(self):
         """Stop condition for training
         """
@@ -777,9 +781,6 @@ class ClassificationTask(ClassyTask):
             and not self.train
         ):
             self._broadcast_buffers()
-
-        if self.train and self.train_phase_idx >= 0:
-            self.optimizer.update_schedule_on_epoch(self.where)
 
     def _broadcast_buffers(self):
         """Explicitly synchronize buffers across all devices."""

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -66,9 +66,6 @@ class FineTuningTask(ClassificationTask):
         else:
             self.base_model.train(phase["train"])
 
-        if self.train and self.train_phase_idx >= 0:
-            self.optimizer.update_schedule_on_epoch(self.where)
-
     def prepare(
         self,
         num_dataloader_workers: int = 0,


### PR DESCRIPTION
Summary:
Setting a checkpoint called `task._set_model_train_mode()` if the checkpoint was a train phase checkpoint. This function used to call `self.optimizer.update_schedule_on_epoch`, which called `self.where`. This would raise an exception for the final checkpoint since the value of where would be 1.0.

Removed this call altogether since the `train_step()` inside `ClassificationTask` calls  `self.optimizer.update_schedule_on_step(self.where)` inside the train step before calling `self.optimizer.step()`.

Added a test case which failed before the fix and passes now.

Differential Revision: D19815391

