### PR TITLE
Fix checkpointing logic to raise exceptions in case of errors

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -301,8 +301,8 @@ def update_classy_state(task, state_dict):
 
 def save_checkpoint(checkpoint_folder, state, checkpoint_file=CHECKPOINT_FILE):
     """
-    Saves a state variable to the specified checkpoint folder. Returns filename
-    of checkpoint if successful, and False otherwise.
+    Saves a state variable to the specified checkpoint folder. Returns the filename
+    of the checkpoint if successful. Raises an exception otherwise.
     """
 
     # make sure that we have a checkpoint folder:
@@ -310,11 +310,8 @@ def save_checkpoint(checkpoint_folder, state, checkpoint_file=CHECKPOINT_FILE):
         try:
             PathManager.mkdirs(checkpoint_folder)
         except BaseException:
-            logging.warning(
-                "Could not create folder %s." % checkpoint_folder, exc_info=True
-            )
-    if not PathManager.isdir(checkpoint_folder):
-        return False
+            logging.warning("Could not create folder %s." % checkpoint_folder)
+            raise
 
     # write checkpoint atomically:
     try:
@@ -324,9 +321,9 @@ def save_checkpoint(checkpoint_folder, state, checkpoint_file=CHECKPOINT_FILE):
         return full_filename
     except BaseException:
         logging.warning(
-            "Did not write checkpoint to %s." % checkpoint_folder, exc_info=True
+            "Unable to write checkpoint to %s." % checkpoint_folder, exc_info=True
         )
-        return False
+        raise
 
 
 def flatten_dict(value_dict, prefix="", sep="_"):

--- a/classy_vision/hooks/checkpoint_hook.py
+++ b/classy_vision/hooks/checkpoint_hook.py
@@ -81,8 +81,7 @@ class CheckpointHook(ClassyHook):
         )
 
         # make copy of checkpoint that won't be overwritten:
-        if checkpoint_file:
-            PathManager.copy(checkpoint_file, f"{self.checkpoint_folder}/{filename}")
+        PathManager.copy(checkpoint_file, f"{self.checkpoint_folder}/{filename}")
 
     def on_start(self, task) -> None:
         if not is_master() or getattr(task, "test_only", False):


### PR DESCRIPTION
Summary:
Fixed a bug where training would continue even if we weren't able to save a checkpoint.

`save_checkpoint` now raises an exception in case of errors, which the `CheckpointHook` doesn't handle so that we crash in case of any issues.

Differential Revision: D21819238

