### PR TITLE
Rename lr to value in parameter schedulers

### DIFF
--- a/classy_vision/configs/hmdb51/r3d34.json
+++ b/classy_vision/configs/hmdb51/r3d34.json
@@ -102,13 +102,13 @@
         "schedulers": [
             {
             "name": "linear",
-            "start_lr": 0.005,
-            "end_lr": 0.04
+            "start_value": 0.005,
+            "end_value": 0.04
             },
             {
             "name": "cosine",
-            "start_lr": 0.04,
-            "end_lr": 0.00004
+            "start_value": 0.04,
+            "end_value": 0.00004
             }
         ],
         "update_interval": "epoch",

--- a/classy_vision/configs/kinetics400/postactivated_i3d50.json
+++ b/classy_vision/configs/kinetics400/postactivated_i3d50.json
@@ -102,8 +102,8 @@
     "param_schedulers": {
       "lr": {
         "name": "cosine",
-        "start_lr": 0.1,
-        "end_lr": 0.0001
+        "start_value": 0.1,
+        "end_value": 0.0001
       }
     },
     "weight_decay": 0.0001,

--- a/classy_vision/configs/kinetics400/preactivated_i3d50.json
+++ b/classy_vision/configs/kinetics400/preactivated_i3d50.json
@@ -102,8 +102,8 @@
     "param_schedulers": {
       "lr": {
         "name": "cosine",
-        "start_lr": 0.1,
-        "end_lr": 0.0001
+        "start_value": 0.1,
+        "end_value": 0.0001
       }
     },
     "weight_decay": 0.0001,

--- a/classy_vision/configs/ucf101/r3d34.json
+++ b/classy_vision/configs/ucf101/r3d34.json
@@ -102,13 +102,13 @@
         "schedulers": [
           {
             "name": "linear",
-            "start_lr": 0.005,
-            "end_lr": 0.04
+            "start_value": 0.005,
+            "end_value": 0.04
           },
           {
             "name": "cosine",
-            "start_lr": 0.04,
-            "end_lr": 0.00004
+            "start_value": 0.04,
+            "end_value": 0.00004
           }
         ],
         "lengths": [0.13, 0.87],

--- a/classy_vision/optim/param_scheduler/composite_scheduler.py
+++ b/classy_vision/optim/param_scheduler/composite_scheduler.py
@@ -41,7 +41,7 @@ class CompositeParamScheduler(ClassyParamScheduler):
               update_interval = "step"
               schedulers = [
                 {"name": "constant", "value": 0.42},
-                {"name": "cosine_decay", "start_lr": 0.42, "end_lr": 0.0001}
+                {"name": "cosine_decay", "start_value": 0.42, "end_value": 0.0001}
               ]
               interval_scaling = ['rescaled', 'rescaled'],
               lengths =  [0.3, 0.7]

--- a/classy_vision/optim/param_scheduler/cosine_scheduler.py
+++ b/classy_vision/optim/param_scheduler/cosine_scheduler.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
 import math
 from typing import Any, Dict
 
@@ -23,14 +22,14 @@ class CosineParamScheduler(ClassyParamScheduler):
 
         .. code-block:: python
 
-          start_lr: 0.1
-          end_lr: 0.0001
+          start_value: 0.1
+          end_value: 0.0001
     """
 
-    def __init__(self, start_lr: float, end_lr: float):
+    def __init__(self, start_value: float, end_value: float):
         super().__init__()
-        self._start_lr = start_lr
-        self._end_lr = end_lr
+        self._start_value = start_value
+        self._end_value = end_value
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "CosineParamScheduler":
@@ -44,12 +43,12 @@ class CosineParamScheduler(ClassyParamScheduler):
             A CosineParamScheduler instance.
         """
         assert (
-            "start_lr" in config and "end_lr" in config
-        ), "Cosine scheduler requires a start_lr and a end_lr"
+            "start_value" in config and "end_value" in config
+        ), "Cosine scheduler requires a start_value and a end_value"
 
-        return cls(start_lr=config["start_lr"], end_lr=config["end_lr"])
+        return cls(start_value=config["start_value"], end_value=config["end_value"])
 
     def __call__(self, where: float):
