### PR TITLE
Move num_dataloader_workers out of ClassyTrainer

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -99,7 +99,7 @@ def main(args, config):
         args.distributed_backend
     ]
 
-    trainer = trainer_class(num_dataloader_workers=args.num_workers)
+    trainer = trainer_class()
 
     logging.info(
         f"Starting training on rank {get_rank()} worker. "

--- a/classy_vision/dataset/__init__.py
+++ b/classy_vision/dataset/__init__.py
@@ -24,7 +24,11 @@ def build_dataset(config, *args, **kwargs):
     dataset class to instantiate. For instance, a config `{"name": "my_dataset",
     "folder": "/data"}` will find a class that was registered as "my_dataset"
     (see :func:`register_dataset`) and call .from_config on it."""
-    return DATASET_REGISTRY[config["name"]].from_config(config, *args, **kwargs)
+    dataset = DATASET_REGISTRY[config["name"]].from_config(config, *args, **kwargs)
+    num_workers = config.get("num_workers")
+    if num_workers is not None:
+        dataset.set_num_workers(num_workers)
+    return dataset
 
 
 def register_dataset(name):

--- a/classy_vision/generic/opts.py
+++ b/classy_vision/generic/opts.py
@@ -19,12 +19,6 @@ def add_generic_args(parser):
         "--config_file", type=str, help="path to config file for model", required=True
     )
     parser.add_argument(
-        "--num_workers",
-        default=4,
-        type=int,
-        help="number of dataloading workers (default = 4)",
-    )
-    parser.add_argument(
         "--checkpoint_folder",
         default="",
         type=str,
@@ -137,7 +131,6 @@ def check_generic_args(args):
     """
 
     # check types and values:
-    assert is_pos_int(args.num_workers), "incorrect number of workers"
     assert is_pos_int(args.visdom_port), "incorrect visdom port"
 
     # create checkpoint folder if it does not exist:

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -66,13 +66,11 @@ class FineTuningTask(ClassificationTask):
         else:
             self.base_model.train(phase["train"])
 
-    def prepare(
-        self, num_dataloader_workers: int = 0, dataloader_mp_context=None
-    ) -> None:
+    def prepare(self) -> None:
         assert (
             self.pretrained_checkpoint is not None
         ), "Need a pretrained checkpoint for fine tuning"
-        super().prepare(num_dataloader_workers, dataloader_mp_context)
+        super().prepare()
         if self.checkpoint is None:
             # no checkpoint exists, load the model's state from the pretrained
             # checkpoint

--- a/classy_vision/trainer/classy_trainer.py
+++ b/classy_vision/trainer/classy_trainer.py
@@ -25,23 +25,6 @@ class ClassyTrainer:
 
     """
 
-    def __init__(
-        self,
-        num_dataloader_workers: int = 0,
-        dataloader_mp_context: Optional[str] = None,
-    ):
-        """Constructor for ClassyTrainer.
-
-        Args:
-            num_dataloader_workers: Number of CPU processes doing dataloading
-                per GPU. If 0, then dataloading is done on main thread.
-            dataloader_mp_context: Determines how to launch
-                new processes for dataloading. Must be one of "fork", "forkserver",
-                "spawn". If None, process launching is inherited from parent.
-        """
-        self.num_dataloader_workers = num_dataloader_workers
-        self.dataloader_mp_context = dataloader_mp_context
-
     def train(self, task: ClassyTask):
         """Runs training phases, phases are generated from the config.
 
@@ -50,10 +33,7 @@ class ClassyTrainer:
                 everything that is needed for training
         """
 
-        task.prepare(
-            num_dataloader_workers=self.num_dataloader_workers,
-            dataloader_mp_context=self.dataloader_mp_context,
-        )
+        task.prepare()
         assert isinstance(task, ClassyTask)
 
         # make sure all the workers start training at the same time

--- a/test/generic/config_utils.py
+++ b/test/generic/config_utils.py
@@ -20,6 +20,7 @@ def get_test_task_config(head_num_classes=1000):
                 "num_samples": 2000,
                 "seed": 0,
                 "batchsize_per_replica": 32,
+                "num_workers": 1,
                 "use_shuffle": True,
                 "transforms": [
                     {
@@ -43,6 +44,7 @@ def get_test_task_config(head_num_classes=1000):
                 "num_samples": 2000,
                 "seed": 0,
                 "batchsize_per_replica": 32,
+                "num_workers": 1,
                 "use_shuffle": False,
                 "transforms": [
                     {
@@ -99,6 +101,7 @@ def get_fast_test_task_config(head_num_classes=1000):
                 "num_samples": 10,
                 "seed": 0,
                 "batchsize_per_replica": 2,
+                "num_workers": 1,
                 "use_shuffle": False,
                 "transforms": [
                     {
@@ -122,6 +125,7 @@ def get_fast_test_task_config(head_num_classes=1000):
                 "num_samples": 10,
                 "seed": 0,
                 "batchsize_per_replica": 2,
+                "num_workers": 1,
                 "use_shuffle": False,
                 "transforms": [
                     {

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -65,10 +65,10 @@ class TestClassificationTask(unittest.TestCase):
             dataset = build_dataset(config["dataset"][phase_type])
             task.set_dataset(dataset, phase_type)
 
-        task.prepare(num_dataloader_workers=1)
+        task.prepare()
 
         task = build_task(config)
-        task.prepare(num_dataloader_workers=1)
+        task.prepare()
 
     def test_checkpointing(self):
         """

--- a/test/trainer_distributed_trainer_test.py
+++ b/test/trainer_distributed_trainer_test.py
@@ -57,7 +57,6 @@ class TestDistributedTrainer(unittest.TestCase):
             --use_env \
             {self.path}/../classy_train.py \
             --config={self.config_files[config_key]} \
-            --num_workers=4 \
             --log_freq=100 \
             --distributed_backend=ddp
             """
@@ -79,7 +78,6 @@ class TestDistributedTrainer(unittest.TestCase):
         --use_env \
         {self.path}/../classy_train.py \
         --config={self.config_files["sync_bn_config"]} \
-        --num_workers=4 \
         --log_freq=100 \
         --distributed_backend=ddp
         """


### PR DESCRIPTION
Summary:
In order to get rid of ClassyTrainer, we need to move num_dataloader_workers and dataloader_mp_context somewhere else. Move the context to the task and num_workers to ClassyDataset. This also changes the default multiprocessing context to spawn, for consistency. That required changing tests in fblearner to dev-nosan.

This is a breaking change to the configs, and I'll announce it in the group before landing. Will also try to land other breaking changes at the same time to minimize disruption.

Differential Revision: D20803692

