### PR TITLE
Fix bug in profiler and task init code

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -774,3 +774,18 @@ def get_model_dummy_input(
         if input_key:
             input = {input_key: input}
     return input
+
+
+@contextlib.contextmanager
+def train_mode(model: nn.Module, train_mode: bool):
+    """Context manager which sets the train mode of a model. After returning, it
+    restores the state of every module inside the model individually."""
+    train_modes = {}
+    for name, module in model.named_modules():
+        train_modes[name] = module.training
+    try:
+        model.train(train_mode)
+        yield
+    finally:
+        for name, module in model.named_modules():
+            module.training = train_modes[name]

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -23,7 +23,6 @@ from classy_vision.generic.util import (
     recursive_copy_to_gpu,
     update_classy_state,
 )
-from classy_vision.hooks import ClassyHookFunctions
 from classy_vision.losses import ClassyLoss, build_loss
 from classy_vision.meters import build_meters
 from classy_vision.models import ClassyModel, build_model
@@ -305,9 +304,6 @@ class ClassificationTask(ClassyTask):
         amp_opt_level = config.get("amp_opt_level")
         meters = build_meters(config.get("meters", {}))
         model = build_model(config["model"])
-        # put model in eval mode in case any hooks modify model states, it'll
-        # be reset to train mode before training
-        model.eval()
         optimizer = build_optimizer(optimizer_config)
 
         task = (


### PR DESCRIPTION
Summary:
- The profiler code to calculate complexity is now wrapped by the `torch.no_grad()` context manager
- The code to convert the model to eval mode was in the wrong place (inside `from_config`). Moved this to `prepare()`. Also added a function which validates that all the modules inside the model are in eval mode.

I caught this issue because using `nn.SyncBatchNorm.convert_sync_batchnorm` inside `prepare()` caused training to hang, but the same change inside a specific model worked without any issues.

Differential Revision: D20342756

