### PR TITLE
Support losses with learned parameters

### DIFF
--- a/classy_vision/losses/classy_loss.py
+++ b/classy_vision/losses/classy_loss.py
@@ -42,3 +42,44 @@ class ClassyLoss(nn.Module):
         Refer to :class:`torch.nn.Module` for more details.
         """
         raise NotImplementedError
+
+    def get_optimizer_params(self, bn_weight_decay=False):
+        """Gets optimizer params.
+
+        The default implementation is very simple. Most losses have no learned
+        parameters, so this is rarely needed.
+        """
+        params = [
+            param for param in self.parameters(recurse=True) if param.requires_grad
+        ]
+        return {"regularized_params": params, "unregularized_params": []}
+
+    def get_classy_state(self) -> Dict[str, Any]:
+        """Get the state of the ClassyLoss.
+
+        The returned state is used for checkpointing. Note that most losses are
+        stateless and do not need to save any state.
+
+        Returns:
+            A state dictionary containing the state of the loss.
+        """
+        return self.state_dict()
+
+    def set_classy_state(self, state: Dict[str, Any]) -> None:
+        """Set the state of the ClassyLoss.
+
+        Args:
+            state_dict: The state dictionary. Must be the output of a call to
+                :func:`get_classy_state`.
+
+        This is used to load the state of the loss from a checkpoint. Note
+        that most losses are stateless and do not need to load any state.
+        """
+        return self.load_state_dict(state)
+
+    def has_learned_parameters(self) -> bool:
+        """Does this loss have learned parameters?"""
+        for _, params in self.get_optimizer_params().items():
+            if len(params) > 0:
+                return True
+        return False

--- a/classy_vision/optim/adam.py
+++ b/classy_vision/optim/adam.py
@@ -29,8 +29,8 @@ class Adam(ClassyOptimizer):
         self.parameters.weight_decay = weight_decay
         self.parameters.amsgrad = amsgrad
 
-    def init_pytorch_optimizer(self, model) -> None:
-        super().init_pytorch_optimizer(model)
+    def init_pytorch_optimizer(self, model, **kwargs) -> None:
+        super().init_pytorch_optimizer(model, **kwargs)
         self.optimizer = torch.optim.Adam(
             self.param_groups_override,
             lr=self.parameters.lr,

--- a/classy_vision/optim/rmsprop.py
+++ b/classy_vision/optim/rmsprop.py
@@ -32,8 +32,8 @@ class RMSProp(ClassyOptimizer):
         self.parameters.eps = eps
         self.parameters.centered = centered
 
-    def init_pytorch_optimizer(self, model):
-        super().init_pytorch_optimizer(model)
+    def init_pytorch_optimizer(self, model, **kwargs):
+        super().init_pytorch_optimizer(model, **kwargs)
         self.optimizer = torch.optim.RMSprop(
             self.param_groups_override,
             lr=self.parameters.lr,

--- a/classy_vision/optim/rmsprop_tf.py
+++ b/classy_vision/optim/rmsprop_tf.py
@@ -168,8 +168,8 @@ class RMSPropTF(ClassyOptimizer):
         self.parameters.eps = eps
         self.parameters.centered = centered
 
-    def init_pytorch_optimizer(self, model):
-        super().init_pytorch_optimizer(model)
+    def init_pytorch_optimizer(self, model, **kwargs):
+        super().init_pytorch_optimizer(model, **kwargs)
         self.optimizer = RMSpropTFOptimizer(
             self.param_groups_override,
             lr=self.parameters.lr,

--- a/classy_vision/optim/sgd.py
+++ b/classy_vision/optim/sgd.py
@@ -27,8 +27,8 @@ class SGD(ClassyOptimizer):
         self.parameters.weight_decay = weight_decay
         self.parameters.nesterov = nesterov
 
-    def init_pytorch_optimizer(self, model):
-        super().init_pytorch_optimizer(model)
+    def init_pytorch_optimizer(self, model, **kwargs):
+        super().init_pytorch_optimizer(model, **kwargs)
         self.optimizer = torch.optim.SGD(
             self.param_groups_override,
             lr=self.parameters.lr,


### PR DESCRIPTION
Summary:
This adds support for stateful losses with learned parameters. Examples include the NormFace / SphereFace / CosFace / ArcFace family of losses, or noise-contrastive estimation losses that learn partition parameters.

Loss parameters are added to the optimizer, and saved to checkpoints. Losses with parameters are wrapped in a separate DistributedDataParallel instance to synchronize parameter initialization, and gradients, across nodes.

Differential Revision: D19717056

