### PR TITLE
Log sample fetch times to tensorboard

### DIFF
--- a/classy_vision/generic/distributed_util.py
+++ b/classy_vision/generic/distributed_util.py
@@ -89,6 +89,15 @@ def all_reduce_min(tensor: torch.Tensor) -> torch.Tensor:
     return all_reduce_op(tensor, torch.distributed.ReduceOp.MIN)
 
 
+def all_reduce_max(tensor: torch.Tensor) -> torch.Tensor:
+    """
+    Wrapper over torch.distributed.all_reduce for performing min
+    reduction of tensor over all processes in both distributed /
+    non-distributed scenarios.
+    """
+    return all_reduce_op(tensor, torch.distributed.ReduceOp.MAX)
+
+
 def all_reduce_op(
     tensor: torch.Tensor,
     op: torch.distributed.ReduceOp,

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -8,10 +8,8 @@ import collections
 import contextlib
 import json
 import logging
-import math
 import os
-import sys
-import traceback
+import time
 from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -475,6 +473,29 @@ def split_batchnorm_params(model: nn.Module):
                 if params.requires_grad:
                     other_params.append(params)
     return batchnorm_params, other_params
+
+
+class Timer:
+    """Timer context manager to get the elapsed time for a code block.
+
+    Example:
+        .. code-block:: python
+
+            with Timer() as timer:
+                do_something()
+            elapsed_time = timer.elapsed_time
+    """
+
+    def __init__(self):
+        self.start = 0
+        self.elapsed_time = 0
+
+    def __enter__(self):
+        self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.elapsed_time = time.perf_counter() - self.start
 
 
 @contextlib.contextmanager

--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -27,6 +27,12 @@ class ModelComplexityHook(ClassyHook):
     on_phase_end = ClassyHook._noop
     on_end = ClassyHook._noop
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.num_flops = None
+        self.num_activations = None
+        self.num_parameters = None
+
     def on_start(self, task) -> None:
         """Measure number of parameters, FLOPs and activations."""
         self.num_flops = 0

--- a/classy_vision/hooks/model_tensorboard_hook.py
+++ b/classy_vision/hooks/model_tensorboard_hook.py
@@ -39,15 +39,13 @@ class ModelTensorboardHook(ClassyHook):
         Args:
             tb_writer: `Tensorboard SummaryWriter <https://tensorboardx.
             readthedocs.io/en/latest/tensorboard.html#tensorboardX.
-            SummaryWriter>`_ instance
-
+            SummaryWriter>`_ instance or None (only on non-master replicas)
         """
         super().__init__()
         if not tb_available:
-            raise RuntimeError(
+            raise ModuleNotFoundError(
                 "tensorboard not installed, cannot use ModelTensorboardHook"
             )
-
         self.tb_writer = tb_writer
 
     @classmethod

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 from classy_vision.generic.util import (
     CHECKPOINT_FILE,
+    Timer,
     load_checkpoint,
     save_checkpoint,
     split_batchnorm_params,
@@ -224,6 +225,19 @@ class TestUtilMethods(unittest.TestCase):
                 # the modes should be different inside the context manager
                 self.assertFalse(self._compare_model_train_mode(orig_model, test_model))
             self.assertTrue(self._compare_model_train_mode(orig_model, test_model))
+
+    @mock.patch("time.perf_counter")
+    def test_timer(self, mock_perf_counter: mock.MagicMock):
+        def test_func(a, b=2):
+            return a + b
+
+        start_time = 10
+        end_time = 12
+        mock_perf_counter.side_effect = [start_time, end_time]
+
+        with Timer() as timer:
+            test_func(1, b=3)
+        self.assertAlmostEqual(timer.elapsed_time, end_time - start_time)
 
 
 class TestUpdateStateFunctions(unittest.TestCase):


### PR DESCRIPTION
Summary:
Log cumulative sample fetch times to get an idea about how much time we're spending waiting on the dataloaders.
- The sample fetch time for a given step is calculated as the max of the sample fetch time across all workers
- Log the cumulative sample fetch time per phase type vs the number of batches
- This change now requires the tb hook to be plugged in to all replicas since there is a sync involved

NOTE: I changed the x axis for the LR curve to be batches instead of samples to be consistent with the sample fetch times plot. This should anyway be easier to understand than samples.

Reviewed By: vreis

Differential Revision: D22298279

