### PR TITLE
Kill ClassyOptimizer.backward

### DIFF
--- a/classy_vision/optim/classy_optimizer.py
+++ b/classy_vision/optim/classy_optimizer.py
@@ -195,19 +195,6 @@ class ClassyOptimizer:
         self.optimizer.load_state_dict(state["optim"])
         self.parameters.update(state["parameters"])
 
-    def backward(self, loss: torch.Tensor) -> None:
-        """
-        Computer gradients with respect to the loss.
-
-        Calls :func:`zero_grad` and then computes the gradient using
-        `torch.Tensor.backward <https://pytorch.org/docs/stable/
-        tensors.html#torch.Tensor.backward>`_. See :mod:`torch.autograd` for
-        more information.
-        """
-        # TODO (aadcock): Add gradient accumulation logic
-        self.zero_grad()
-        loss.backward()
-
     def update_schedule_on_epoch(self, where: float) -> None:
         """
         Update the param schedule at the end of an epoch.

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -823,14 +823,14 @@ class ClassificationTask(ClassyTask):
             self.update_meters(output, sample)
 
         # Run backwards pass / update optimizer
+        self.optimizer.zero_grad()
         if self.amp_args is not None:
-            self.optimizer.zero_grad()
             with apex.amp.scale_loss(
                 local_loss, self.optimizer.optimizer
             ) as scaled_loss:
                 scaled_loss.backward()
         else:
-            self.optimizer.backward(local_loss)
+            local_loss.backward()
 
         self.check_inf_nan(loss)
 


### PR DESCRIPTION
Summary:
This is a one-line method that gets called once. Normally this would be fine,
but here this mixes optimizer with the loss in a way that is inconsistent with
PyTorch: everyone is used to calling loss.backward(), not optimizer.backward().

Get rid of this nonsense.

Differential Revision: D21049228

