### PR TITLE
Use flatten instead of view/reshape for better onnx export

### DIFF
--- a/classy_vision/heads/fully_connected_head.py
+++ b/classy_vision/heads/fully_connected_head.py
@@ -71,7 +71,7 @@ class FullyConnectedHead(ClassyHead):
         out = self.avgpool(x)
 
         # final classifier:
-        out = out.reshape(out.size(0), -1)
+        out = out.flatten(start_dim=1)
         if self.fc is not None:
             out = self.fc(out)
         return out

--- a/classy_vision/heads/fully_convolutional_linear_head.py
+++ b/classy_vision/heads/fully_convolutional_linear_head.py
@@ -37,7 +37,7 @@ class FullyConvolutionalLinear(nn.Module):
         if not self.training:
             x = self.act(x)
             x = x.mean([1, 2, 3])
-        x = x.view(x.shape[0], -1)
+        x = x.flatten(start_dim=1)
         return x
 
 


### PR DESCRIPTION
This fixes the problem of onnx exports being incompatible with TensorRT. #438 