### PR TITLE
Add Squeeze and Excitation to ResNeXt models

### DIFF
--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -93,6 +93,7 @@ from .mlp import MLP  # isort:skip
 from .resnet import ResNet  # isort:skip
 from .resnext import ResNeXt  # isort:skip
 from .resnext3d import ResNeXt3D  # isort:skip
+from .squeeze_and_excitation_layer import SqueezeAndExcitationLayer  # isort:skip
 
 
 __all__ = [
@@ -107,4 +108,5 @@ __all__ = [
     "ResNet",
     "ResNeXt",
     "ResNeXt3D",
+    "SqueezeAndExcitationLayer",
 ]

--- a/classy_vision/models/squeeze_and_excitation_layer.py
+++ b/classy_vision/models/squeeze_and_excitation_layer.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import torch.nn as nn
+
+
+class SqueezeAndExcitationLayer(nn.Module):
+    """Squeeze and excitation layer, as per https://arxiv.org/pdf/1709.01507.pdf"""
+
+    def __init__(self, in_planes, reduction_ratio=16):
+        super().__init__()
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        reduced_planes = in_planes // reduction_ratio
+        self.excitation = nn.Sequential(
+            nn.Conv2d(in_planes, reduced_planes, kernel_size=1, stride=1, bias=True),
+            nn.ReLU(),
+            nn.Conv2d(reduced_planes, in_planes, kernel_size=1, stride=1, bias=True),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x):
+        x_squeezed = self.avgpool(x)
+        x_excited = self.excitation(x_squeezed)
+        x_scaled = x * x_excited
+        return x_scaled

--- a/test/models_resnext_test.py
+++ b/test/models_resnext_test.py
@@ -8,7 +8,7 @@ import unittest
 from test.generic.utils import compare_model_state
 
 import torch
-from classy_vision.models import build_model
+from classy_vision.models import ResNeXt, build_model
 
 
 MODELS = {
@@ -51,6 +51,26 @@ MODELS = {
             }
         ],
     },
+    "small_resnet_se": {
+        "name": "resnet",
+        "num_blocks": [1, 1, 1, 1],
+        "init_planes": 4,
+        "reduction": 4,
+        "small_input": True,
+        "zero_init_bn_residuals": True,
+        "basic_layer": True,
+        "final_bn_relu": True,
+        "use_se": True,
+        "heads": [
+            {
+                "name": "fully_connected",
+                "unique_id": "default_head",
+                "num_classes": 1000,
+                "fork_block": "block3-0",
+                "in_plane": 128,
+            }
+        ],
+    },
 }
 
 
@@ -78,8 +98,17 @@ class TestResnext(unittest.TestCase):
 
         compare_model_state(self, state, new_state, check_heads=True)
 
+    def test_build_preset_model(self):
+        configs = [{"name": "resnet18"}, {"name": "resnet18", "use_se": True}]
+        for config in configs:
+            model = build_model(config)
+            self.assertIsInstance(model, ResNeXt)
+
     def test_small_resnext(self):
         self._test_model(MODELS["small_resnext"])
 
     def test_small_resnet(self):
         self._test_model(MODELS["small_resnet"])
+
+    def test_small_resnet_se(self):
+        self._test_model(MODELS["small_resnet_se"])


### PR DESCRIPTION
Summary:
Added a `SqueezeAndExcitation` layer to a new sub-package, `models.common` (open to other suggestions, I didn't want to have a `generic.py` or `util.py` as that is too vague and broad).

Plugged in the layer to `ResNeXt` models.

Differential Revision: D20283172

