### PR TITLE
Split train/eval step

### DIFF
--- a/classy_vision/tasks/classy_task.py
+++ b/classy_vision/tasks/classy_task.py
@@ -156,6 +156,26 @@ class ClassyTask(ABC):
         """
         pass
 
+    @abstractmethod
+    def eval_step(self, use_gpu, local_variables: Optional[Dict] = None) -> None:
+        """
+        Run an evaluation step.
+
+        This corresponds to evaluating the model over one batch of data.
+
+        Args:
+            use_gpu: True if training on GPUs, False otherwise
+            local_variables: Local variables created in the function. Can be passed to
+                custom :class:`classy_vision.hooks.ClassyHook`.
+        """
+        pass
+
+    def step(self, use_gpu, local_variables: Optional[Dict] = None) -> None:
+        if self.train:
+            self.train_step(use_gpu, local_variables)
+        else:
+            self.eval_step(use_gpu, local_variables)
+
     def run_hooks(self, local_variables: Dict[str, Any], hook_function: str) -> None:
         """
         Helper function that runs a hook function for all the

--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -77,7 +77,7 @@ class ClassyTrainer:
             task.on_phase_start(local_variables)
             while True:
                 try:
-                    task.train_step(self.use_gpu, local_variables)
+                    task.step(self.use_gpu, local_variables)
                 except StopIteration:
                     break
             task.on_phase_end(local_variables)

--- a/classy_vision/trainer/elastic_trainer.py
+++ b/classy_vision/trainer/elastic_trainer.py
@@ -114,7 +114,7 @@ class ElasticTrainer(ClassyTrainer):
                 state.advance_to_next_phase = True
                 state.skip_current_phase = False  # Reset flag
             else:
-                state.task.train_step(use_gpu, local_variables)
+                state.task.step(use_gpu, local_variables)
         except StopIteration:
             state.advance_to_next_phase = True
         if state.advance_to_next_phase:


### PR DESCRIPTION
Summary:
Split ClassificationTask.train_step into train_step and eval_step.

A lot of use cases (metric learning, video) use the same training code but
evaluate differently. This allows supporting that in a cleaner way.

Differential Revision: D19622567

