### PR TITLE
Load checkpoint on master and broadcast to all replicas

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -78,17 +78,16 @@ def main(args, config):
     task = build_task(config)
 
     # Load checkpoint, if available.
-    checkpoint = load_checkpoint(args.checkpoint_load_path)
-    task.set_checkpoint(checkpoint)
+    if args.checkpoint_load_path:
+        task.set_checkpoint(args.checkpoint_load_path)
 
     # Load a checkpoint contraining a pre-trained model. This is how we
     # implement fine-tuning of existing models.
-    pretrained_checkpoint = load_checkpoint(args.pretrained_checkpoint_path)
-    if pretrained_checkpoint is not None:
+    if args.pretrained_checkpoint_path:
         assert isinstance(
             task, FineTuningTask
         ), "Can only use a pretrained checkpoint for fine tuning tasks"
-        task.set_pretrained_checkpoint(pretrained_checkpoint)
+        task.set_pretrained_checkpoint(args.pretrained_checkpoint_path)
 
     # Configure hooks to do tensorboard logging, checkpoints and so on
     task.set_hooks(configure_hooks(args, config))

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -31,19 +31,22 @@ class FineTuningTask(ClassificationTask):
         """
         task = super().from_config(config)
 
-        pretrained_checkpoint = load_checkpoint(config.get("pretrained_checkpoint"))
-
-        if pretrained_checkpoint is not None:
-            task.set_pretrained_checkpoint(pretrained_checkpoint)
+        pretrained_checkpoint_path = config.get("pretrained_checkpoint")
+        if pretrained_checkpoint_path:
+            task.set_pretrained_checkpoint(pretrained_checkpoint_path)
 
         task.set_reset_heads(config.get("reset_heads", False))
         task.set_freeze_trunk(config.get("freeze_trunk", False))
         return task
 
-    def set_pretrained_checkpoint(self, checkpoint: Dict[str, Any]) -> "FineTuningTask":
-        assert (
-            "classy_state_dict" in checkpoint
-        ), "Checkpoint does not contain classy_state_dict"
+    def set_pretrained_checkpoint(self, checkpoint_path: str) -> "FineTuningTask":
+        checkpoint = load_checkpoint(checkpoint_path)
+        self.pretrained_checkpoint = checkpoint
+        return self
+
+    def _set_pretrained_checkpoint_dict(
+        self, checkpoint: Dict[str, Any]
+    ) -> "FineTuningTask":
         self.pretrained_checkpoint = checkpoint
         return self
 

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -6,7 +6,10 @@
 
 from typing import Any, Dict
 
-from classy_vision.generic.util import load_checkpoint, update_classy_model
+from classy_vision.generic.util import (
+    load_and_broadcast_checkpoint,
+    update_classy_model,
+)
 from classy_vision.tasks import ClassificationTask, register_task
 
 
@@ -14,7 +17,8 @@ from classy_vision.tasks import ClassificationTask, register_task
 class FineTuningTask(ClassificationTask):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.pretrained_checkpoint = None
+        self.pretrained_checkpoint_dict = None
+        self.pretrained_checkpoint_path = None
         self.reset_heads = False
         self.freeze_trunk = False
 
@@ -40,14 +44,13 @@ class FineTuningTask(ClassificationTask):
         return task
 
     def set_pretrained_checkpoint(self, checkpoint_path: str) -> "FineTuningTask":
-        checkpoint = load_checkpoint(checkpoint_path)
-        self.pretrained_checkpoint = checkpoint
+        self.pretrained_checkpoint_path = checkpoint_path
         return self
 
     def _set_pretrained_checkpoint_dict(
-        self, checkpoint: Dict[str, Any]
+        self, checkpoint_dict: Dict[str, Any]
     ) -> "FineTuningTask":
-        self.pretrained_checkpoint = checkpoint
+        self.pretrained_checkpoint_dict = checkpoint_dict
         return self
 
     def set_reset_heads(self, reset_heads: bool) -> "FineTuningTask":
@@ -70,16 +73,23 @@ class FineTuningTask(ClassificationTask):
             self.base_model.train(phase["train"])
 
     def prepare(self) -> None:
-        assert (
-            self.pretrained_checkpoint is not None
-        ), "Need a pretrained checkpoint for fine tuning"
         super().prepare()
-        if self.checkpoint is None:
+        if self.checkpoint_dict is None:
             # no checkpoint exists, load the model's state from the pretrained
             # checkpoint
+
+            if self.pretrained_checkpoint_path:
+                self.pretrained_checkpoint_dict = load_and_broadcast_checkpoint(
+                    self.pretrained_checkpoint_path
+                )
+
+            assert (
+                self.pretrained_checkpoint_dict is not None
+            ), "Need a pretrained checkpoint for fine tuning"
+
             state_load_success = update_classy_model(
                 self.base_model,
-                self.pretrained_checkpoint["classy_state_dict"]["base_model"],
+                self.pretrained_checkpoint_dict["classy_state_dict"]["base_model"],
                 self.reset_heads,
             )
             assert (

--- a/test/generic_distributed_util_test.py
+++ b/test/generic_distributed_util_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import tempfile
+import unittest
+
+import torch
+from classy_vision.generic.distributed_util import broadcast_object
+from torch.multiprocessing import Event, Process, Queue
+
+
+def init_and_run_process(
+    rank, world_size, filename, fn, input, q, wait_event, backend="gloo"
+):
+    torch.distributed.init_process_group(
+        backend, init_method=f"file://{filename}", rank=rank, world_size=world_size
+    )
+    r = fn(input)
+    q.put(r)
+
+    wait_event.wait()
+    return
+
+
+def run_in_process_group(world_size, filename, fn, inputs):
+    if torch.distributed.is_initialized():
+        torch.distributed.destroy_process_group()
+    processes = []
+    q = Queue()
+    wait_event = Event()
+
+    # run the remaining processes
+    # for rank in range(world_size - 1):
+    for rank in range(world_size):
+        p = Process(
+            target=init_and_run_process,
+            args=(rank, world_size, filename, fn, inputs[rank], q, wait_event),
+        )
+        p.start()
+        processes.append(p)
+
+    # fetch the results from the queue before joining, the background processes
+    # need to be alive if the queue contains tensors. See
+    # https://discuss.pytorch.org/t/using-torch-tensor-over-multiprocessing-queue-process-fails/2847/3  # noqa: B950
+    results = []
+    for _ in range(len(processes)):
+        results.append(q.get())
+
+    wait_event.set()
+
+    for p in processes:
+        p.join()
+    return results
+
+
+class TestDistributedUtil(unittest.TestCase):
+    def test_broadcast_object(self):
+        world_size = 3
+        for obj in [
+            {"a": 12, "b": [2, 3, 4], "tensor": torch.randn(10, 10)},
+            None,
+            {"tensor": torch.randn(10000, 10000)},  # 400 MB
+        ]:
+            filename = tempfile.NamedTemporaryFile(delete=True).name
+            inputs = [None] * world_size
+            # only the master worker has the object
+            inputs[0] = obj
+            results = run_in_process_group(
+                world_size, filename, broadcast_object, inputs
+            )
+            self.assertEqual(len(results), world_size)
+            for result in results:
+                if isinstance(obj, dict):
+                    for key in obj:
+                        if key == "tensor":
+                            self.assertTrue(torch.allclose(result[key], obj[key]))
+                        else:
+                            self.assertEqual(result[key], obj[key])
+                else:
+                    self.assertEqual(result, obj)

--- a/test/hooks_checkpoint_hook_test.py
+++ b/test/hooks_checkpoint_hook_test.py
@@ -8,7 +8,6 @@ import copy
 import os
 import shutil
 import tempfile
-import unittest
 from test.generic.config_utils import get_fast_test_task_config, get_test_task_config
 from test.generic.hook_test_utils import HookTestBase
 
@@ -173,7 +172,7 @@ class TestCheckpointHook(HookTestBase):
             task = build_task(config)
 
             # set the checkpoint
-            task.set_checkpoint(checkpoint)
+            task._set_checkpoint_dict(checkpoint)
 
             task.set_use_gpu(use_gpu)
 

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -106,28 +106,6 @@ class TestClassificationTask(unittest.TestCase):
             task_2.train_step()
             self._compare_states(task.get_classy_state(), task_2.get_classy_state())
 
-    def test_checkpoint_from_config(self):
-        config = get_fast_test_task_config()
-        task = build_task(config).set_hooks(
-            [CheckpointHook(self.base_dir, {}, phase_types=["train"])]
-        )
-        trainer = LocalTrainer()
-        trainer.train(task)
-
-        task_2 = build_task(config)
-
-        # set task_2's state as task's final train checkpoint
-        task_2.set_checkpoint(self.base_dir)
-        task_2.prepare()
-
-        # create a task by passing the checkpoint in the config
-        config["checkpoint"] = self.base_dir
-        task_3 = build_task(config)
-        task_3.prepare()
-
-        # task_2 and task_3 should have the same state
-        self._compare_states(task_2.get_classy_state(), task_3.get_classy_state())
-
     def test_final_train_checkpoint(self):
         """Test that a train phase checkpoint with a where of 1.0 can be loaded"""
 

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -20,20 +20,20 @@ class TestFineTuningTask(unittest.TestCase):
         return compare_model_state(self, state_1, state_2, check_heads=check_heads)
 
     def _get_fine_tuning_config(
-        self, head_num_classes=1000, pretrained_checkpoint=False
+        self, head_num_classes=100, pretrained_checkpoint=False
     ):
         config = get_fast_test_task_config(head_num_classes=head_num_classes)
         config["name"] = "fine_tuning"
-        config["num_epochs"] = 10
+        config["num_epochs"] = 2
 
         if pretrained_checkpoint:
             config["pretrained_checkpoint"] = "/path/to/pretrained/checkpoint"
 
         return config
 
-    def _get_pre_train_config(self, head_num_classes=1000):
+    def _get_pre_train_config(self, head_num_classes=100):
         config = get_fast_test_task_config(head_num_classes=head_num_classes)
-        config["num_epochs"] = 10
+        config["num_epochs"] = 2
         return config
 
     def test_build_task(self):
@@ -62,7 +62,7 @@ class TestFineTuningTask(unittest.TestCase):
             fine_tuning_task.prepare()
 
         # test: prepare should succeed after pre-trained checkpoint is set
-        fine_tuning_task.set_pretrained_checkpoint(checkpoint)
+        fine_tuning_task._set_pretrained_checkpoint_dict(checkpoint)
         fine_tuning_task.prepare()
 
         # test: prepare should succeed if a pre-trained checkpoint is provided in the
@@ -73,21 +73,20 @@ class TestFineTuningTask(unittest.TestCase):
             return_value=checkpoint,
         ):
             fine_tuning_task = build_task(fine_tuning_config)
-
         fine_tuning_task.prepare()
 
         # test: a fine tuning task with incompatible heads with a manually set
         # pre-trained checkpoint should fail to prepare if the heads are not reset
         fine_tuning_config = self._get_fine_tuning_config(head_num_classes=10)
         fine_tuning_task = build_task(fine_tuning_config)
-        fine_tuning_task.set_pretrained_checkpoint(checkpoint)
+        fine_tuning_task._set_pretrained_checkpoint_dict(checkpoint)
 
         with self.assertRaises(Exception):
             fine_tuning_task.prepare()
 
         # test: a fine tuning task with incompatible heads with a manually set
         # pre-trained checkpoint should succeed to prepare if the heads are reset
-        fine_tuning_task.set_pretrained_checkpoint(
+        fine_tuning_task._set_pretrained_checkpoint_dict(
             copy.deepcopy(checkpoint)
         ).set_reset_heads(True)
 
@@ -104,7 +103,6 @@ class TestFineTuningTask(unittest.TestCase):
             return_value=copy.deepcopy(checkpoint),
         ):
             fine_tuning_task = build_task(fine_tuning_config)
-
         with self.assertRaises(Exception):
             fine_tuning_task.prepare()
 
@@ -115,20 +113,20 @@ class TestFineTuningTask(unittest.TestCase):
         fine_tuning_task.prepare()
 
     def test_train(self):
-        pre_train_config = self._get_pre_train_config(head_num_classes=1000)
+        pre_train_config = self._get_pre_train_config(head_num_classes=100)
         pre_train_task = build_task(pre_train_config)
         trainer = LocalTrainer()
         trainer.train(pre_train_task)
         checkpoint = get_checkpoint_dict(pre_train_task, {})
 
-        for reset_heads, heads_num_classes in [(False, 1000), (True, 200)]:
+        for reset_heads, heads_num_classes in [(False, 100), (True, 20)]:
             for freeze_trunk in [True, False]:
                 fine_tuning_config = self._get_fine_tuning_config(
                     head_num_classes=heads_num_classes
                 )
                 fine_tuning_task = build_task(fine_tuning_config)
                 fine_tuning_task = (
-                    fine_tuning_task.set_pretrained_checkpoint(
+                    fine_tuning_task._set_pretrained_checkpoint_dict(
                         copy.deepcopy(checkpoint)
                     )
                     .set_reset_heads(reset_heads)

--- a/tutorials/fine_tuning.ipynb
+++ b/tutorials/fine_tuning.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -56,7 +56,7 @@
     "\n",
     "train_dataset = SyntheticImageDataset.from_config({\n",
     "    \"batchsize_per_replica\": 32,\n",
-    "    \"num_samples\": 2000,\n",
+    "    \"num_samples\": 200,\n",
     "    \"crop_size\": 224,\n",
     "    \"class_ratio\": 0.5,\n",
     "    \"seed\": 0,\n",
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "collapsed": true
    },
@@ -143,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true
    },
@@ -228,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -303,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "collapsed": true
    },
@@ -323,33 +323,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0502 162930.244 local_trainer.py:24] Using CPU\n",
+      "I0502 162930.254 loss_lr_meter_logging_hook.py:38] Starting training. Task: <classy_vision.tasks.classification_task.ClassificationTask object at 0x7f993fa69a10>\n",
+      "I0502 165422.367 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 0 (100.00% done), loss: 1.9421, meters: [accuracy_meter(top_1=0.670000,top_5=0.840000)]\n",
+      "I0502 165422.368 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 165611.635 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 0 (100.00% done), loss: 14.6478, meters: [accuracy_meter(top_1=0.535000,top_5=1.000000)]\n",
+      "I0502 172233.979 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 1 (100.00% done), loss: 0.9628, meters: [accuracy_meter(top_1=0.910000,top_5=1.000000)]\n",
+      "I0502 172233.980 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 172425.138 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 1 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 174927.788 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 2 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 174927.789 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 175116.757 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 2 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 181608.966 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 3 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n",
+      "I0502 181608.967 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588462166.8579776'...\n",
+      "I0502 181757.168 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 3 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000,top_5=1.000000)]\n"
+     ]
+    }
+   ],
    "source": [
     "trainer.train(pretrain_task)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Training is done! Let us now load the saved checkpoint, we will use this later for fine tuning."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from classy_vision.generic.util import load_checkpoint\n",
-    "\n",
-    "pretrained_checkpoint = load_checkpoint(pretrain_checkpoint_dir)"
    ]
   },
   {
@@ -368,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "collapsed": true
    },
@@ -393,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "collapsed": true
    },
@@ -417,7 +416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "collapsed": true
    },
@@ -437,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "collapsed": true
    },
@@ -455,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "collapsed": true
    },
@@ -484,7 +483,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "collapsed": true
    },
@@ -504,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "collapsed": true
    },
@@ -526,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "collapsed": true
    },
@@ -549,7 +548,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "collapsed": true
    },
@@ -586,11 +585,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {
+      "bento_obj_id": "140295984440976"
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fine_tuning_task.set_freeze_trunk(True)"
    ]
@@ -604,11 +614,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {
+      "bento_obj_id": "140295984440976"
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "fine_tuning_task.set_reset_heads(True)"
    ]
@@ -617,18 +638,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to give our task the pre-trained checkpoint, which it'll need to start pre-training on."
+    "We need to give our task the path to our pre-trained checkpoint, which it'll need to start fine-tuning on."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0502 181800.442 util.py:483] Attempting to load checkpoint from /tmp/checkpoint_1588462166.8579776/checkpoint.torch\n",
+      "I0502 181800.639 util.py:488] Loaded checkpoint from /tmp/checkpoint_1588462166.8579776/checkpoint.torch\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {
+      "bento_obj_id": "140295984440976"
+     },
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "fine_tuning_task.set_pretrained_checkpoint(pretrained_checkpoint)"
+    "fine_tuning_task.set_pretrained_checkpoint(pretrain_checkpoint_dir)"
    ]
   },
   {
@@ -640,11 +680,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0502 181800.646 local_trainer.py:24] Using CPU\n",
+      "I0502 181801.040 util.py:510] Model state load successful\n",
+      "I0502 181801.042 loss_lr_meter_logging_hook.py:38] Starting training. Task: <classy_vision.tasks.fine_tuning_task.FineTuningTask object at 0x7f993450e690>\n",
+      "I0502 181950.398 loss_lr_meter_logging_hook.py:76] Synced meters: [0] train phase 0 (100.00% done), loss: 0.1105, meters: [accuracy_meter(top_1=0.895000)]\n",
+      "I0502 181950.399 checkpoint_hook.py:78] Saving checkpoint to '/tmp/checkpoint_1588468680.417235'...\n",
+      "I0502 182137.554 loss_lr_meter_logging_hook.py:76] Synced meters: [0] test phase 0 (100.00% done), loss: 0.0000, meters: [accuracy_meter(top_1=1.000000)]\n"
+     ]
+    }
+   ],
    "source": [
     "trainer.train(fine_tuning_task)"
    ]
@@ -671,9 +722,9 @@
    "bento/extensions/theme/main.css": true
   },
   "kernelspec": {
-   "display_name": "Classy Vision",
+   "display_name": "Classy Vision (local)",
    "language": "python",
-   "name": "bento_kernel_classy_vision"
+   "name": "classy_vision_local"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Summary:
- The checkpoint is loaded only on the master and is broadcast to all replicas
- This logic is moved to `prepare()` since `torch.distributed` needs to be initialized

Differential Revision: D21375099

