### PR TITLE
Enable NCCL blocking wait to avoid hangs

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -96,7 +96,7 @@ def main(args, config):
     # set the final hooks of the task.
     task.set_hooks(configure_hooks(args, config) + task.hooks)
 
-    # LocalTrainer is used for a single node. DistributedTrainer will setup
+    # LocalTrainer is used for a single replica. DistributedTrainer will setup
     # training to use PyTorch's DistributedDataParallel.
     trainer_class = {"none": LocalTrainer, "ddp": DistributedTrainer}[
         args.distributed_backend


### PR DESCRIPTION
Summary: Our training runs were hanging some times with 100% GPU utilization. There is no timeout for NCCL ops by default which means we never fail and retry in these situations. Setting `os.environ["NCCL_BLOCKING_WAIT"] = "1"` to enable the timeout logic

Differential Revision: D22085054

