### PR TITLE
Migrate to Hydra 1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ install_dep: &install_dep
         which python
         which pip
         pip install --upgrade pip
+        pip install --upgrade --progress-bar off setuptools
         pip install --progress-bar off -r requirements.txt
         pip list
 

--- a/classy_train.py
+++ b/classy_train.py
@@ -63,6 +63,7 @@ from torchvision import set_image_backend, set_video_backend
 
 try:
     import hydra
+    import omegaconf
 
     hydra_available = True
 except ImportError:
@@ -154,11 +155,11 @@ def configure_hooks(args, config):
 
 if hydra_available:
 
-    @hydra.main(config_path="hydra_configs/args.yaml")
+    @hydra.main(config_path="hydra_configs", config_name="args")
     def hydra_main(cfg):
         args = cfg
         check_generic_args(cfg)
-        config = cfg.config.to_container()
+        config = omegaconf.OmegaConf.to_container(cfg.config)
         main(args, config)
 
 

--- a/classy_vision/hydra/conf/config/resnet50_synthetic.yaml
+++ b/classy_vision/hydra/conf/config/resnet50_synthetic.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   name: classification_task
   num_epochs: 2

--- a/classy_vision/hydra/conf/dataset/synthetic_image.yaml
+++ b/classy_vision/hydra/conf/dataset/synthetic_image.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   dataset:
     train:

--- a/classy_vision/hydra/conf/loss/cross_entropy.yaml
+++ b/classy_vision/hydra/conf/loss/cross_entropy.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   loss:
     name: CrossEntropyLoss

--- a/classy_vision/hydra/conf/loss/label_smoothing_cross_entropy.yaml
+++ b/classy_vision/hydra/conf/loss/label_smoothing_cross_entropy.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   loss:
     name: label_smoothing_cross_entropy

--- a/classy_vision/hydra/conf/meters/accuracy.yaml
+++ b/classy_vision/hydra/conf/meters/accuracy.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   meters:
     accuracy:

--- a/classy_vision/hydra/conf/model/resnet_50.yaml
+++ b/classy_vision/hydra/conf/model/resnet_50.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   model:
     name: resnet

--- a/classy_vision/hydra/conf/optimizer/sgd.yaml
+++ b/classy_vision/hydra/conf/optimizer/sgd.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   optimizer:
     name: sgd

--- a/classy_vision/hydra/conf/param_scheduler/step.yaml
+++ b/classy_vision/hydra/conf/param_scheduler/step.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   optimizer:
     param_schedulers:

--- a/classy_vision/hydra/conf/task/classification_task.yaml
+++ b/classy_vision/hydra/conf/task/classification_task.yaml
@@ -1,3 +1,4 @@
+# @package _global_
 config:
   name: classification_task
   num_epochs: 2

--- a/classy_vision/templates/synthetic/hydra_configs/args.yaml
+++ b/classy_vision/templates/synthetic/hydra_configs/args.yaml
@@ -62,6 +62,11 @@ config:
     accuracy:
       topk: [1]
 defaults:
-  - task: classification_task
+  - config: null
+  - dataset: null
+  - loss: null
+  - meters: null
+  - model: null
   - optimizer: sgd
   - param_scheduler: step
+  - task: classification_task

--- a/hydra_plugins/__init__.py
+++ b/hydra_plugins/__init__.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-# Copyright (c) Facebook, Inc. and its affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/hydra_plugins/classy_vision_path/classy_vision_path.py
+++ b/hydra_plugins/classy_vision_path/classy_vision_path.py
@@ -4,9 +4,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from hydra.plugins import SearchPathPlugin
+from hydra.core.config_search_path import ConfigSearchPath
+from hydra.plugins.search_path_plugin import SearchPathPlugin
 
 
 class ClassyVisionPathPlugin(SearchPathPlugin):
-    def manipulate_search_path(self, search_path):
-        search_path.append("classy_vision", "pkg://classy_vision.hydra.conf")
+    def manipulate_search_path(self, search_path: ConfigSearchPath) -> None:
+        search_path.append(
+            provider="classy_vision", path="pkg://classy_vision.hydra.conf"
+        )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, find_packages, setup
 
 
 if __name__ == "__main__":
@@ -44,7 +44,8 @@ if __name__ == "__main__":
         },
         license="MIT License",
         python_requires=">=3.6",
-        packages=find_packages(exclude=("tests",)),
+        packages=find_packages(exclude=("tests",))
+        + find_namespace_packages(include=["hydra_plugins.*"]),
         install_requires=reqs.strip().split("\n"),
         extras_require={
             "dev": [


### PR DESCRIPTION
Summary:
- Migrated to Hydra 1.0
- We need to figure out what the best hierarchy is for Classy given Hydra's new capabilities since the original decision might not be the best now
  - I tried out package directives as well and they work well
  - Leaving this for the future though

Documenting the API changes here -
```
pip install .
pip install hydra-core==1.0.0rc1 # to be replaced with final version
classy_project my_hydra_project

# some example runs with the new API
# note that since task, optimizer and param_scheduler are used in args.yaml, they will not need a + prefix in the command

./my_hydra_project/classy_train.py +model=resnet_50
./my_hydra_project/classy_train.py +loss=cross_entropy +model=resnet50
```

Differential Revision: D21916837

