### PR TITLE
Remove ClassyModel.evaluation_mode

### DIFF
--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -87,7 +87,6 @@ import_all_modules(FILE_ROOT, "classy_vision.models")
 
 from .classy_block import ClassyBlock  # isort:skip
 from .classy_model import (  # isort:skip
-    ClassyModelEvaluationMode,  # isort:skip
     ClassyModelWrapper,  # isort:skip
     ClassyModelHeadExecutorWrapper,  # isort:skip
 )  # isort:skip
@@ -105,7 +104,6 @@ __all__ = [
     "register_model",
     "ClassyBlock",
     "ClassyModel",
-    "ClassyModelEvaluationMode",
     "ClassyModelHeadExecutorWrapper",
     "ClassyModelWrapper",
     "DenseNet",

--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -16,11 +16,6 @@ from classy_vision.heads.classy_head import ClassyHead
 from .classy_block import ClassyBlock
 
 
-class ClassyModelEvaluationMode(Enum):
-    DEFAULT = 0
-    VIDEO_CLIP_AVERAGING = 1
-
-
 class _ClassyModelMeta(type):
     """Metaclass to return a ClassyModel instance wrapped by a ClassyModelWrapper."""
 
@@ -474,14 +469,6 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         """If implemented, returns number of layers in model
         """
         raise NotImplementedError
-
-    @property
-    def evaluation_mode(self):
-        """Used by video models for averaging over contiguous clips.
-        """
-        # TODO: Remove this once we have a video task, this logic should
-        # live in a video specific task
-        return ClassyModelEvaluationMode.DEFAULT
 
 
 class _ClassyModelAdapter(ClassyModel):

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -11,7 +11,7 @@ import torch.nn as nn
 from classy_vision.generic.util import is_pos_int, is_pos_int_list
 
 from . import register_model
-from .classy_model import ClassyModel, ClassyModelEvaluationMode
+from .classy_model import ClassyModel
 from .resnext3d_stage import ResStage
 from .resnext3d_stem import R2Plus1DStem, ResNeXt3DStem
 
@@ -289,10 +289,6 @@ class ResNeXt3DBase(ClassyModel):
     @property
     def model_depth(self):
         return sum(self.num_blocks)
-
-    @property
-    def evaluation_mode(self):
-        return ClassyModelEvaluationMode.VIDEO_CLIP_AVERAGING
 
     @property
     def input_key(self):


### PR DESCRIPTION
Summary: Removes all cases of ClassyModel.evaluation_mode and ClassyModelEvaluationMode. This function doesn't appear to be used.

Differential Revision: D21673340

