### PR TITLE
Increase max_depth for recursive_copy_to_gpu

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -807,7 +807,7 @@ class ClassificationTask(ClassyTask):
         # Copy sample to GPU
         target = sample["target"]
         if self.use_gpu:
-            sample = recursive_copy_to_gpu(sample, non_blocking=True)
+            sample = recursive_copy_to_gpu(sample, non_blocking=True, max_depth=4)
 
         if self.mixup_transform is not None:
             sample = self.mixup_transform(sample)


### PR DESCRIPTION
Summary: In some datasets, the sample contains nested dictionaries which fail to upload on `recursive_copy_to_gpu`. Increase the depth to cover that case.

Differential Revision: D21764871