-        return self._end_lr + 0.5 * (self._start_lr - self._end_lr) * (
+        return self._end_value + 0.5 * (self._start_value - self._end_value) * (
             1 + math.cos(math.pi * where)
         )

--- a/classy_vision/optim/param_scheduler/linear_scheduler.py
+++ b/classy_vision/optim/param_scheduler/linear_scheduler.py
@@ -12,22 +12,22 @@ from . import ClassyParamScheduler, register_param_scheduler
 @register_param_scheduler("linear")
 class LinearParamScheduler(ClassyParamScheduler):
     """
-    Linearly interpolates parameter between ``start_lr`` and ``end_lr``.
+    Linearly interpolates parameter between ``start_value`` and ``end_value``.
     Can be used for either warmup or decay based on start and end values.
 
     Example:
 
         .. code-block:: python
 
-            start_lr: 0.0001
-            end_lr: 0.01
+            start_value: 0.0001
+            end_value: 0.01
     Corresponds to a linear increasing schedule with values in [0.0001, 0.01)
     """
 
-    def __init__(self, start_lr: float, end_lr: float):
+    def __init__(self, start_value: float, end_value: float):
         super().__init__()
-        self._start_lr = start_lr
-        self._end_lr = end_lr
+        self._start_value = start_value
+        self._end_value = end_value
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "LinearParamScheduler":
@@ -41,10 +41,10 @@ class LinearParamScheduler(ClassyParamScheduler):
             A LinearParamScheduler instance.
         """
         assert (
-            "start_lr" in config and "end_lr" in config
+            "start_value" in config and "end_value" in config
         ), "Linear scheduler requires a start and a end"
-        return cls(start_lr=config["start_lr"], end_lr=config["end_lr"])
+        return cls(start_value=config["start_value"], end_value=config["end_value"])
 
     def __call__(self, where: float):
         # interpolate between start and end values
-        return self._end_lr * where + self._start_lr * (1 - where)
+        return self._end_value * where + self._start_value * (1 - where)

--- a/classy_vision/optim/param_scheduler/polynomial_decay_scheduler.py
+++ b/classy_vision/optim/param_scheduler/polynomial_decay_scheduler.py
@@ -19,17 +19,17 @@ class PolynomialDecayParamScheduler(ClassyParamScheduler):
 
         .. code-block:: python
 
-          base_lr: 0.1
+          base_value: 0.1
           power: 0.9
 
     Then the param value will be 0.1 for epoch 0, 0.099 for epoch 1, and
     so on.
     """
 
-    def __init__(self, base_lr, power):
+    def __init__(self, base_value, power):
         super().__init__()
 
-        self._base_lr = base_lr
+        self._base_value = base_value
         self._power = power
 
     @classmethod
@@ -44,9 +44,9 @@ class PolynomialDecayParamScheduler(ClassyParamScheduler):
             A PolynomialDecayParamScheduler instance.
         """
         assert (
-            "base_lr" in config and "power" in config
+            "base_value" in config and "power" in config
         ), "Polynomial decay scheduler requires a base lr and a power of decay"
-        return cls(base_lr=config["base_lr"], power=config["power"])
+        return cls(base_value=config["base_value"], power=config["power"])
 
     def __call__(self, where: float):
-        return self._base_lr * (1 - where) ** self._power
+        return self._base_value * (1 - where) ** self._power

--- a/classy_vision/optim/param_scheduler/step_with_fixed_gamma_scheduler.py
+++ b/classy_vision/optim/param_scheduler/step_with_fixed_gamma_scheduler.py
@@ -20,7 +20,7 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
 
         .. code-block:: python
 
-          base_lr: 0.1
+          base_value: 0.1
           gamma: 0.1
           num_decays: 3
           num_epochs: 120
@@ -40,9 +40,9 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
         Returns:
             A StepWithFixedGammaParamScheduler instance.
         """
-        for key in ["base_lr", "gamma", "num_decays", "num_epochs"]:
+        for key in ["base_value", "gamma", "num_decays", "num_epochs"]:
             assert key in config, f"Step with fixed decay scheduler requires: {key}"
-        for key in ["base_lr", "gamma"]:
+        for key in ["base_value", "gamma"]:
             assert (
                 isinstance(config[key], (int, float)) and config[key] > 0
             ), f"{key} must be a positive number"
@@ -52,20 +52,20 @@ class StepWithFixedGammaParamScheduler(ClassyParamScheduler):
             ), f"{key} must be a positive integer"
 
         return cls(
-            base_lr=config["base_lr"],
+            base_value=config["base_value"],
             num_decays=config["num_decays"],
             gamma=config["gamma"],
             num_epochs=config["num_epochs"],
         )
 
-    def __init__(self, base_lr, num_decays, gamma, num_epochs):
+    def __init__(self, base_value, num_decays, gamma, num_epochs):
         super().__init__()
 
-        self.base_lr = base_lr
+        self.base_value = base_value
         self.num_decays = num_decays
         self.gamma = gamma
         self.num_epochs = num_epochs
