### PR TITLE
Fix fine-tuning

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -519,9 +519,7 @@ class ClassificationTask(ClassyTask):
             self.base_model, self.optimizer.optimizer = apex.amp.initialize(
                 self.base_model, self.optimizer.optimizer, opt_level=self.amp_opt_level
             )
-
-        if is_distributed_training_run():
-            self.init_distributed_data_parallel_model()
+        self.init_distributed_data_parallel_model()
 
     def init_distributed_data_parallel_model(self):
         """
@@ -531,6 +529,8 @@ class ClassificationTask(ClassyTask):
 
         Needed for distributed training. This is where a model should be wrapped by DDP.
         """
+        if not is_distributed_training_run():
+            return
         assert (
             self.distributed_model is None
         ), "init_ddp_non_elastic must only be called once"

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -100,3 +100,6 @@ class FineTuningTask(ClassificationTask):
                 for h in heads.values():
                     for param in h.parameters():
                         param.requires_grad = True
+            # re-create ddp model
+            self.distributed_model = None
+            super().init_distributed_data_parallel_model()


### PR DESCRIPTION
Summary:
After we wrap the model for DDP, we're not supposed to change the model parameters directly. But for fine-tuning, we would need to freeze the trunk for some use cases. We ran into errors like
> Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss.

Here we recreate the DDP model after freezing.

Differential Revision: D20002843

