### PR TITLE
Allow specifying checkpoint path in tasks

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -78,17 +78,16 @@ def main(args, config):
     task = build_task(config)
 
     # Load checkpoint, if available.
-    checkpoint = load_checkpoint(args.checkpoint_load_path)
-    task.set_checkpoint(checkpoint)
+    if args.checkpoint_load_path:
+        task.set_checkpoint(args.checkpoint_load_path)
 
     # Load a checkpoint contraining a pre-trained model. This is how we
     # implement fine-tuning of existing models.
-    pretrained_checkpoint = load_checkpoint(args.pretrained_checkpoint_path)
-    if pretrained_checkpoint is not None:
+    if args.pretrained_checkpoint_path:
         assert isinstance(
             task, FineTuningTask
         ), "Can only use a pretrained checkpoint for fine tuning tasks"
-        task.set_pretrained_checkpoint(pretrained_checkpoint)
+        task.set_pretrained_checkpoint(args.pretrained_checkpoint_path)
 
     # Configure hooks to do tensorboard logging, checkpoints and so on
     task.set_hooks(configure_hooks(args, config))

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -31,19 +31,22 @@ class FineTuningTask(ClassificationTask):
         """
         task = super().from_config(config)
 
-        pretrained_checkpoint = load_checkpoint(config.get("pretrained_checkpoint"))
-
-        if pretrained_checkpoint is not None:
-            task.set_pretrained_checkpoint(pretrained_checkpoint)
+        pretrained_checkpoint_path = config.get("pretrained_checkpoint")
+        if pretrained_checkpoint_path:
+            task.set_pretrained_checkpoint(pretrained_checkpoint_path)
 
         task.set_reset_heads(config.get("reset_heads", False))
         task.set_freeze_trunk(config.get("freeze_trunk", False))
         return task
 
-    def set_pretrained_checkpoint(self, checkpoint: Dict[str, Any]) -> "FineTuningTask":
-        assert (
-            "classy_state_dict" in checkpoint
-        ), "Checkpoint does not contain classy_state_dict"
+    def set_pretrained_checkpoint(self, checkpoint_path: str) -> "FineTuningTask":
+        checkpoint = load_checkpoint(checkpoint_path)
+        self.pretrained_checkpoint = checkpoint
+        return self
+
+    def _set_pretrained_checkpoint_dict(
+        self, checkpoint: Dict[str, Any]
+    ) -> "FineTuningTask":
         self.pretrained_checkpoint = checkpoint
         return self
 

--- a/test/hooks_checkpoint_hook_test.py
+++ b/test/hooks_checkpoint_hook_test.py
@@ -8,7 +8,6 @@ import copy
 import os
 import shutil
 import tempfile
-import unittest
 from test.generic.config_utils import get_fast_test_task_config, get_test_task_config
 from test.generic.hook_test_utils import HookTestBase
 
@@ -173,7 +172,7 @@ class TestCheckpointHook(HookTestBase):
             task = build_task(config)
 
             # set the checkpoint
-            task.set_checkpoint(checkpoint)
+            task._set_checkpoint_dict(checkpoint)
 
             task.set_use_gpu(use_gpu)
 

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -12,7 +12,7 @@ from test.generic.utils import compare_model_state, compare_samples, compare_sta
 
 import torch
 from classy_vision.dataset import build_dataset
-from classy_vision.generic.util import get_checkpoint_dict, load_checkpoint
+from classy_vision.generic.util import get_checkpoint_dict
 from classy_vision.hooks import CheckpointHook, LossLrMeterLoggingHook
 from classy_vision.losses import build_loss
 from classy_vision.models import build_model
@@ -89,7 +89,7 @@ class TestClassificationTask(unittest.TestCase):
             task.advance_phase()
 
             # set task's state as task_2's checkpoint
-            task_2.set_checkpoint(get_checkpoint_dict(task, {}, deep_copy=True))
+            task_2._set_checkpoint_dict(get_checkpoint_dict(task, {}, deep_copy=True))
             task_2.prepare()
 
             # task 2 should have the same state
@@ -120,16 +120,13 @@ class TestClassificationTask(unittest.TestCase):
         trainer = LocalTrainer()
         trainer.train(task)
 
-        # load the final train checkpoint
-        checkpoint = load_checkpoint(self.base_dir)
-
         # make sure fetching the where raises an exception, which means that
         # where is >= 1.0
         with self.assertRaises(Exception):
             task.where
 
         # set task_2's state as task's final train checkpoint
-        task_2.set_checkpoint(checkpoint)
+        task_2.set_checkpoint(self.base_dir)
         task_2.prepare()
 
         # we should be able to train the task
@@ -156,7 +153,7 @@ class TestClassificationTask(unittest.TestCase):
         trainer.train(train_task)
 
         # set task's state as task_2's checkpoint
-        test_only_task.set_checkpoint(
+        test_only_task._set_checkpoint_dict(
             get_checkpoint_dict(train_task, {}, deep_copy=True)
         )
         test_only_task.prepare()
@@ -216,7 +213,7 @@ class TestClassificationTask(unittest.TestCase):
             task.prepare()
 
             # set task's state as task_2's checkpoint
-            task_2.set_checkpoint(get_checkpoint_dict(task, {}, deep_copy=True))
+            task_2._set_checkpoint_dict(get_checkpoint_dict(task, {}, deep_copy=True))
 
             # we should be able to run the trainer using state from a different device
             trainer = LocalTrainer()

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -20,20 +20,20 @@ class TestFineTuningTask(unittest.TestCase):
         return compare_model_state(self, state_1, state_2, check_heads=check_heads)
 
     def _get_fine_tuning_config(
-        self, head_num_classes=1000, pretrained_checkpoint=False
+        self, head_num_classes=100, pretrained_checkpoint=False
     ):
         config = get_fast_test_task_config(head_num_classes=head_num_classes)
         config["name"] = "fine_tuning"
-        config["num_epochs"] = 10
+        config["num_epochs"] = 2
 
         if pretrained_checkpoint:
             config["pretrained_checkpoint"] = "/path/to/pretrained/checkpoint"
 
         return config
 
-    def _get_pre_train_config(self, head_num_classes=1000):
+    def _get_pre_train_config(self, head_num_classes=100):
         config = get_fast_test_task_config(head_num_classes=head_num_classes)
-        config["num_epochs"] = 10
+        config["num_epochs"] = 2
         return config
 
     def test_build_task(self):
@@ -62,7 +62,7 @@ class TestFineTuningTask(unittest.TestCase):
             fine_tuning_task.prepare()
 
         # test: prepare should succeed after pre-trained checkpoint is set
-        fine_tuning_task.set_pretrained_checkpoint(checkpoint)
+        fine_tuning_task._set_pretrained_checkpoint_dict(checkpoint)
         fine_tuning_task.prepare()
 
         # test: prepare should succeed if a pre-trained checkpoint is provided in the
@@ -73,21 +73,20 @@ class TestFineTuningTask(unittest.TestCase):
             return_value=checkpoint,
         ):
             fine_tuning_task = build_task(fine_tuning_config)
-
         fine_tuning_task.prepare()
 
         # test: a fine tuning task with incompatible heads with a manually set
         # pre-trained checkpoint should fail to prepare if the heads are not reset
         fine_tuning_config = self._get_fine_tuning_config(head_num_classes=10)
         fine_tuning_task = build_task(fine_tuning_config)
-        fine_tuning_task.set_pretrained_checkpoint(checkpoint)
+        fine_tuning_task._set_pretrained_checkpoint_dict(checkpoint)
 
         with self.assertRaises(Exception):
             fine_tuning_task.prepare()
 
         # test: a fine tuning task with incompatible heads with a manually set
         # pre-trained checkpoint should succeed to prepare if the heads are reset
-        fine_tuning_task.set_pretrained_checkpoint(
+        fine_tuning_task._set_pretrained_checkpoint_dict(
             copy.deepcopy(checkpoint)
         ).set_reset_heads(True)
 
@@ -104,7 +103,6 @@ class TestFineTuningTask(unittest.TestCase):
             return_value=copy.deepcopy(checkpoint),
         ):
             fine_tuning_task = build_task(fine_tuning_config)
-
         with self.assertRaises(Exception):
             fine_tuning_task.prepare()
 
@@ -115,20 +113,20 @@ class TestFineTuningTask(unittest.TestCase):
         fine_tuning_task.prepare()
 
     def test_train(self):
-        pre_train_config = self._get_pre_train_config(head_num_classes=1000)
+        pre_train_config = self._get_pre_train_config(head_num_classes=100)
         pre_train_task = build_task(pre_train_config)
         trainer = LocalTrainer()
         trainer.train(pre_train_task)
         checkpoint = get_checkpoint_dict(pre_train_task, {})
 
-        for reset_heads, heads_num_classes in [(False, 1000), (True, 200)]:
+        for reset_heads, heads_num_classes in [(False, 100), (True, 20)]:
             for freeze_trunk in [True, False]:
                 fine_tuning_config = self._get_fine_tuning_config(
                     head_num_classes=heads_num_classes
                 )
                 fine_tuning_task = build_task(fine_tuning_config)
                 fine_tuning_task = (
-                    fine_tuning_task.set_pretrained_checkpoint(
+                    fine_tuning_task._set_pretrained_checkpoint_dict(
                         copy.deepcopy(checkpoint)
                     )
                     .set_reset_heads(reset_heads)

--- a/tutorials/fine_tuning.ipynb
+++ b/tutorials/fine_tuning.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -56,7 +56,7 @@
     "\n",
     "train_dataset = SyntheticImageDataset.from_config({\n",
     "    \"batchsize_per_replica\": 32,\n",
-    "    \"num_samples\": 2000,\n",
+    "    \"num_samples\": 200,\n",
     "    \"crop_size\": 224,\n",
     "    \"class_ratio\": 0.5,\n",
     "    \"seed\": 0,\n",
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "collapsed": true
    },
@@ -323,33 +323,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0502 162930.244 local_trainer.py:24] Using CPU\n",
+      "I0502 162930.254 loss_lr_meter_logging_hook.py:38] Starting training. Task: <classy_vision.tasks.classification_task.ClassificationTask object at 0x7f993fa69a10>\n",
+      "I0502 165422.367 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 0 (100.00% done), loss: 1.9421, meters: [accuracy_meter(top_1=0.670000,top_5=0.840000)]\n",
+      "I0502 165422.368 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 165611.635 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 0 (100.00% done), loss: 14.6478, meters: [accuracy_meter(top_1=0.535000,top_5=1.000000)]\n",
+      "I0502 172233.979 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 1 (100.00% done), loss: 0.9628, meters: [accuracy_meter(top_1=0.910000,top_5=1.000000)]\n",
+      "I0502 172233.980 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 172425.138 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 1 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 174927.788 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 2 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 174927.789 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 175116.757 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 2 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 181608.966 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 3 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 181608.967 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 181757.168 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 3 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n"
+     ]
+    }
+   ],
    "source": [
     "trainer.train(pretrain_task)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Training is done! Let us now load the saved checkpoint, we will use this later for fine tuning."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from classy_vision.generic.util import load_checkpoint\n",
-    "\n",
-    "pretrained_checkpoint = load_checkpoint(pretrain_checkpoint_dir)"
    ]
   },
   {
@@ -368,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "collapsed": true
    },
@@ -393,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "collapsed": true
    },
@@ -417,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -437,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -455,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
@@ -484,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -504,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -526,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -549,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true
    },
@@ -586,11 +585,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {
+      "bento_obj_id": "140295984440976"
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fine_tuning_task.set_freeze_trunk(True)"
    ]
@@ -604,11 +614,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {
+      "bento_obj_id": "140295984440976"
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fine_tuning_task.set_reset_heads(True)"
    ]
@@ -617,18 +638,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to give our task the pre-trained checkpoint, which it'll need to start pre-training on."
+    "We need to give our task the path to our pre-trained checkpoint, which it'll need to start fine-tuning on."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0502 181800.442 util.py:483] Attempting to load checkpoint from /tmp/checkpoint_1588462166.8579776/checkpoint.torch\n",
+      "I0502 181800.639 util.py:488] Loaded checkpoint from /tmp/checkpoint_1588462166.8579776/checkpoint.torch\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {
+      "bento_obj_id": "140295984440976"
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "fine_tuning_task.set_pretrained_checkpoint(pretrained_checkpoint)"
+    "fine_tuning_task.set_pretrained_checkpoint(pretrain_checkpoint_dir)"
    ]
   },
   {
@@ -640,11 +680,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0502 181800.646 local_trainer.py:24] Using CPU\n",
+      "I0502 181801.040 util.py:510] Model state load successful\n",
+      "I0502 181801.042 loss_lr_meter_logging_hook.py:38] Starting training. Task: <classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>\n",
+      "I0502 181950.398 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 0 (100.00% done), loss: 0.1105, meters: [accuracy_meter(top_1=0.895000)]\n",
+      "I0502 181950.399 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588468680.417235'...\n",
+      "I0502 182137.554 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 0 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000)]\n"
+     ]
+    }
+   ],
    "source": [
     "trainer.train(fine_tuning_task)"
    ]
@@ -671,9 +722,9 @@
    "bento/extensions/theme/main.css": true
   },
   "kernelspec": {
-   "display_name": "Classy Vision",
+   "display_name": "Classy Vision (local)",
    "language": "python",
-   "name": "bento_kernel_classy_vision"
+   "name": "classy_vision_local"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Summary:
- Changed the set_checkpoint and set_pretrained_checkpoint calls to take either the `checkpoint_path`, or the `checkpoint`.
  - The tests still pass the checkpoint, and that arg can be possibly be removed in a follow up diff.
- Added test cases and fixed tests
  - The fine tuning tests were too slow and were timing out, made them faster

Differential Revision: D21231849

