### PR TITLE
Fix a difference in the SE layer squeeze

### DIFF
--- a/classy_vision/models/regnet.py
+++ b/classy_vision/models/regnet.py
@@ -213,8 +213,12 @@ class BottleneckTransform(nn.Sequential):
         )
 
         if se_ratio:
-            w_se = int(round(width_in * se_ratio))
-            self.se = SqueezeAndExcitationLayer(in_planes=w_b, reduction_ratio=w_se)
+            # The SE reduction ratio is defined with respect to the
+            # beginning of the block
+            width_se_out = int(round(se_ratio * width_in))
+            self.se = SqueezeAndExcitationLayer(
+                in_planes=w_b, reduction_ratio=None, reduced_planes=width_se_out
+            )
 
         self.c = nn.Conv2d(w_b, width_out, 1, stride=1, padding=0, bias=False)
         self.final_bn = nn.BatchNorm2d(width_out, eps=bn_epsilon, momentum=bn_momentum)

--- a/classy_vision/models/squeeze_and_excitation_layer.py
+++ b/classy_vision/models/squeeze_and_excitation_layer.py
@@ -5,16 +5,30 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from typing import Optional
+
 import torch.nn as nn
 
 
 class SqueezeAndExcitationLayer(nn.Module):
     """Squeeze and excitation layer, as per https://arxiv.org/pdf/1709.01507.pdf"""
 
-    def __init__(self, in_planes, reduction_ratio=16):
+    def __init__(
+        self,
+        in_planes,
+        reduction_ratio: Optional[int] = 16,
+        reduced_planes: Optional[int] = None,
+    ):
         super().__init__()
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
-        reduced_planes = in_planes // reduction_ratio
+
+        # Either reduction_ratio is defined, or out_planes is defined,
+        # neither both nor none of them
+        assert bool(reduction_ratio) != bool(reduced_planes)
+
+        reduced_planes = (
+            in_planes // reduction_ratio if reduced_planes is None else reduced_planes
+        )
         self.excitation = nn.Sequential(
             nn.Conv2d(in_planes, reduced_planes, kernel_size=1, stride=1, bias=True),
             nn.ReLU(),


### PR DESCRIPTION
Summary: The reduction ratio was not applied in the same way in between the original RegNet implementation and the one in ClassyVision. Fixing this

Differential Revision: D22400429

