### PR TITLE
Fix tensorboard

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -129,7 +129,7 @@ def configure_hooks(args, config):
         try:
             from tensorboardX import SummaryWriter
 
-            tb_writer = SummaryWriter(log_dir=base_folder / "tensorboard")
+            tb_writer = SummaryWriter(log_dir=Path(base_folder) / "tensorboard")
             hooks.append(TensorboardPlotHook(tb_writer))
         except ImportError:
             logging.warning("tensorboardX not installed, skipping tensorboard hooks")


### PR DESCRIPTION
D19418196 changed base_folder to be a string instead of Path, and that
broke the Tensorboard integration in OSS. Fixing it now.

Long-term we'll get rid of tensorboardX and that'll give test coverage
on the tensorboard code as well.