### PR TITLE
Refactor weight decay on BatchNorm handling

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -450,6 +450,33 @@ def get_model_dummy_input(
     return input
 
 
+def split_batchnorm_params(model: nn.Module):
+    """Finds the set of BatchNorm parameters in the model.
+
+    Recursively traverses all parameters in the given model and returns a tuple
+    of lists: the first element is the set of batchnorm parameters, the second
+    list contains all other parameters of the model."""
+    batchnorm_params = []
+    other_params = []
+    for module in model.modules():
+        # If module has children (i.e. internal node of constructed DAG) then
+        # only add direct parameters() to the list of params, else go over
+        # children node to find if they are BatchNorm or have "bias".
+        if list(module.children()) != []:
+            for params in module.parameters(recurse=False):
+                if params.requires_grad:
+                    other_params.append(params)
+        elif isinstance(module, nn.modules.batchnorm._BatchNorm):
+            for params in module.parameters():
+                if params.requires_grad:
+                    batchnorm_params.append(params)
+        else:
+            for params in module.parameters():
+                if params.requires_grad:
+                    other_params.append(params)
+    return batchnorm_params, other_params
+
+
 @contextlib.contextmanager
 def _train_mode(model: nn.Module, train_mode: bool):
     """Context manager which sets the train mode of a model. After returning, it

--- a/classy_vision/losses/classy_loss.py
+++ b/classy_vision/losses/classy_loss.py
@@ -43,17 +43,6 @@ class ClassyLoss(nn.Module):
         """
         raise NotImplementedError
 
-    def get_optimizer_params(self, bn_weight_decay=False):
-        """Gets optimizer params.
-
-        The default implementation is very simple. Most losses have no learned
-        parameters, so this is rarely needed.
-        """
-        params = [
-            param for param in self.parameters(recurse=True) if param.requires_grad
-        ]
-        return {"regularized_params": params, "unregularized_params": []}
-
     def get_classy_state(self) -> Dict[str, Any]:
         """Get the state of the ClassyLoss.
 
@@ -79,6 +68,4 @@ class ClassyLoss(nn.Module):
 
     def has_learned_parameters(self) -> bool:
         """Does this loss have learned parameters?"""
-        return any(
-            len(params) > 0 for (_, params) in self.get_optimizer_params().items()
-        )
+        return any(param.requires_grad for param in self.parameters(recurse=True))

--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -406,52 +406,6 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         self._head_outputs = outputs
         return outputs
 
-    def get_optimizer_params(self, bn_weight_decay=False):
-        """Returns param groups for optimizer.
-
-        Function to return dict of params with "keys" from
-        {"regularized_params", "unregularized_params"}
-        to "values" a list of `pytorch Params <https://pytorch.org/docs/
-        stable/nn.html#torch.nn.Parameter>`_.
-
-        "weight_decay" provided as part of optimizer is only used
-        for "regularized_params". For "unregularized_params", weight_decay is set
-        to 0.0
-
-        This implementation sets `BatchNorm's <https://pytorch.org/docs/
-        stable/nn.html#normalization-layers>`_ all trainable params to be
-        unregularized_params if ``bn_weight_decay`` is False.
-
-        Override this function for any custom behavior.
-
-        Args:
-            bn_weight_decay (bool): Apply weight decay to bn params if true
-        """
-        unregularized_params = []
-        regularized_params = []
-        for module in self.modules():
-            # If module has children (i.e. internal node of constructed DAG) then
-            # only add direct parameters() to the list of params, else go over
-            # children node to find if they are BatchNorm or have "bias".
-            if list(module.children()) != []:
-                for params in module.parameters(recurse=False):
-                    if params.requires_grad:
-                        regularized_params.append(params)
-            elif not bn_weight_decay and isinstance(
-                module, nn.modules.batchnorm._BatchNorm
-            ):
-                for params in module.parameters():
-                    if params.requires_grad:
-                        unregularized_params.append(params)
-            else:
-                for params in module.parameters():
-                    if params.requires_grad:
-                        regularized_params.append(params)
-        return {
-            "regularized_params": regularized_params,
-            "unregularized_params": unregularized_params,
-        }
-
     @property
     def input_shape(self):
         """If implemented, returns expected input tensor shape

--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -275,10 +275,6 @@ class DenseNet(ClassyModel):
 
         return out
 
-    def get_optimizer_params(self):
-        # use weight decay on BatchNorm for DenseNets
-        return super().get_optimizer_params(bn_weight_decay=True)
-
     @property
     def input_shape(self):
         if self.small_input:

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -268,7 +268,6 @@ class ResNeXt(ClassyModel):
         base_width_and_cardinality: Optional[Union[Tuple, List]] = None,
         basic_layer: bool = False,
         final_bn_relu: bool = True,
-        bn_weight_decay: Optional[bool] = False,
         use_se: bool = False,
         se_reduction_ratio: int = 16,
     ):
