### PR TITLE
Fix distributed training test

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -43,6 +43,7 @@ from datetime import datetime
 from pathlib import Path
 
 import torch
+from classy_vision.generic.distributed_util import get_rank, get_world_size
 from classy_vision.generic.opts import check_generic_args, parse_train_arguments
 from classy_vision.generic.registry_utils import import_all_packages_from_directory
 from classy_vision.generic.util import load_checkpoint, load_json
@@ -104,6 +105,10 @@ def main(args, config):
 
     trainer = trainer_class(use_gpu=use_gpu, num_dataloader_workers=args.num_workers)
 
+    logging.info(
+        f"Starting training on rank {get_rank()} worker. "
+        f"World size is {get_world_size()}"
+    )
     # That's it! When this call returns, training is done.
     trainer.train(task)
 

--- a/test/trainer_distributed_trainer_test.py
+++ b/test/trainer_distributed_trainer_test.py
@@ -57,7 +57,8 @@ class TestDistributedTrainer(unittest.TestCase):
             --device={device} \
             --config={self.config_files[config_key]} \
             --num_workers=4 \
-            --log_freq=100
+            --log_freq=100 \
+            --distributed_backend=ddp
             """
             result = subprocess.run(cmd, shell=True)
             success = result.returncode == 0


### PR DESCRIPTION
Summary: The distributed training test was running the local trainer on each process. The `distributed_backend` argument needed to be added since `classy_train.py` now runs the `LocalTrainer` by default.

Differential Revision: D20296492

