### PR TITLE
add test phase with ema

### DIFF
--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -91,7 +91,10 @@ class ExponentialMovingAverageModelHook(ClassyHook):
 
     def on_phase_start(self, task) -> None:
         # restore the right state depending on the phase type
-        self.set_model_state(task, use_ema=not task.train)
+        use_ema = (
+            (not task.train and task.ema) if hasattr(task, "ema") else not task.train
+        )
+        self.set_model_state(task, use_ema=use_ema)
 
     def on_phase_end(self, task) -> None:
         if task.train:

--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -75,6 +75,8 @@ class LossLrMeterLoggingHook(ClassyHook):
             f"{prefix}[{get_rank()}] {phase_type} phase {phase_type_idx} "
             f"({phase_pct*100:.2f}% done), loss: {loss:.4f}, meters: {task.meters}"
         )
+        if phase_type == "test" and hasattr(task, "ema"):
+            msg += f", ema: {task.ema}"
         if log_batches:
             msg += f", processed batches: {batches}"
 


### PR DESCRIPTION
Summary:
EMA can greatly improve test accuracy. Currently, when EMA is enabled, we do not run a separate test phase without EMA, which makes it difficult to know how much gain EMA brings.
Therefore, when EMA hook is used, we run two separate test phase, one with EMA and the other w/o EMA.

Differential Revision: D21919378

