### PR TITLE
do not miss hooks from config

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -91,7 +91,7 @@ def main(args, config):
         task.set_pretrained_checkpoint(args.pretrained_checkpoint_path)
 
     # Configure hooks to do tensorboard logging, checkpoints and so on
-    task.set_hooks(configure_hooks(args, config))
+    task.set_hooks(configure_hooks(args, config) + task.hooks)
 
     # LocalTrainer is used for a single node. DistributedTrainer will setup
     # training to use PyTorch's DistributedDataParallel.

--- a/classy_vision/generic/profiler.py
+++ b/classy_vision/generic/profiler.py
@@ -70,6 +70,20 @@ def profile(
                 return profiler
 
 
+def get_input_shape(x):
+    """
+    Some layer may take tuple/list/dict/list[dict] as input in forward function. We
+    recursively dive into the tuple/list until we meet a tensor
+    """
+    if isinstance(x, (list, tuple)):
+        assert len(x) > 0, "input x of tuple/list type must have at least one element"
+        return [get_input_shape(xi) for xi in x]
+    elif isinstance(x, dict):
+        return {k: get_input_shape(v) for k, v in x.items()}
+    else:
+        return x.size()
+
+
 def _get_batchsize_per_replica(x):
     """
     Some layer may take tuple/list/dict/list[dict] as input in forward function. We
@@ -331,7 +345,7 @@ def _layer_flops(layer, x, y):
 
     message = [
         f"module type: {typestr}",
-        f"input size: {list(x.size())}",
+        f"input size: {get_input_shape(x)}",
         f"output size: {list(y.size())}",
         f"params(M): {count_params(layer) / 1e6}",
         f"flops(M): {int(flops) / 1e6}",

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -253,6 +253,16 @@ def load_checkpoint(
     return checkpoint
 
 
+def get_checkpoint_name(phase_idx):
+    return "model_phase-{phase}_end.torch".format(phase=phase_idx)
+
+
+def parse_checkpoint_name(checkpoint) -> int:
+    """Return phase index after parsing checkpoint name
+    """
+    return int(checkpoint[len("model_phase-") : checkpoint.find("_end.torch")])
+
+
 def update_classy_model(model, model_state_dict, reset_heads):
     """
     Updates the model with the provided model state dictionary.

--- a/classy_vision/hooks/checkpoint_hook.py
+++ b/classy_vision/hooks/checkpoint_hook.py
@@ -5,10 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Collection, Dict, Optional
+from typing import Any, Collection, Dict, Optional  # noqa
 
 from classy_vision.generic.distributed_util import is_master
-from classy_vision.generic.util import get_checkpoint_dict, save_checkpoint
+from classy_vision.generic.util import (
+    get_checkpoint_dict,
+    get_checkpoint_name,
+    save_checkpoint,
+)
 from classy_vision.hooks import register_hook
 from classy_vision.hooks.classy_hook import ClassyHook
 from fvcore.common.file_io import PathManager
@@ -104,5 +108,5 @@ class CheckpointHook(ClassyHook):
         if self.phase_counter % self.checkpoint_period != 0:
             return
 
-        checkpoint_name = "model_phase-{phase}_end.torch".format(phase=task.phase_idx)
+        checkpoint_name = get_checkpoint_name(task.phase_idx)
         self._save_checkpoint(task, checkpoint_name)

--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -91,7 +91,10 @@ class ExponentialMovingAverageModelHook(ClassyHook):
 
     def on_phase_start(self, task) -> None:
         # restore the right state depending on the phase type
-        self.set_model_state(task, use_ema=not task.train)
+        use_ema = (
+            (not task.train and task.ema) if hasattr(task, "ema") else not task.train
+        )
+        self.set_model_state(task, use_ema=use_ema)
 
     def on_phase_end(self, task) -> None:
         if task.train:

--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -75,6 +75,8 @@ class LossLrMeterLoggingHook(ClassyHook):
             f"{prefix}[{get_rank()}] {phase_type} phase {phase_type_idx} "
             f"({phase_pct*100:.2f}% done), loss: {loss:.4f}, meters: {task.meters}"
         )
+        if phase_type == "test" and hasattr(task, "ema"):
+            msg += f", ema: {task.ema}"
         if log_batches:
             msg += f", processed batches: {batches}"
 


### PR DESCRIPTION
Summary: Besides hard-coded hooks, we allow extra hooks set in the json config. Such hooks are currently missed in `classy_train.py`. This diff fixes it.

Differential Revision: D22033327

