### PR TITLE
Make hook checkpoints backwards compatible

### DIFF
--- a/classy_vision/hooks/classy_hook.py
+++ b/classy_vision/hooks/classy_hook.py
@@ -18,7 +18,10 @@ class ClassyHookState:
         return self.__dict__
 
     def set_classy_state(self, state_dict: Dict[str, Any]):
-        self.__dict__ = state_dict
+        # We take a conservative approach and only update the dictionary instead of
+        # replacing it. This allows hooks to continue functioning in case the state
+        # is loaded from older implementations.
+        self.__dict__.update(state_dict)
 
 
 class ClassyHook(ABC):

--- a/test/hooks_classy_hook_test.py
+++ b/test/hooks_classy_hook_test.py
@@ -25,7 +25,25 @@ class TestHook(ClassyHook):
 
     @classmethod
     def from_config(cls, config):
-        return TestHook(**config)
+        return cls(**config)
+
+
+@register_hook("test_hook_new")
+class TestHookNew(ClassyHook):
+    on_start = ClassyHook._noop
+    on_phase_start = ClassyHook._noop
+    on_step = ClassyHook._noop
+    on_phase_end = ClassyHook._noop
+    on_end = ClassyHook._noop
+
+    def __init__(self, b, c):
+        super().__init__()
+        self.state.b = b
+        self.state.c = c
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
 
 
 class TestClassyHook(unittest.TestCase):
@@ -53,3 +71,12 @@ class TestClassyHook(unittest.TestCase):
         test_hook.set_classy_state(state_dict)
         self.assertEqual(test_hook.state.a, a)
         self.assertEqual(test_hook.state.b, b)
+
+        # make sure we're able to load old checkpoints
+        b_new = {1: 2}
+        c_new = "hello"
+        test_hook_new = TestHookNew(b_new, c_new)
+        test_hook_new.set_classy_state(state_dict)
+        self.assertEqual(test_hook_new.state.a, a)
+        self.assertEqual(test_hook_new.state.b, b)
+        self.assertEqual(test_hook_new.state.c, c_new)


### PR DESCRIPTION
Summary:
If we ever add any new state to a hook, the old checkpoints become unusable since the hook crashes. This is because we replace the state's internal `__dict__` and the newly added attributes are erased.

Instead, this diff converts the `set_classy_state` to an `update` which will ensure that such hooks will continue running. There are no guarantees on correctness though.

The other option is to not set the state of a hook at all if there is a key mismatch. We can revisit this if the latter turns out to be a better option.

Differential Revision: D22604083

