### PR TITLE
Add from_config to checkpoint hook

### DIFF
--- a/classy_vision/hooks/checkpoint_hook.py
+++ b/classy_vision/hooks/checkpoint_hook.py
@@ -30,7 +30,7 @@ class CheckpointHook(ClassyHook):
     def __init__(
         self,
         checkpoint_folder: str,
-        input_args: Any,
+        input_args: Any = None,
         phase_types: Optional[Collection[str]] = None,
         checkpoint_period: int = 1,
     ) -> None:
@@ -60,6 +60,13 @@ class CheckpointHook(ClassyHook):
         self.phase_types: Collection[str] = phase_types
         self.checkpoint_period: int = checkpoint_period
         self.phase_counter: int = 0
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "CheckpointHook":
+        assert isinstance(
+            config["checkpoint_folder"], str
+        ), "checkpoint_folder must be a string specifying the checkpoint directory"
+        return CheckpointHook(**config)
 
     def _save_checkpoint(self, task, filename):
         if getattr(task, "test_only", False):

--- a/test/hooks_checkpoint_hook_test.py
+++ b/test/hooks_checkpoint_hook_test.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import os
 import shutil
 import tempfile
@@ -23,6 +24,29 @@ class TestCheckpointHook(unittest.TestCase):
 
     def tearDown(self) -> None:
         shutil.rmtree(self.base_dir)
+
+    def test_constructors(self) -> None:
+        """
+        Test that the hooks are constructed correctly.
+        """
+        config = {
+            "checkpoint_folder": "/test/",
+            "input_args": {"foo": "bar"},
+            "phase_types": ["train"],
+            "checkpoint_period": 2,
+        }
+
+        hook1 = CheckpointHook(**config)
+        hook2 = CheckpointHook.from_config(config)
+
+        self.assertTrue(isinstance(hook1, CheckpointHook))
+        self.assertTrue(isinstance(hook2, CheckpointHook))
+
+        # Verify assert logic works correctly
+        with self.assertRaises(AssertionError):
+            bad_config = copy.deepcopy(config)
+            bad_config["checkpoint_folder"] = 12
+            CheckpointHook.from_config(bad_config)
 
     def test_state_checkpointing(self) -> None:
         """


### PR DESCRIPTION
Summary: Adds from_config to checkpoint hook for use by configuration system.

Reviewed By: vreis

Differential Revision: D19755146

