### PR TITLE
All reduce losses when required, instead of every iteration

### DIFF
--- a/test/hooks_output_csv_hook_test.py
+++ b/test/hooks_output_csv_hook_test.py
@@ -51,10 +51,10 @@ class TestCSVHook(HookTestBase):
         )
 
     def test_train(self) -> None:
-        folder = f"{self.base_dir}/train_test/"
-        os.makedirs(folder)
-
         for use_gpu in {False, torch.cuda.is_available()}:
+            folder = f"{self.base_dir}/train_test/{use_gpu}"
+            os.makedirs(folder)
+
             task = build_task(get_fast_test_task_config(head_num_classes=2))
 
             csv_hook = OutputCSVHook(folder)

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import copy
 import shutil
 import tempfile
 import unittest
@@ -69,6 +70,30 @@ class TestClassificationTask(unittest.TestCase):
 
         task = build_task(config)
         task.prepare()
+
+    def test_synchronize_losses_non_distributed(self):
+        """
+        Tests that synchronize losses has no side effects in a non-distributed setting.
+        """
+        test_config = get_fast_test_task_config()
+        task = build_task(test_config)
+        task.prepare()
+
+        old_losses = copy.deepcopy(task.losses)
+        task.synchronize_losses()
+        self.assertEqual(old_losses, task.losses)
+
+    def test_synchronize_losses_when_losses_empty(self):
+        config = get_fast_test_task_config()
+        task = build_task(config)
+        task.prepare()
+
+        task.set_use_gpu(torch.cuda.is_available())
+
+        # Losses should be empty when creating task
+        self.assertEqual(len(task.losses), 0)
+
+        task.synchronize_losses()
 
     def test_checkpointing(self):
         """


### PR DESCRIPTION
Summary: Instead of all reducing losses between different machines at every iteration in train_step, this commit all reduces losses only when required. This reduces synchronization between the different machines and helps improve speed for SlowMo (or any method which does not synchronize every iteration)

Reviewed By: mannatsingh

Differential Revision: D21841514

