### PR TITLE
Create .gitattributes to mark tutorials as documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tutorials/* linguist-documentation


### PR DESCRIPTION
Classy Vision shows up as a Jupyter Notebook repo since the tutorials' total size is much larger (because of embedded images). This fixes that by marking them tutorial files as documentation.