### PR TITLE
add property input_batchsize to ClassyModel

### DIFF
--- a/classy_vision/generic/profiler.py
+++ b/classy_vision/generic/profiler.py
@@ -372,7 +372,7 @@ def restore_forward(model):
     return model
 
 
-def compute_complexity(model, compute_fn, input_shape, input_key=None):
+def compute_complexity(model, compute_fn, input_shape, input_batchsize, input_key=None):
     """
     Compute the complexity of a forward pass.
     """
@@ -381,7 +381,9 @@ def compute_complexity(model, compute_fn, input_shape, input_key=None):
     assert isinstance(model, nn.Module)
     if not isinstance(input_shape, abc.Sequence):
         return None
-    input = get_model_dummy_input(model, input_shape, input_key)
+    input = get_model_dummy_input(
+        model, input_shape, input_key, batchsize=input_batchsize
+    )
     compute_list = []
 
     # measure FLOPs:
@@ -395,18 +397,24 @@ def compute_complexity(model, compute_fn, input_shape, input_key=None):
     return sum(compute_list)
 
 
-def compute_flops(model, input_shape=(3, 224, 224), input_key=None):
+def compute_flops(model, input_shape=(3, 224, 224), input_batchsize=1, input_key=None):
     """
     Compute the number of FLOPs needed for a forward pass.
     """
-    return compute_complexity(model, _layer_flops, input_shape, input_key)
+    return compute_complexity(
+        model, _layer_flops, input_shape, input_batchsize, input_key
+    )
 
 
-def compute_activations(model, input_shape=(3, 224, 224), input_key=None):
+def compute_activations(
+    model, input_shape=(3, 224, 224), input_batchsize=1, input_key=None
+):
     """
     Compute the number of activations created in a forward pass.
     """
-    return compute_complexity(model, _layer_activations, input_shape, input_key)
+    return compute_complexity(
+        model, _layer_activations, input_shape, input_batchsize, input_key
+    )
 
 
 def count_params(model):

--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -40,6 +40,7 @@ class ModelComplexityHook(ClassyHook):
                 self.num_flops = compute_flops(
                     task.base_model,
                     input_shape=task.base_model.input_shape,
+                    input_batchsize=task.base_model.input_batchsize,
                     input_key=task.base_model.input_key
                     if hasattr(task.base_model, "input_key")
                     else None,
@@ -48,6 +49,7 @@ class ModelComplexityHook(ClassyHook):
                     logging.info("FLOPs for forward pass: skipped.")
                     self.num_flops = 0
                 else:
+                    self.num_flops /= task.base_model.input_batchsize
                     logging.info(
                         "FLOPs for forward pass: %d MFLOPs"
                         % (float(self.num_flops) / 1e6)
@@ -62,10 +64,12 @@ class ModelComplexityHook(ClassyHook):
                 self.num_activations = compute_activations(
                     task.base_model,
                     input_shape=task.base_model.input_shape,
+                    input_batchsize=task.base_model.input_batchsize,
                     input_key=task.base_model.input_key
                     if hasattr(task.base_model, "input_key")
                     else None,
                 )
+                self.num_activations /= task.base_model.input_batchsize
                 logging.info(f"Number of activations in model: {self.num_activations}")
             except NotImplementedError:
                 logging.info(

--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -288,6 +288,17 @@ class ClassyModel(nn.Module):
         raise NotImplementedError
 
     @property
+    def input_batchsize(self):
+        """Return the batchsize in the input tensor to the model.
+
+        Default value is 1, which is sufficient for most cases. For some corner
+        cases, we may need batchsize larger than 1 to avoid degenerate cases
+        where the number of samples per channel in the input tensor of BatchNorm
+        operator is only 1, which will fail the BatchNorm operator.
+        """
+        return 1
+
+    @property
     def output_shape(self):
         """If implemented, returns expected output tensor shape
         """


### PR DESCRIPTION
Summary:
When using `ModelComplexityHook` to profile models, we need to run forward pass using dummy input tensor. Currently, batch size is always 1. For some corner cases, we may need batch size larger than 1 to avoid degenerate cases where the number of samples per channel in the input tensor of BatchNorm operator is only 1, which will fail the BatchNorm operator.

Thus, add a new property `input_batchsize` to ClassyModel. Default value 1, which is BC. For child class of `ClassyModel`, we can override this property with batch size > 1, and avoid de-generate cases related to BatchNorm.

Differential Revision: D20379872

