### PR TITLE
Support strings in recursive_copy_to_gpu

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -764,11 +764,9 @@ class ClassificationTask(ClassyTask):
             + "'target' keys"
         )
 
-        # Copy sample to GPU
         target = sample["target"]
         if self.use_gpu:
-            for key, value in sample.items():
-                sample[key] = recursive_copy_to_gpu(value, non_blocking=True)
+            sample = recursive_copy_to_gpu(sample, non_blocking=True)
 
         with torch.no_grad():
             output = self.model(sample["input"])
@@ -809,8 +807,7 @@ class ClassificationTask(ClassyTask):
         # Copy sample to GPU
         target = sample["target"]
         if self.use_gpu:
-            for key, value in sample.items():
-                sample[key] = recursive_copy_to_gpu(value, non_blocking=True)
+            sample = recursive_copy_to_gpu(sample, non_blocking=True)
 
         if self.mixup_transform is not None:
             sample = self.mixup_transform(sample)

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -278,20 +278,17 @@ class TestUtilMethods(unittest.TestCase):
                 self.assertTrue(gpu_value[0].is_cuda)
                 self.assertTrue(gpu_value[1].is_cuda)
 
-        invalid_gpu_copy_values = [1234, True, 1.0]
-        for value in invalid_gpu_copy_values:
-            with self.assertRaises(AttributeError):
-                gpu_value = util.recursive_copy_to_gpu(value)
-
         invalid_gpu_copy_depth = [
             ((((tensor_a, tensor_b), tensor_b), tensor_b), tensor_b),
             {"tensor_map_a": {"tensor_map_b": {"tensor_map_c": {"tensor": tensor_a}}}},
             [[[[tensor_a, tensor_b], tensor_b], tensor_b], tensor_b],
-            "abcd",  # Strings are sequences, includeing single char strings
         ]
         for value in invalid_gpu_copy_depth:
             with self.assertRaises(ValueError):
                 gpu_value = util.recursive_copy_to_gpu(value, max_depth=3)
+
+        value = {"a": "b"}
+        self.assertEqual(value, util.recursive_copy_to_gpu(value))
 
     _json_config_file = ROOT / "generic_util_json_blob_test.json"
 


### PR DESCRIPTION
Summary:
For debugging, it's useful to make the dataset return an "id" key that's used
to identify the sample. Right now this breaks recursive_copy_to_gpu because
strings are sequences and can't be copied to the GPU. Fix that.

Differential Revision: D21626659

