### PR TITLE
Add test utility for hooks

### DIFF
--- a/classy_vision/hooks/checkpoint_hook.py
+++ b/classy_vision/hooks/checkpoint_hook.py
@@ -28,7 +28,7 @@ class CheckpointHook(ClassyHook):
     def __init__(
         self,
         checkpoint_folder: str,
-        input_args: Any,
+        input_args: Any = None,
         phase_types: Optional[Collection[str]] = None,
         checkpoint_period: int = 1,
     ) -> None:
@@ -44,6 +44,13 @@ class CheckpointHook(ClassyHook):
             checkpoint_period: Checkpoint at the end of every x phases (default 1)
         """
         super().__init__()
+        assert isinstance(
+            checkpoint_folder, str
+        ), "checkpoint_folder must be a string specifying the checkpoint directory"
+        assert (
+            isinstance(checkpoint_period, int) and checkpoint_period > 0
+        ), "checkpoint_period must be a positive integer"
+
         self.checkpoint_folder: str = checkpoint_folder
         self.input_args: Any = input_args
         if phase_types is None:
@@ -58,6 +65,10 @@ class CheckpointHook(ClassyHook):
         self.phase_types: Collection[str] = phase_types
         self.checkpoint_period: int = checkpoint_period
         self.phase_counter: int = 0
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "CheckpointHook":
+        return CheckpointHook(**config)
 
     def _save_checkpoint(self, task, filename):
         if getattr(task, "test_only", False):

--- a/test/generic/hook_test_utils.py
+++ b/test/generic/hook_test_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+
+class HookTestBase(unittest.TestCase):
+
+    def constructor_test_helper(
+            self,
+            arg_list,
+            config,
+            hook_type,
+            hook_registry_name=None,
+            invalid_configs=None,
+    ):
+        hook1 = hook_type(*arg_list)
+        self.assertTrue(isinstance(hook1, hook_type))
+
+        hook2 = hook_type.from_config(config)
+        self.assertTrue(isinstance(hook2, hook_type))
+
+        if hook_registry_name is not None:
+            config["name"] = hook_registry_name
+            hook3 = build_hook(config)
+            del config["name"]
+            self.assertTrue(isinstance(hook3, hook_type))
+
+        if invalid_configs is not None:
+            # Verify assert logic works correctly
+            for cfg in invalid_configs:
+                with self.assertRaises(AssertionError):
+                    hook_type.from_config(cfg)

--- a/test/hooks_checkpoint_hook_test.py
+++ b/test/hooks_checkpoint_hook_test.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import os
 import shutil
 import tempfile
@@ -23,6 +24,29 @@ class TestCheckpointHook(unittest.TestCase):
 
     def tearDown(self) -> None:
         shutil.rmtree(self.base_dir)
+
+    def test_constructors(self) -> None:
+        """
+        Test that the hooks are constructed correctly.
+        """
+        config = {
+            "checkpoint_folder": "/test/",
+            "input_args": {"foo": "bar"},
+            "phase_types": ["train"],
+            "checkpoint_period": 2,
+        }
+
+        hook1 = CheckpointHook(**config)
+        hook2 = CheckpointHook.from_config(config)
+
+        self.assertTrue(isinstance(hook1, CheckpointHook))
+        self.assertTrue(isinstance(hook2, CheckpointHook))
+
+        # Verify assert logic works correctly
+        with self.assertRaises(AssertionError):
+            bad_config = copy.deepcopy(config)
+            bad_config["checkpoint_folder"] = 12
+            CheckpointHook.from_config(bad_config)
 
     def test_state_checkpointing(self) -> None:
         """


### PR DESCRIPTION
Summary: Added a base test class for the hook constructor tests which have a lot of copy pasta

Differential Revision: D20543898

