### PR TITLE
Support Apex Sync BN in EMA hook

### DIFF
--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -31,7 +31,7 @@ class ExponentialMovingAverageModelHook(ClassyHook):
     on_end = ClassyHook._noop
 
     def __init__(
-        self, decay: float, consider_bn_buffers: bool = True, device: str = "cpu"
+        self, decay: float, consider_bn_buffers: bool = True, device: str = "gpu"
     ) -> None:
         """The constructor method of ExponentialMovingAverageModelHook.
 
@@ -64,10 +64,7 @@ class ExponentialMovingAverageModelHook(ClassyHook):
                 (f"{module_name}_buffer_{name}", buffer)
                 for module_name, module in model.named_modules()
                 for name, buffer in module.named_buffers()
-                if isinstance(
-                    module,
-                    (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm),
-                )
+                if isinstance(module, nn.modules.batchnorm._BatchNorm)
             )
             iterable = itertools.chain(iterable, buffers_iterable)
         return iterable


### PR DESCRIPTION
Summary:
Our check for BN modules didn't look for Apex Sync BN. Replace the list of modules with `nn.modules.batchnorm._BatchNorm`, which matches the check inside `ClassyModel`.

Also, changed the default device to gpu.

Reviewed By: vreis

Differential Revision: D21723738

