### PR TITLE
Make blocks attachable automatically when needed

### DIFF
--- a/classy_vision/models/classy_block.py
+++ b/classy_vision/models/classy_block.py
@@ -19,16 +19,11 @@ class ClassyBlock(nn.Module):
         self.name = name
         self.output = torch.zeros(0)
         self._module = module
-        self._should_cache_output = False
 
-    def set_cache_output(self, should_cache_output: bool = True):
-        """
-        Whether to cache the output of wrapped module for head execution.
-        """
-        self._should_cache_output = should_cache_output
+    def wrapped_module(self):
+        return self._module
 
     def forward(self, input):
         output = self._module(input)
-        if self._should_cache_output:
-            self.output = output
+        self.output = output
         return output

--- a/classy_vision/models/resnext3d_stage.py
+++ b/classy_vision/models/resnext3d_stage.py
@@ -91,7 +91,6 @@ class ResStage(ResStageBase):
         num_groups,
         skip_transformation_type,
         residual_transformation_type,
-        block_callback=None,
         inplace_relu=True,
         bn_eps=1e-5,
         bn_mmt=0.1,
@@ -127,8 +126,6 @@ class ResStage(ResStageBase):
                 num_groups>1 is for ResNeXt like networks.
             skip_transformation_type (str): the type of skip transformation
             residual_transformation_type (str): the type of residual transformation
-            block_callback (function object): a callback function to be called with
-                residual block and its name as input arguments
             disable_pre_activation (bool): If true, disable the preactivation,
                 which includes BatchNorm3D and ReLU.
             final_stage (bool): If true, this is the last stage in the model.
@@ -171,8 +168,6 @@ class ResStage(ResStageBase):
                     disable_pre_activation=block_disable_pre_activation,
                 )
                 block_name = self._block_name(p, stage_idx, i)
-                if block_callback:
-                    res_block = block_callback(block_name, res_block)
                 blocks.append((block_name, res_block))
 
             if final_stage and (
@@ -185,8 +180,6 @@ class ResStage(ResStageBase):
                 activate_relu = nn.ReLU(inplace=True)
                 activate_bn_name = "-".join([block_name, "bn"])
                 activate_relu_name = "-".join([block_name, "relu"])
-                if block_callback:
-                    activate_relu = block_callback(activate_relu_name, activate_relu)
                 blocks.append((activate_bn_name, activate_bn))
                 blocks.append((activate_relu_name, activate_relu))
 


### PR DESCRIPTION
Summary:
I was frustrated by the fact that I needed to change the code for every model if I needed to be able to attach heads to it - something we need to do with most trained models.
Ideally, users should be able to write their models without writing anything classy vision specific and be able to attach heads.

I've made a couple of diffs which get us there, wanted to see what everyone thought about them. Please look at the second diff to see the end result.

In this diff, I make the following changes -
- `build_attachable_block` becomes a private function (`_build_attachable_block`), and models  don't need to call it anymore.
- Instead, when someone tries to attach to a module called `my_block`, we recursively search for it and wrap it by a `ClassyBlock` on the fly
- Updated `get_classy_state` and `set_classy_state` to be compatible with the changes
- Users can attach heads to any block which has a unique name (like `block3-2`)
- `models_classy_model_test` wasn't being run internally; renamed
`classy_block_test` to `models_classy_block_test`
- Added additional test cases to test the changes

NOTE: This breaks all checkpoints since the model definitions have changed.

Differential Revision: D20714865

