### PR TITLE
Remove output_shape from ClassyModel

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -412,12 +412,6 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         raise NotImplementedError
 
     @property
-    def output_shape(self):
-        """If implemented, returns expected output tensor shape
-        """
-        raise NotImplementedError
-
-    @property
     def model_depth(self):
         """If implemented, returns number of layers in model
         """


### PR DESCRIPTION
Summary:
The output_shape of a model could be dynamic, and sometimes could be more than a tensor (like List[tensor]). Having a output_shape at ClassyModel doesn't make sense.
Each individual models could still implement a output_shape method if they want.

Differential Revision: D22498871

