### PR TITLE
Move distributed options to a seperate config section

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -260,6 +260,7 @@ class ClassificationTask(ClassyTask):
         self,
         broadcast_buffers_mode: BroadcastBuffersMode = BroadcastBuffersMode.BEFORE_EVAL,
         batch_norm_sync_mode: BatchNormSyncMode = BatchNormSyncMode.DISABLED,
+        batch_norm_sync_group_size: int = 0,
         find_unused_parameters: bool = True,
     ):
         """Set distributed options.
@@ -269,6 +270,10 @@ class ClassificationTask(ClassyTask):
                 :class:`BroadcastBuffersMode` for options.
             batch_norm_sync_mode: Batch normalization synchronization mode. See
                 :class:`BatchNormSyncMode` for options.
+            batch_norm_sync_group_size: Group size to use for synchronized batch norm.
+                0 means that the stats are synchronized across all replicas. For
+                efficient synchronization, set it to the number of GPUs in a node (
+                usually 8).
             find_unused_parameters: See
                 :class:`torch.nn.parallel.DistributedDataParallel` for information.
 
@@ -277,6 +282,16 @@ class ClassificationTask(ClassyTask):
                 is not installed.
         """
         self.broadcast_buffers_mode = broadcast_buffers_mode
+
+        if batch_norm_sync_group_size > 0:
+            if not batch_norm_sync_mode == BatchNormSyncMode.APEX:
+                # this should ideally work with PyTorch Sync BN as well, but it
+                # fails while initializing DDP for some reason.
+                raise ValueError(
+                    "batch_norm_sync_group_size can be > 0 only when "
+                    "Apex Synchronized Batch Normalization is being used."
+                )
+        self.batch_norm_sync_group_size = batch_norm_sync_group_size
 
         if batch_norm_sync_mode == BatchNormSyncMode.DISABLED:
             logging.info("Synchronized Batch Normalization is disabled")
@@ -431,6 +446,7 @@ class ClassificationTask(ClassyTask):
                 batch_norm_sync_mode=BatchNormSyncMode[
                     config.get("batch_norm_sync_mode", "disabled").upper()
                 ],
+                batch_norm_sync_group_size=config.get("batch_norm_sync_group_size", 0),
                 find_unused_parameters=config.get("find_unused_parameters", True),
             )
             .set_hooks(hooks)
@@ -584,7 +600,12 @@ class ClassificationTask(ClassyTask):
         if self.batch_norm_sync_mode == BatchNormSyncMode.PYTORCH:
             self.base_model = nn.SyncBatchNorm.convert_sync_batchnorm(self.base_model)
         elif self.batch_norm_sync_mode == BatchNormSyncMode.APEX:
-            self.base_model = apex.parallel.convert_syncbn_model(self.base_model)
+            sync_bn_process_group = apex.parallel.create_syncbn_process_group(
+                self.batch_norm_sync_group_size
+            )
+            self.base_model = apex.parallel.convert_syncbn_model(
+                self.base_model, process_group=sync_bn_process_group
+            )
 
         # move the model and loss to the right device
         if self.use_gpu:

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -429,6 +429,22 @@ class ClassificationTask(ClassyTask):
         if hooks_config is not None:
             hooks = build_hooks(hooks_config)
 
+        distributed_config = config.get("distributed", {})
+        distributed_options = {
+            "broadcast_buffers_mode": BroadcastBuffersMode[
+                distributed_config.get("broadcast_buffers", "before_eval").upper()
+            ],
+            "batch_norm_sync_mode": BatchNormSyncMode[
+                distributed_config.get("batch_norm_sync_mode", "disabled").upper()
+            ],
+            "batch_norm_sync_group_size": distributed_config.get(
+                "batch_norm_sync_group_size", 0
+            ),
+            "find_unused_parameters": distributed_config.get(
+                "find_unused_parameters", True
+            ),
+        }
+
         task = (
             cls()
             .set_num_epochs(config["num_epochs"])
@@ -439,16 +455,7 @@ class ClassificationTask(ClassyTask):
             .set_meters(meters)
             .set_amp_args(amp_args)
             .set_mixup_transform(mixup_transform)
-            .set_distributed_options(
-                broadcast_buffers_mode=BroadcastBuffersMode[
-                    config.get("broadcast_buffers", "before_eval").upper()
-                ],
-                batch_norm_sync_mode=BatchNormSyncMode[
-                    config.get("batch_norm_sync_mode", "disabled").upper()
-                ],
-                batch_norm_sync_group_size=config.get("batch_norm_sync_group_size", 0),
-                find_unused_parameters=config.get("find_unused_parameters", True),
-            )
+            .set_distributed_options(**distributed_options)
             .set_hooks(hooks)
         )
 


### PR DESCRIPTION
Summary: We had distributed options at the highest level in the config. This felt unorganized, especially now that we have 4 options. Moving them to a "distributed" section in the config.

Differential Revision: D21868859

