### PR TITLE
Model Tensorboard hook improvements

### DIFF
--- a/classy_vision/generic/visualize.py
+++ b/classy_vision/generic/visualize.py
@@ -145,7 +145,7 @@ def plot_model(
     input_key: Optional[Union[str, List[str]]] = None,
     writer: Optional["SummaryWriter"] = None,
     folder: str = "",
-    train: bool = True,
+    train: bool = False,
 ) -> None:
     """Visualizes a model in TensorBoard.
 
@@ -165,11 +165,12 @@ def plot_model(
     input = get_model_dummy_input(model, size, input_key)
     if writer is None:
         writer = SummaryWriter(log_dir=folder, comment="Model graph")
-    with writer:
+    with torch.no_grad():
         orig_train = model.training
-        model.train(train)  # visualize model in desired mode
+        model.train(train)
         writer.add_graph(model, input_to_model=(input,))
         model.train(orig_train)
+        writer.flush()
 
 
 # function that produces an image map:

--- a/classy_vision/hooks/model_tensorboard_hook.py
+++ b/classy_vision/hooks/model_tensorboard_hook.py
@@ -77,6 +77,5 @@ class ModelTensorboardHook(ClassyHook):
                     writer=self.tb_writer,
                 )
             except Exception:
-                logging.warn(
-                    "Unable to plot model to tensorboard. Exception: ", exc_info=True
-                )
+                logging.warn("Unable to plot model to tensorboard")
+                logging.debug("Exception encountered:", exc_info=True)


### PR DESCRIPTION
Summary:
- We were tracking gradients while plotting the model in the train phase
  - The model is now plotted in test phase by default
  - The tracing is done inside a `torch.no_grad()` context
- Print the exception log only in debug mode

This used to print pages and pages of logs which have been removed.

The plotting still doesn't work for AMP wrapped models, but we just log a single line exception now

Differential Revision: D22868236

