### PR TITLE
Extend BatchNorm weight decay settings to all BN layers

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -266,8 +266,7 @@ class ClassyModel(nn.Module):
                     if params.requires_grad:
                         regularized_params.append(params)
             elif not bn_weight_decay and isinstance(
-                module,
-                (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm),
+                module, nn.modules.batchnorm._BatchNorm
             ):
                 for params in module.parameters():
                     if params.requires_grad:


### PR DESCRIPTION
Summary: This widens the set of BatchNorm layers to include all _BatchNorm subclasses, including those from 3rd party libraries like apex.

Differential Revision: D20455114

