### PR TITLE
Reduce data logged to tensorboard

### DIFF
--- a/test/manual/hooks_tensorboard_plot_hook_test.py
+++ b/test/manual/hooks_tensorboard_plot_hook_test.py
@@ -147,6 +147,7 @@ class TestTensorboardPlotHook(unittest.TestCase):
 
         writer = DummySummaryWriter()
         hook = TensorboardPlotHook(writer)
+        hook.log_period = 1
         task.set_hooks([hook])
         task.optimizer.param_schedulers["lr"] = mock_lr_scheduler
 


### PR DESCRIPTION
Summary:
We were logging learning rate and loss for every single step, which makes
tensorboard too slow to load in long training runs. Log every 10th step, which
should be enough for all cases: we always log at the end of every phase as
well.

Differential Revision: D20441202