@@ -291,7 +290,6 @@ class ResNeXt(ClassyModel):
         assert all(is_pos_int(n) for n in num_blocks)
         assert is_pos_int(init_planes) and is_pos_int(reduction)
         assert type(small_input) == bool
-        assert type(bn_weight_decay) == bool
         assert (
             type(zero_init_bn_residuals) == bool
         ), "zero_init_bn_residuals must be a boolean, set to true if gamma of last\
@@ -303,12 +301,6 @@ class ResNeXt(ClassyModel):
             and is_pos_int(base_width_and_cardinality[1])
         )
         assert isinstance(use_se, bool), "use_se has to be a boolean"
-
-        # Chooses whether to apply weight decay to batch norm
-        # parameters. This improves results in some situations,
-        # e.g. ResNeXt models trained / evaluated using the Imagenet
-        # dataset, but can cause worse performance in other scenarios
-        self.bn_weight_decay = bn_weight_decay
 
         # initial convolutional block:
         self.num_blocks = num_blocks
@@ -424,7 +416,6 @@ class ResNeXt(ClassyModel):
             "basic_layer": basic_layer,
             "final_bn_relu": config.get("final_bn_relu", True),
             "zero_init_bn_residuals": config.get("zero_init_bn_residuals", False),
-            "bn_weight_decay": config.get("bn_weight_decay", False),
             "use_se": config.get("use_se", False),
             "se_reduction_ratio": config.get("se_reduction_ratio", 16),
         }
@@ -440,9 +431,6 @@ class ResNeXt(ClassyModel):
         out = self.blocks(out)
 
         return out
-
-    def get_optimizer_params(self):
-        return super().get_optimizer_params(bn_weight_decay=self.bn_weight_decay)
 
     @property
     def input_shape(self):
@@ -583,7 +571,6 @@ class ResNeXt50(_ResNeXt):
             basic_layer=False,
             zero_init_bn_residuals=True,
             base_width_and_cardinality=(4, 32),
-            bn_weight_decay=True,
             **kwargs,
         )
 
@@ -596,7 +583,6 @@ class ResNeXt101(_ResNeXt):
             basic_layer=False,
             zero_init_bn_residuals=True,
             base_width_and_cardinality=(4, 32),
-            bn_weight_decay=True,
             **kwargs,
         )
 
@@ -609,6 +595,5 @@ class ResNeXt152(_ResNeXt):
             basic_layer=False,
             zero_init_bn_residuals=True,
             base_width_and_cardinality=(4, 32),
-            bn_weight_decay=True,
             **kwargs,
         )

--- a/classy_vision/optim/adam.py
+++ b/classy_vision/optim/adam.py
@@ -29,10 +29,9 @@ class Adam(ClassyOptimizer):
         self.parameters.weight_decay = weight_decay
         self.parameters.amsgrad = amsgrad
 
