### PR TITLE
Support output flops on FAIM model.

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -777,6 +777,35 @@ def get_model_dummy_input(
     return input
 
 
+# dummy imput for MultimodalVideo
+def get_multimodel_dummy_input(model, input_shape, batchsize=1, non_blocking=False):
+    input = {}
+    on_gpu = is_on_gpu(model)
+    for key, shape in input_shape.items():
+        if isinstance(shape, tuple):
+            shape = list(shape)
+
+        if on_gpu:
+            input[key] = {
+                "data": torch.randn([batchsize] + shape)
+                .float()
+                .cuda(non_blocking=non_blocking),
+                "lengths": torch.Tensor([1] * batchsize)
+                .int()
+                .cuda(non_blocking=non_blocking),
+                "valid": torch.Tensor([1] * batchsize)
+                .bool()
+                .cuda(non_blocking=non_blocking),
+            }
+        else:
+            input[key] = {
+                "data": torch.randn([batchsize] + shape).float(),
+                "lengths": torch.Tensor([1] * batchsize).int(),
+                "valid": torch.Tensor([1] * batchsize).bool(),
+            }
+    return input
+
+
 @contextlib.contextmanager
 def _train_mode(model: nn.Module, train_mode: bool):
     """Context manager which sets the train mode of a model. After returning, it


### PR DESCRIPTION
Summary:
Changes in FAIM video code base:
* Add `flops` definition for the modules that are specific to FAIM.
* Add few unit tests.

Changes in ClassyVision code base:
* Add `LayerNorm`, `BatchNorm1d`,   in `_layer_flops`.
* Add `get_multimodel_dummy_input` to support Dict input.
* Not recursive to leaf if the module has `flops` attribute. (e.g for `nn.MultiheadAttention`)

 ---

Below listed the modules with/without flops supported in FAIM video:
**Supported**
class MLP
	nn.Linear
	nn.BatchNorm1d
	nn.ReLU
	nn.Dropout
	nn.LayerNorm
class Normalization
	nn.BatchNorm1d
	nn.LayerNorm

class TemporalPooling
class FusionLayer
class LearnMissingDefault
class AttentionMultihead
	nn.MultiheadAttention

**Not supported**
class LSTM
class TemporalConvolution
class TransformerEncoder
class AttentionFCSoftmax
class XLUEmbedder
class SEGate
class EmbeddingNonLocalGate
class GateLayer

Differential Revision: D20560701

