### PR TITLE
Broadcast buffers before eval phases by default

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -143,7 +143,7 @@ class ClassificationTask(ClassyTask):
         self.data_iterator = None
         self.losses = []
         self.broadcast_buffers_mode: BroadcastBuffersMode = (
-            BroadcastBuffersMode.DISABLED
+            BroadcastBuffersMode.BEFORE_EVAL
         )
         self.amp_args = None
         self.mixup_transform = None
@@ -258,7 +258,7 @@ class ClassificationTask(ClassyTask):
 
     def set_distributed_options(
         self,
-        broadcast_buffers_mode: BroadcastBuffersMode = BroadcastBuffersMode.DISABLED,
+        broadcast_buffers_mode: BroadcastBuffersMode = BroadcastBuffersMode.BEFORE_EVAL,
         batch_norm_sync_mode: BatchNormSyncMode = BatchNormSyncMode.DISABLED,
         find_unused_parameters: bool = True,
     ):
@@ -426,7 +426,7 @@ class ClassificationTask(ClassyTask):
             .set_mixup_transform(mixup_transform)
             .set_distributed_options(
                 broadcast_buffers_mode=BroadcastBuffersMode[
-                    config.get("broadcast_buffers", "disabled").upper()
+                    config.get("broadcast_buffers", "before_eval").upper()
                 ],
                 batch_norm_sync_mode=BatchNormSyncMode[
                     config.get("batch_norm_sync_mode", "disabled").upper()


### PR DESCRIPTION
Summary:
Doing this so that the numbers reported in test phases during training and those reported from loaded checkpoints are the same.

Broadcasting buffers before a phase should have no measurable impact on the training speed.

Differential Revision: D21728240

