### PR TITLE
Implement a Classy hook to convert trained model to a TorchScript

### DIFF
--- a/classy_vision/hooks/__init__.py
+++ b/classy_vision/hooks/__init__.py
@@ -84,6 +84,7 @@ def build_hook(hook_config: Dict[str, Any]):
 import_all_modules(FILE_ROOT, "classy_vision.hooks")
 
 from .checkpoint_hook import CheckpointHook  # isort:skip
+from .torchscript_hook import TorchscriptHook  # isort:skip
 from .exponential_moving_average_model_hook import (  # isort:skip
     ExponentialMovingAverageModelHook,
 )
@@ -106,6 +107,7 @@ __all__ = [
     "ExponentialMovingAverageModelHook",
     "LossLrMeterLoggingHook",
     "TensorboardPlotHook",
+    "TorchscriptHook",
     "ModelComplexityHook",
     "ModelTensorboardHook",
     "ProfilerHook",

--- a/classy_vision/hooks/torchscript_hook.py
+++ b/classy_vision/hooks/torchscript_hook.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+
+import torch
+from classy_vision.generic.distributed_util import is_master
+from classy_vision.generic.util import eval_model, get_model_dummy_input
+from classy_vision.hooks import register_hook
+from classy_vision.hooks.classy_hook import ClassyHook
+from fvcore.common.file_io import PathManager
+
+
+# constants
+TORCHSCRIPT_FILE = "torchscript.pt"
+
+
+@register_hook("torchscript")
+class TorchscriptHook(ClassyHook):
+    """
+    Hook to convert a task model into torch script.
+
+    Saves the torch scripts in torchscript_folder.
+    """
+
+    on_phase_start = ClassyHook._noop
+    on_phase_end = ClassyHook._noop
+    on_step = ClassyHook._noop
+
+    def __init__(self, torchscript_folder: str) -> None:
+        """The constructor method of TorchscriptHook.
+
+        Args:
+            torchscript_folder: Folder to store torch scripts in.
+        """
+        super().__init__()
+        assert isinstance(
+            torchscript_folder, str
+        ), "torchscript_folder must be a string specifying the torchscript directory"
+
+        self.torchscript_folder: str = torchscript_folder
+
+    def save_torchscript(self, task) -> None:
+        model = task.base_model
+        input_shape = (
+            model.input_shape if hasattr(task.base_model, "input_shape") else None
+        )
+        if not input_shape:
+            logging.warning(
+                "This model doesn't implement input_shape."
+                "Cannot save torchscripted model."
+            )
+            return
+        input_data = get_model_dummy_input(
+            model,
+            input_shape,
+            input_key=model.input_key if hasattr(model, "input_key") else None,
+        )
+        with eval_model(model) and torch.no_grad():
+            torchscript = torch.jit.trace(model, input_data)
+
+        # save torchscript:
+        logging.info("Saving torchscript to '{}'...".format(self.torchscript_folder))
+        torchscript_name = f"{self.torchscript_folder}/{TORCHSCRIPT_FILE}"
+        with PathManager.open(torchscript_name, "wb") as f:
+            torch.jit.save(torchscript, f)
+
+    def on_start(self, task) -> None:
+        if not is_master() or getattr(task, "test_only", False):
+            return
+        if not PathManager.exists(self.torchscript_folder):
+            err_msg = "Torchscript folder '{}' does not exist.".format(
+                self.torchscript_folder
+            )
+            raise FileNotFoundError(err_msg)
+
+    def on_end(self, task) -> None:
+        """Save model into torchscript by the end of training.
+        """
+        if not is_master() or getattr(task, "test_only", False):
+            return
+        self.save_torchscript(task)

--- a/test/hooks_torchscript_hook_test.py
+++ b/test/hooks_torchscript_hook_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+import os
+import shutil
+import tempfile
+from test.generic.config_utils import get_test_task_config
+from test.generic.hook_test_utils import HookTestBase
+
+import torch
+from classy_vision.hooks import TorchscriptHook
+from classy_vision.tasks import build_task
+
+
+TORCHSCRIPT_FILE = "torchscript.pt"
+
+
+class TestTorchscriptHook(HookTestBase):
+    def setUp(self) -> None:
+        self.base_dir = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.base_dir)
+
+    def test_constructors(self) -> None:
+        """
+        Test that the hooks are constructed correctly.
+        """
+        config = {"torchscript_folder": "/test/"}
+        invalid_config = copy.deepcopy(config)
+        invalid_config["torchscript_folder"] = 12
+
+        self.constructor_test_helper(
+            config=config,
+            hook_type=TorchscriptHook,
+            hook_registry_name="torchscript",
+            invalid_configs=[invalid_config],
+        )
+
+    def test_torchscripting(self):
+        """
+        Test that the save_torchscript function works as expected.
+        """
+        config = get_test_task_config()
+        task = build_task(config)
+        task.prepare()
+
+        torchscript_folder = self.base_dir + "/torchscript_end_test/"
+
+        # create a torchscript hook
+        torchscript_hook = TorchscriptHook(torchscript_folder)
+
+        # create checkpoint dir, verify on_start hook runs
+        os.mkdir(torchscript_folder)
+        torchscript_hook.on_start(task)
+
+        task.train = True
+        # call the on end function
+        torchscript_hook.on_end(task)
+
+        # load torchscript file
+        torchscript_file_name = (
+            f"{torchscript_hook.torchscript_folder}/{TORCHSCRIPT_FILE}"
+        )
+        torchscript = torch.jit.load(torchscript_file_name)
+        # compare model load from checkpoint vs torchscript
+        with torch.no_grad():
+            batchsize = 1
+            model = task.model
+            input_data = torch.randn(
+                (batchsize,) + model.input_shape, dtype=torch.float
+            )
+            if torch.cuda.is_available():
+                input_data = input_data.cuda()
+            checkpoint_out = model(input_data)
+            torchscript_out = torchscript(input_data)
+            self.assertTrue(torch.allclose(checkpoint_out, torchscript_out))


### PR DESCRIPTION
Summary:
When we deploy PyTorch model to inference platform, we need to convert the trained model into `TorchScript`.

In this task, we want to implement a ClassyVision hook, which is triggered by the end of FBLearner workflow and serialize the trained model from checkpoint into TorchScript.

Introduce a new workflow param `torchscript_path` for user to specify a path to save the files.

Differential Revision: D21506773