-        values = [base_lr]
+        values = [base_value]
         for _ in range(num_decays):
             values.append(values[-1] * gamma)
 

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -83,7 +83,7 @@ class APITest(unittest.TestCase):
 
         optimizer = SGD(momentum=0.9, weight_decay=1e-4, nesterov=True)
         optimizer.set_param_schedulers(
-            {"lr": LinearParamScheduler(start_lr=0.01, end_lr=0.009)}
+            {"lr": LinearParamScheduler(start_value=0.01, end_value=0.009)}
         )
 
         task = (

--- a/test/generic/optim_test_util.py
+++ b/test/generic/optim_test_util.py
@@ -212,7 +212,7 @@ class TestOptimizer(ABC):
         config["lr"] = {
             "name": "composite",
             "schedulers": [
-                {"name": "linear", "start_lr": init_lr, "end_lr": 0.1},
+                {"name": "linear", "start_value": init_lr, "end_value": 0.1},
                 {"name": "step", "values": [0.1, 0.01, 0.001]},
             ],
             "update_interval": "epoch",

--- a/test/optim_param_scheduler_composite_test.py
+++ b/test/optim_param_scheduler_composite_test.py
@@ -45,7 +45,7 @@ class TestCompositeScheduler(unittest.TestCase):
             "name": "composite",
             "schedulers": [
                 {"name": "step", "values": [0.1, 0.2, 0.3, 0.4, 0.5], "num_epochs": 10},
-                {"name": "cosine", "start_lr": 0.42, "end_lr": 0.0001},
+                {"name": "cosine", "start_value": 0.42, "end_value": 0.0001},
             ],
             "lengths": [0.5, 0.5],
         }
@@ -54,8 +54,8 @@ class TestCompositeScheduler(unittest.TestCase):
         return {
             "name": "composite",
             "schedulers": [
-                {"name": "linear", "start_lr": 0.0, "end_lr": 0.5},
-                {"name": "linear", "start_lr": 0.5, "end_lr": 1.0},
+                {"name": "linear", "start_value": 0.0, "end_value": 0.5},
+                {"name": "linear", "start_value": 0.5, "end_value": 1.0},
             ],
             "lengths": [0.5, 0.5],
             "interval_scaling": ["rescaled", "rescaled"],

--- a/test/optim_param_scheduler_cosine_test.py
+++ b/test/optim_param_scheduler_cosine_test.py
@@ -15,7 +15,7 @@ class TestCosineScheduler(unittest.TestCase):
     _num_epochs = 10
 
     def _get_valid_decay_config(self):
-        return {"name": "cosine", "start_lr": 0.1, "end_lr": 0}
+        return {"name": "cosine", "start_value": 0.1, "end_value": 0}
 
     def _get_valid_decay_config_intermediate_values(self):
         return [0.0976, 0.0905, 0.0794, 0.0655, 0.05, 0.0345, 0.0206, 0.0095, 0.0024]
@@ -26,13 +26,13 @@ class TestCosineScheduler(unittest.TestCase):
 
         bad_config = copy.deepcopy(config)
         # Invalid Base lr
-        del bad_config["start_lr"]
+        del bad_config["start_value"]
         with self.assertRaises(AssertionError):
             CosineParamScheduler.from_config(bad_config)
 
-        # Invalid end_lr
-        bad_config["start_lr"] = config["start_lr"]
-        del bad_config["end_lr"]
+        # Invalid end_value
+        bad_config["start_value"] = config["start_value"]
+        del bad_config["end_value"]
         with self.assertRaises(AssertionError):
             CosineParamScheduler.from_config(bad_config)
 
@@ -45,7 +45,7 @@ class TestCosineScheduler(unittest.TestCase):
             for epoch_num in range(self._num_epochs)
         ]
         expected_schedule = [
-            config["start_lr"]
+            config["start_value"]
         ] + self._get_valid_decay_config_intermediate_values()
 
         self.assertEqual(schedule, expected_schedule)
@@ -53,9 +53,9 @@ class TestCosineScheduler(unittest.TestCase):
     def test_scheduler_as_warmup(self):
         config = self._get_valid_decay_config()
         # Swap start and end lr to change to warmup
-        tmp = config["start_lr"]
-        config["start_lr"] = config["end_lr"]
-        config["end_lr"] = tmp
+        tmp = config["start_value"]
+        config["start_value"] = config["end_value"]
+        config["end_value"] = tmp
 
         scheduler = CosineParamScheduler.from_config(config)
         schedule = [
@@ -63,7 +63,7 @@ class TestCosineScheduler(unittest.TestCase):
             for epoch_num in range(self._num_epochs)
         ]
         # Schedule should be decay reversed
-        expected_schedule = [config["start_lr"]] + list(
+        expected_schedule = [config["start_value"]] + list(
             reversed(self._get_valid_decay_config_intermediate_values())
         )
 
@@ -75,9 +75,9 @@ class TestCosineScheduler(unittest.TestCase):
 
         warmup_config = copy.deepcopy(decay_config)
         # Swap start and end lr to change to warmup
-        tmp = warmup_config["start_lr"]
-        warmup_config["start_lr"] = warmup_config["end_lr"]
-        warmup_config["end_lr"] = tmp
+        tmp = warmup_config["start_value"]
+        warmup_config["start_value"] = warmup_config["end_value"]
+        warmup_config["end_value"] = tmp
         warmup_scheduler = CosineParamScheduler.from_config(warmup_config)
 
         decay_schedule = [

--- a/test/optim_param_scheduler_linear_test.py
+++ b/test/optim_param_scheduler_linear_test.py
@@ -18,20 +18,20 @@ class TestLienarScheduler(unittest.TestCase):
         return [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09]
 
     def _get_valid_config(self):
-        return {"name": "linear", "start_lr": 0.0, "end_lr": 0.1}
+        return {"name": "linear", "start_value": 0.0, "end_value": 0.1}
 
     def test_invalid_config(self):
         config = self._get_valid_config()
 
         bad_config = copy.deepcopy(config)
         # No start lr
-        del bad_config["start_lr"]
+        del bad_config["start_value"]
         with self.assertRaises(AssertionError):
             LinearParamScheduler.from_config(bad_config)
 
         # No end lr
-        bad_config["start_lr"] = config["start_lr"]
-        del bad_config["end_lr"]
+        bad_config["start_value"] = config["start_value"]
+        del bad_config["end_value"]
         with self.assertRaises(AssertionError):
             LinearParamScheduler.from_config(bad_config)
 
@@ -44,19 +44,19 @@ class TestLienarScheduler(unittest.TestCase):
             round(scheduler(epoch_num / self._num_epochs), 4)
             for epoch_num in range(self._num_epochs)
         ]
-        expected_schedule = [config["start_lr"]] + self._get_valid_intermediate()
+        expected_schedule = [config["start_value"]] + self._get_valid_intermediate()
         self.assertEqual(schedule, expected_schedule)
 
         # Check as decay
-        tmp = config["start_lr"]
-        config["start_lr"] = config["end_lr"]
-        config["end_lr"] = tmp
+        tmp = config["start_value"]
+        config["start_value"] = config["end_value"]
+        config["end_value"] = tmp
         scheduler = LinearParamScheduler.from_config(config)
         schedule = [
             round(scheduler(epoch_num / self._num_epochs), 4)
             for epoch_num in range(self._num_epochs)
         ]
-        expected_schedule = [config["start_lr"]] + list(
+        expected_schedule = [config["start_value"]] + list(
             reversed(self._get_valid_intermediate())
         )
         self.assertEqual(schedule, expected_schedule)

--- a/test/optim_param_scheduler_polynomial_test.py
+++ b/test/optim_param_scheduler_polynomial_test.py
@@ -20,7 +20,7 @@ class TestPolynomialScheduler(unittest.TestCase):
         return {
             "name": "polynomial",
             "num_epochs": self._num_epochs,
-            "base_lr": 0.1,
+            "base_value": 0.1,
             "power": 1,
         }
 
@@ -30,7 +30,7 @@ class TestPolynomialScheduler(unittest.TestCase):
 
         # Invalid Base lr
         bad_config = copy.deepcopy(config)
-        del bad_config["base_lr"]
+        del bad_config["base_value"]
         with self.assertRaises(AssertionError):
             PolynomialDecayParamScheduler.from_config(bad_config)
 

--- a/test/optim_param_scheduler_step_with_fixed_gamma_test.py
+++ b/test/optim_param_scheduler_step_with_fixed_gamma_test.py
@@ -19,7 +19,7 @@ class TestStepWithFixedGammaScheduler(unittest.TestCase):
     def _get_valid_config(self):
         return {
             "name": "step_with_fixed_gamma",
-            "base_lr": 1,
+            "base_value": 1,
             "gamma": 0.1,
             "num_decays": 3,
             "num_epochs": self._num_epochs,
@@ -39,9 +39,9 @@ class TestStepWithFixedGammaScheduler(unittest.TestCase):
         with self.assertRaises(AssertionError):
             StepWithFixedGammaParamScheduler.from_config(bad_config)
 
-        # Invalid base_lr
+        # Invalid base_value
         bad_config = copy.deepcopy(config)
-        bad_config["base_lr"] = -0.01
+        bad_config["base_value"] = -0.01
         with self.assertRaises(AssertionError):
             StepWithFixedGammaParamScheduler.from_config(bad_config)
 


### PR DESCRIPTION
Summary:
Some parameter schedulers referred to their values as lr since the schedulers were originally only meant for learning rates. This diff renames the following parameters -
`start_lr` -> `start_value`
`end_lr` -> `end_value`
`base_lr` -> `base_value`

Differential Revision: D20251584