-    def init_pytorch_optimizer(self, model, **kwargs) -> None:
-        super().init_pytorch_optimizer(model, **kwargs)
+    def prepare(self, param_groups) -> None:
         self.optimizer = torch.optim.Adam(
-            self.param_groups_override,
+            param_groups,
             lr=self.parameters.lr,
             betas=self.parameters.betas,
             eps=self.parameters.eps,

--- a/classy_vision/optim/classy_optimizer.py
+++ b/classy_vision/optim/classy_optimizer.py
@@ -4,11 +4,10 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Optional, Union
 
 import torch
-from classy_vision.losses import ClassyLoss
-from classy_vision.models import ClassyModel
 from torch import nn
 
 from .param_scheduler import ClassyParamScheduler, UpdateInterval
@@ -22,17 +21,14 @@ class AttrDict(dict):
         self.__dict__ = self
 
 
-class ClassyOptimizer:
+class ClassyOptimizer(ABC):
     """
     Base class for classy optimizers.
 
     This wraps a :class:`torch.optim.Optimizer` instance, handles learning
-    rate scheduling by using a :class:`param_scheduler.ClassyParamScheduler`
-    and supports specifying regularized and unregularized param groups.
-    Specifying unregularized params is especially useful to avoid applying
-    weight decay on batch norm. See
-    :func:`classy_vision.models.ClassyModel.get_optimizer_params` for more
-    information.
+    rate scheduling by using a :class:`param_scheduler.ClassyParamScheduler`.
+    Scheduling is also supported for any other hyperparameter (e.g. weight decay,
+    momentum and others)
 
     Deriving classes can extend functionality be overriding the appropriate functions.
     """
@@ -42,7 +38,6 @@ class ClassyOptimizer:
         self.param_schedulers = {}
         self.parameters = AttrDict()
         self.optimizer = None
-        self.optimizer_params = None
 
     def set_param_schedulers(
         self, param_schedulers: Dict[str, ClassyParamScheduler]
@@ -63,63 +58,6 @@ class ClassyOptimizer:
         )
         return self
 
-    @staticmethod
-    def _validate_optimizer_params(model: Union[ClassyLoss, ClassyModel]):
-        optimizer_params = model.get_optimizer_params()
-
-        assert isinstance(optimizer_params, dict) and set(optimizer_params.keys()) == {
-            "regularized_params",
-            "unregularized_params",
-        }, "get_optimizer_params() of {0} should return dict with exact two keys\
-            'regularized_params', 'unregularized_params'".format(
-            type(model).__name__
-        )
-
-        trainable_params = [
-            params for params in model.parameters() if params.requires_grad
-        ]
-        assert len(trainable_params) == len(
-            optimizer_params["regularized_params"]
-        ) + len(optimizer_params["unregularized_params"]), (
-            "get_optimizer_params() of {0} should return params that cover all"
-            "trainable params of model".format(type(model).__name__)
-        )
-
-        return optimizer_params
-
-    def _validate_and_get_optimizer_params(
-        self, model: ClassyModel, loss: Optional[nn.Module] = None
-    ) -> Dict[str, Any]:
-        """
-        Validate and return the optimizer params.
-
-        The optimizer params are fetched from
-        :fun:`models.ClassyModel.get_optimizer_params`.
-
-        Args:
-            model: The model to get the params from.
-            loss: The loss. If present, and a ClassyLoss, then the loss may
-                also contribute parameters.
-
-        Returns:
-            A dict containing "regularized_params" and "unregularized_params".
-            Weight decay will only be applied to "regularized_params".
-        """
-        if isinstance(model, torch.nn.parallel.DistributedDataParallel):
-            model = model.module
-
-        optimizer_params = self._validate_optimizer_params(model)
-
-        if loss is not None and isinstance(loss, ClassyLoss):
-            loss_params = self._validate_optimizer_params(loss)
-            # Merge loss and model params.
-            optimizer_params = {
-                key: value + loss_params[key]
-                for (key, value) in optimizer_params.items()
-            }
-
-        return optimizer_params
-
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "ClassyOptimizer":
         """Instantiates a ClassyOptimizer from a configuration.
@@ -132,43 +70,68 @@ class ClassyOptimizer:
         """
         raise NotImplementedError
 
-    def init_pytorch_optimizer(
-        self, model: ClassyModel, loss: Optional[Union[ClassyLoss, Any]] = None
-    ) -> None:
+    @abstractmethod
+    def prepare(self, param_groups):
         """
-        Initialize the underlying :class:`torch.optim.Optimizer` instance.
+        Prepares the optimizer for training.
 
-        Using the provided model, create param groups for the optimizer with a
-        weight decay override for params which should be left unregularized.
-
-        Note:
-            Deriving classes should initialize the underlying Pytorch optimizer
-            in this call. The simplest way to do this after a call to
-
-            ``super().init_pytorch_optimizer()``
+        Deriving classes should initialize the underlying PyTorch
+        :class:`torch.optim.Optimizer` in this call. The param_groups argument
+        follows the same format supported by PyTorch (list of parameters, or
+        list of param group dictionaries).
 
         Warning:
             This should called only after the model has been moved to the correct
             device.
         """
-        self.optimizer_params = self._validate_and_get_optimizer_params(model, loss)
+        raise NotImplementedError
 
-        param_groups_override = []
-        self.contains_unregularized_params = False
-        if len(self.optimizer_params["unregularized_params"]) != 0:
-            param_groups_override.append(
-                {
-                    "params": self.optimizer_params["unregularized_params"],
-                    "weight_decay": 0.0,
-                }
-            )
-            self.contains_unregularized_params = True
+    def set_param_groups(self, param_groups, frozen_param_groups=None):
+        """
+        Specifies what parameters will be optimized.
 
-        if len(self.optimizer_params["regularized_params"]) != 0:
-            param_groups_override.append(
-                {"params": self.optimizer_params["regularized_params"]}
+        This is the public API where users of ClassyOptimizer can specify what
+        parameters will get optimized. Unlike PyTorch optimizers, we don't
+        require the list of param_groups in the constructor.
+
+        param_groups have the same semantics/usage as PyTorch.
+        frozen_param_groups are a list of param groups that won't be scheduled by
+        ClassyOptimizer. This is useful, for instance, to disable weight decay on a
+        subset of parameters while keeping LR scheduling on those same parameters.
+        """
+
+        def cast_param_groups(params):
+            """Converts a list/dict to the PyTorch param_groups format."""
+
+            if params is None:
+                return []
+
+            if isinstance(params, dict):
+                assert "params" in params
+                return [params]
+
+            pg = list(params)
+            if len(pg) == 0:
+                raise ValueError("optimizer got an empty parameter list")
+            if not isinstance(pg[0], dict):
+                pg = [{"params": pg}]
+            return pg
+
+        frozen_param_groups = cast_param_groups(frozen_param_groups)
+        assert isinstance(frozen_param_groups, list)
+
+        # _frozen_overrides is a copy of frozen_param_groups without the
+        # "params" key.  We need an actual copy here because once param groups
+        # are passed to the optimizer they get mutated.
+        self._frozen_overrides = []
+        for param_group in frozen_param_groups:
+            self._frozen_overrides.append(
+                {k: v for k, v in param_group.items() if k != "params"}
             )
-        self.param_groups_override = param_groups_override
+
+        # The order between frozen_param_groups and param_groups here matters,
+        # see _update_schedule implementation.
+        self.prepare(frozen_param_groups + cast_param_groups(param_groups))
 
     def get_classy_state(self) -> Dict[str, Any]:
         """Get the state of the ClassyOptimizer.
@@ -260,13 +223,12 @@ class ClassyOptimizer:
         for group in self.optimizer.param_groups:
             group.update(self.parameters)
 
-        # Here there's an assumption that pytorch optimizer maintain the order of
-        # param_groups and batch_norm param_group is 0th param_group as initially
-        # set in the __init__ call.
-        # It seems like pytorch optim doesn't have way to get params by 'id':
-        #   See thread https://github.com/pytorch/pytorch/issues/1489
-        if self.contains_unregularized_params:
-            self.optimizer.param_groups[0].update(weight_decay=0.0)
+        # Here there's an assumption that pytorch optimizer maintain the order
+        # of param_groups and that frozen_param_groups were added before the
+        # others. This must be kept in sync with the prepare call in
+        # set_param_groups
+        for i, override in enumerate(self._frozen_overrides):
+            self.optimizer.param_groups[i].update(**override)
 
     def step(self, closure: Optional[Callable] = None):
         """

--- a/classy_vision/optim/rmsprop.py
+++ b/classy_vision/optim/rmsprop.py
@@ -32,10 +32,9 @@ class RMSProp(ClassyOptimizer):
         self.parameters.eps = eps
         self.parameters.centered = centered
 
-    def init_pytorch_optimizer(self, model, **kwargs):
-        super().init_pytorch_optimizer(model, **kwargs)
+    def prepare(self, param_groups):
         self.optimizer = torch.optim.RMSprop(
-            self.param_groups_override,
+            param_groups,
             lr=self.parameters.lr,
             momentum=self.parameters.momentum,
             weight_decay=self.parameters.weight_decay,

--- a/classy_vision/optim/rmsprop_tf.py
+++ b/classy_vision/optim/rmsprop_tf.py
@@ -168,10 +168,9 @@ class RMSPropTF(ClassyOptimizer):
         self.parameters.eps = eps
         self.parameters.centered = centered
 
-    def init_pytorch_optimizer(self, model, **kwargs):
-        super().init_pytorch_optimizer(model, **kwargs)
+    def prepare(self, param_groups):
         self.optimizer = RMSpropTFOptimizer(
-            self.param_groups_override,
+            param_groups,
             lr=self.parameters.lr,
             momentum=self.parameters.momentum,
             weight_decay=self.parameters.weight_decay,

--- a/classy_vision/optim/sgd.py
+++ b/classy_vision/optim/sgd.py
@@ -31,10 +31,9 @@ class SGD(ClassyOptimizer):
         self.parameters.use_larc = use_larc
         self.larc_config = larc_config
 
-    def init_pytorch_optimizer(self, model, **kwargs):
-        super().init_pytorch_optimizer(model, **kwargs)
+    def prepare(self, param_groups):
         self.optimizer = torch.optim.SGD(
-            self.param_groups_override,
+            param_groups,
             lr=self.parameters.lr,
             nesterov=self.parameters.nesterov,
             momentum=self.parameters.momentum,

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -20,6 +20,7 @@ from classy_vision.generic.util import (
     CHECKPOINT_FILE,
     load_checkpoint,
     save_checkpoint,
+    split_batchnorm_params,
     update_classy_model,
     update_classy_state,
 )
@@ -168,6 +169,29 @@ class TestUtilMethods(unittest.TestCase):
             if module.training != expected_mode:
                 return False
         return True
+
+    def test_split_batchnorm_params(self):
+        class MyModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.lin = nn.Linear(2, 3, bias=False)
+                self.relu = nn.ReLU()
+                self.bn = nn.BatchNorm1d(3)
+
+            def forward(self, x):
+                return self.bn(self.relu(self.lin(x)))
+
+        torch.manual_seed(1)
+        model = MyModel()
+
+        bn_params, lin_params = split_batchnorm_params(model)
+
+        self.assertEquals(len(bn_params), 2)
+        self.assertEquals(len(lin_params), 1)
+
+        self.assertTrue(torch.allclose(bn_params[0], model.bn.weight))
+        self.assertTrue(torch.allclose(bn_params[1], model.bn.bias))
+        self.assertTrue(torch.allclose(lin_params[0], model.lin.weight))
 
     def test_train_model_eval_model(self):
         class TestModel(nn.Module):

--- a/test/tasks_fine_tuning_task_test.py
+++ b/test/tasks_fine_tuning_task_test.py
@@ -91,6 +91,7 @@ class TestFineTuningTask(unittest.TestCase):
             fine_tuning_task.prepare()
 
         # test: prepare should succeed after pre-trained checkpoint is set
+        fine_tuning_task = build_task(fine_tuning_config)
         fine_tuning_task._set_pretrained_checkpoint_dict(checkpoint)
         fine_tuning_task.prepare()
 
@@ -115,6 +116,7 @@ class TestFineTuningTask(unittest.TestCase):
 
         # test: a fine tuning task with incompatible heads with a manually set
         # pre-trained checkpoint should succeed to prepare if the heads are reset
+        fine_tuning_task = build_task(fine_tuning_config)
         fine_tuning_task._set_pretrained_checkpoint_dict(
             copy.deepcopy(checkpoint)
         ).set_reset_heads(True)
@@ -137,6 +139,7 @@ class TestFineTuningTask(unittest.TestCase):
         # test: a fine tuning task with incompatible heads with the pre-trained
         # checkpoint provided in the config should succeed to prepare if the heads are
         # reset
+        fine_tuning_task = build_task(fine_tuning_config)
         fine_tuning_task.set_reset_heads(True)
         with mock.patch(
             "classy_vision.tasks.fine_tuning_task.load_and_broadcast_checkpoint",


### PR DESCRIPTION
Summary:
Sending this for review early due to S204449. Tests/lint will be fixed later.

The way we implement weight decay on batch norm is too rigid: each model is
expected to implement a method returning the BatchNorm parameters. In practice, all models implement that method the same way and it causes boilerplate in the config handling/constructors. In addition to that, users of ClassyOptimizer do not have control over the param groups passed to the underlying PyTorch optimizer. This is an issue for implementing features like discriminative learning rates.

This refactors ClassyOptimizer to accept two sets of param groups. One set will be updated according to the schedulers (LR, WD etc), another one (frozen_param_groups) will get scheduled but whatever values were present in that param group originally will stay as they are. This is needed so we can still change the learning rate on an optimizer that has a frozen weight decay (since the WD is set by a "constant" scheduler).

Differential Revision: D22186394

