### PR TITLE
Allow configuring arbitrary AMP args

### DIFF
--- a/test/manual/tasks_classification_task_amp_test.py
+++ b/test/manual/tasks_classification_task_amp_test.py
@@ -23,20 +23,14 @@ class TestClassificationTaskAMP(unittest.TestCase):
 
         # test a valid AMP opt level
         config = copy.deepcopy(config)
-        config["amp_opt_level"] = "O1"
+        config["amp_args"] = {"opt_level": "O1"}
         task = build_task(config)
         self.assertTrue(isinstance(task, ClassificationTask))
-
-        # test an invalid AMP opt level
-        config = copy.deepcopy(config)
-        config["amp_opt_level"] = "O5"
-        with self.assertRaises(Exception):
-            task = build_task(config)
 
     @unittest.skipUnless(torch.cuda.is_available(), "This test needs a gpu to run")
     def test_training(self):
         config = get_fast_test_task_config()
-        config["amp_opt_level"] = "O2"
+        config["amp_args"] = {"opt_level": "O2"}
         task = build_task(config)
         trainer = LocalTrainer(use_gpu=True)
         trainer.train(task)


### PR DESCRIPTION
Summary:
For a few experiments I've had to change flags other than opt_level. Change
the amp argument to take a dictionary and override any argument in
amp.initialize.

Differential Revision: D20428478

