### PR TITLE
Fix OutputCSVHook test on GPUs

### DIFF
--- a/test/hooks_output_csv_hook_test.py
+++ b/test/hooks_output_csv_hook_test.py
@@ -51,10 +51,10 @@ class TestCSVHook(HookTestBase):
         )
 
     def test_train(self) -> None:
-        folder = f"{self.base_dir}/train_test/"
-        os.makedirs(folder)
-
         for use_gpu in {False, torch.cuda.is_available()}:
+            folder = f"{self.base_dir}/train_test/{use_gpu}"
+            os.makedirs(folder)
+
             task = build_task(get_fast_test_task_config(head_num_classes=2))
 
             csv_hook = OutputCSVHook(folder)


### PR DESCRIPTION
Summary:
For GPUs we were running the test twice with the same file, which causes twice
the number of lines to be written to the output.

Differential Revision: D21847811

