### PR TITLE
expose argument find_unused_parameters in init_distributed_data_parallel_model()

### DIFF
--- a/classy_vision/generic/distributed_util.py
+++ b/classy_vision/generic/distributed_util.py
@@ -163,13 +163,17 @@ def get_cuda_device_index() -> int:
     return _cuda_device_index
 
 
-def init_distributed_data_parallel_model(model, broadcast_buffers=False):
+def init_distributed_data_parallel_model(
+    model, broadcast_buffers=False, find_unused_parameters=False
+):
     global _cuda_device_index
 
     if _cuda_device_index == _CPU_DEVICE_INDEX:
         # CPU-only model, don't specify device
         return torch.nn.parallel.DistributedDataParallel(
-            model, broadcast_buffers=broadcast_buffers
+            model,
+            broadcast_buffers=broadcast_buffers,
+            find_unused_parameters=find_unused_parameters,
         )
     else:
         # GPU model
@@ -178,4 +182,5 @@ def init_distributed_data_parallel_model(model, broadcast_buffers=False):
             device_ids=[_cuda_device_index],
             output_device=_cuda_device_index,
             broadcast_buffers=broadcast_buffers,
+            find_unused_parameters=find_unused_parameters,
         )


### PR DESCRIPTION
Summary:
For architecture search, we will add multiple candidate modules at each layer position. At architecture search stage, we may only sample one of them  for forward/backward pass.

DDP will complain not all module parameters are used to produce the final loss by default. To suppress it, we need to be able to set `find_unused_parameters` to True in the `torch.nn.parallel.DistributedDataParallel` API.

Differential Revision: D20201843

