### PR TITLE
Classy Optimizer refactor

### DIFF
--- a/classy_vision/hooks/tensorboard_plot_hook.py
+++ b/classy_vision/hooks/tensorboard_plot_hook.py
@@ -106,7 +106,7 @@ class TensorboardPlotHook(ClassyHook):
                 task.last_batch.step_data["sample_fetch_time"]
             )
         if task.train:
-            self.learning_rates.append(task.optimizer.parameters.lr)
+            self.learning_rates.append(task.optimizer.options_view.lr)
 
     def _get_cum_sample_fetch_times(self, phase_type) -> Tuple[List[float], ...]:
         if not self.sample_fetch_times:

--- a/classy_vision/hooks/visdom_hook.py
+++ b/classy_vision/hooks/visdom_hook.py
@@ -78,7 +78,7 @@ class VisdomHook(ClassyHook):
         metrics[loss_key].append(loss)
 
         # Optimizer LR for the phase
-        optimizer_lr = task.optimizer.parameters.lr
+        optimizer_lr = task.optimizer.options_view.lr
         lr_key = phase_type + "_learning_rate"
         if lr_key not in metrics:
             metrics[lr_key] = []

--- a/classy_vision/optim/__init__.py
+++ b/classy_vision/optim/__init__.py
@@ -36,7 +36,10 @@ def build_optimizer(config):
     :func:`build_param_scheduler` on each config in the dictionary.
     """
     optimizer = OPTIMIZER_REGISTRY[config["name"]].from_config(config)
+    return optimizer
 
+
+def build_optimizer_schedulers(config):
     # create a deepcopy since we will be modifying the param scheduler config
     param_scheduler_config = copy.deepcopy(config.get("param_schedulers", {}))
 
@@ -48,8 +51,7 @@ def build_optimizer(config):
         param: build_param_scheduler(cfg)
         for param, cfg in param_scheduler_config.items()
     }
-    optimizer.set_param_schedulers(param_schedulers)
-    return optimizer
+    return param_schedulers
 
 
 def register_optimizer(name):
@@ -106,5 +108,6 @@ __all__ = [
     "RMSPropTF",
     "SGD",
     "build_optimizer",
+    "build_optimizer_schedulers",
     "register_optimizer",
 ]

--- a/classy_vision/optim/adam.py
+++ b/classy_vision/optim/adam.py
@@ -23,20 +23,20 @@ class Adam(ClassyOptimizer):
     ) -> None:
         super().__init__()
 
-        self.parameters.lr = lr
-        self.parameters.betas = betas
-        self.parameters.eps = eps
-        self.parameters.weight_decay = weight_decay
-        self.parameters.amsgrad = amsgrad
+        self._lr = lr
+        self._betas = betas
+        self._eps = eps
+        self._weight_decay = weight_decay
+        self._amsgrad = amsgrad
 
     def prepare(self, param_groups) -> None:
         self.optimizer = torch.optim.Adam(
             param_groups,
-            lr=self.parameters.lr,
-            betas=self.parameters.betas,
-            eps=self.parameters.eps,
-            weight_decay=self.parameters.weight_decay,
-            amsgrad=self.parameters.amsgrad,
+            lr=self._lr,
+            betas=self._betas,
+            eps=self._eps,
+            weight_decay=self._weight_decay,
+            amsgrad=self._amsgrad,
         )
 
     @classmethod

--- a/classy_vision/optim/rmsprop.py
+++ b/classy_vision/optim/rmsprop.py
@@ -25,22 +25,22 @@ class RMSProp(ClassyOptimizer):
     ) -> None:
         super().__init__()
 
-        self.parameters.lr = lr
-        self.parameters.momentum = momentum
-        self.parameters.weight_decay = weight_decay
-        self.parameters.alpha = alpha
-        self.parameters.eps = eps
-        self.parameters.centered = centered
+        self._lr = lr
+        self._momentum = momentum
+        self._weight_decay = weight_decay
+        self._alpha = alpha
+        self._eps = eps
+        self._centered = centered
 
     def prepare(self, param_groups):
         self.optimizer = torch.optim.RMSprop(
             param_groups,
-            lr=self.parameters.lr,
-            momentum=self.parameters.momentum,
-            weight_decay=self.parameters.weight_decay,
-            alpha=self.parameters.alpha,
-            eps=self.parameters.eps,
-            centered=self.parameters.centered,
+            lr=self._lr,
+            momentum=self._momentum,
+            weight_decay=self._weight_decay,
+            alpha=self._alpha,
+            eps=self._eps,
+            centered=self._centered,
         )
 
     @classmethod

--- a/classy_vision/optim/rmsprop_tf.py
+++ b/classy_vision/optim/rmsprop_tf.py
@@ -161,22 +161,22 @@ class RMSPropTF(ClassyOptimizer):
     ) -> None:
         super().__init__()
 
-        self.parameters.lr = lr
-        self.parameters.momentum = momentum
-        self.parameters.weight_decay = weight_decay
-        self.parameters.alpha = alpha
-        self.parameters.eps = eps
-        self.parameters.centered = centered
+        self._lr = lr
+        self._momentum = momentum
+        self._weight_decay = weight_decay
+        self._alpha = alpha
+        self._eps = eps
+        self._centered = centered
 
     def prepare(self, param_groups):
         self.optimizer = RMSpropTFOptimizer(
             param_groups,
-            lr=self.parameters.lr,
-            momentum=self.parameters.momentum,
-            weight_decay=self.parameters.weight_decay,
-            alpha=self.parameters.alpha,
-            eps=self.parameters.eps,
-            centered=self.parameters.centered,
+            lr=self._lr,
+            momentum=self._momentum,
+            weight_decay=self._weight_decay,
+            alpha=self._alpha,
+            eps=self._eps,
+            centered=self._centered,
         )
 
     @classmethod

--- a/classy_vision/optim/sgd.py
+++ b/classy_vision/optim/sgd.py
@@ -24,27 +24,27 @@ class SGD(ClassyOptimizer):
     ):
         super().__init__()
 
-        self.parameters.lr = lr
-        self.parameters.momentum = momentum
-        self.parameters.weight_decay = weight_decay
-        self.parameters.nesterov = nesterov
-        self.parameters.use_larc = use_larc
-        self.larc_config = larc_config
+        self._lr = lr
+        self._momentum = momentum
+        self._weight_decay = weight_decay
+        self._nesterov = nesterov
+        self._use_larc = use_larc
+        self._larc_config = larc_config
 
     def prepare(self, param_groups):
         self.optimizer = torch.optim.SGD(
             param_groups,
-            lr=self.parameters.lr,
-            nesterov=self.parameters.nesterov,
-            momentum=self.parameters.momentum,
-            weight_decay=self.parameters.weight_decay,
+            lr=self._lr,
+            nesterov=self._nesterov,
+            momentum=self._momentum,
+            weight_decay=self._weight_decay,
         )
-        if self.parameters.use_larc:
+        if self._use_larc:
             try:
                 from apex.parallel.LARC import LARC
             except ImportError:
                 raise RuntimeError("Apex needed for LARC")
-            self.optimizer = LARC(optimizer=self.optimizer, **self.larc_config)
+            self.optimizer = LARC(optimizer=self.optimizer, **self._larc_config)
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "SGD":

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -36,7 +36,11 @@ from classy_vision.hooks import CheckpointHook, ClassyHook, build_hooks
 from classy_vision.losses import ClassyLoss, build_loss
 from classy_vision.meters import ClassyMeter, build_meters
 from classy_vision.models import ClassyModel, build_model
-from classy_vision.optim import ClassyOptimizer, build_optimizer
+from classy_vision.optim import (
+    ClassyOptimizer,
+    build_optimizer,
+    build_optimizer_schedulers,
+)
 from torch.distributed import broadcast
 
 from . import register_task
@@ -103,6 +107,8 @@ class ClassificationTask(ClassyTask):
     :var test_only: Used to only run the test phase
     :var base_model: Model to be trained, unwrapped in DDP or DP wrappers
     :var optimizer: Optimizer used in train step
+    :var optimizer_schedulers: Dictionary. Key is the name of the optimizer
+        option (e.g. lr), value is a ClassyParamScheduler
     :var checkpoint: Serializable dict which represents state in training
     :var phases: List of phase specific information, e.g. if phase is
         train / test.
@@ -135,6 +141,7 @@ class ClassificationTask(ClassyTask):
         self.test_only = False
         self.base_model = None
         self.optimizer = None
+        self.optimizer_schedulers = {}
         self.checkpoint_dict = None
         self.checkpoint_path = None
         self.phases = []
@@ -402,6 +409,10 @@ class ClassificationTask(ClassyTask):
             logging.info(f"mixup enabled")
         return self
 
+    def set_optimizer_schedulers(self, schedulers):
+        self.optimizer_schedulers = schedulers
+        return self
+
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "ClassificationTask":
         """Instantiates a ClassificationTask from a configuration.
@@ -425,6 +436,7 @@ class ClassificationTask(ClassyTask):
                 config["num_epochs"] * train_phases_per_epoch
             )
             optimizer = build_optimizer(optimizer_config)
+            param_schedulers = build_optimizer_schedulers(optimizer_config)
 
         datasets = {}
         phase_types = ["train", "test"]
@@ -482,6 +494,7 @@ class ClassificationTask(ClassyTask):
 
         if not test_only:
             task.set_optimizer(optimizer)
+            task.set_optimizer_schedulers(param_schedulers)
 
         use_gpu = config.get("use_gpu")
         if use_gpu is not None:
@@ -622,28 +635,20 @@ class ClassificationTask(ClassyTask):
         }
 
     def prepare_optimizer(self, optimizer, model, loss=None):
+        bn_params, params = split_batchnorm_params(model)
+        if loss is not None:
+            bn_params_loss, params_loss = split_batchnorm_params(loss)
+            bn_params = bn_params + bn_params_loss
+            params = params + params_loss
+
+        bn_schedulers = self.optimizer_schedulers.copy()
         if not self.bn_weight_decay:
-            bn_params, params = split_batchnorm_params(model)
-            if loss is not None:
-                bn_params_loss, params_loss = split_batchnorm_params(loss)
-                bn_params = bn_params + bn_params_loss
-                params = params + params_loss
+            bn_schedulers["weight_decay"] = 0
 
-            frozen_param_groups = (
-                {"params": bn_params, "weight_decay": 0} if len(bn_params) > 0 else None
-            )
-            param_groups = {"params": params}
-        else:
-            frozen_param_groups = None
-            params = model.parameters()
-            if loss is not None:
-                params = chain(params, loss.parameters())
-
-            param_groups = {"params": list(params)}
-
-        self.optimizer.set_param_groups(
-            param_groups=param_groups, frozen_param_groups=frozen_param_groups
-        )
+        param_groups = [{"params": params, **self.optimizer_schedulers}]
+        if len(bn_params) > 0:
+            param_groups.append({"params": bn_params, **bn_schedulers})
+        self.optimizer.set_param_groups(param_groups)
 
     def prepare(self):
         """Prepares task for training, populates all derived attributes """
@@ -766,8 +771,6 @@ class ClassificationTask(ClassyTask):
 
         num_steps = num_phases * self.num_batches_per_phase
         where = current_step / num_steps
-
-        assert where >= 0 and where < 1, f"Invalid where: {where}"
 
         return where
 
@@ -947,8 +950,7 @@ class ClassificationTask(ClassyTask):
 
         self.check_inf_nan(loss)
 
-        self.optimizer.update_schedule_on_step(self.where)
-        self.optimizer.step()
+        self.optimizer.step(where=self.where)
 
         self.num_updates += self.get_global_batchsize()
 
@@ -1010,7 +1012,7 @@ class ClassificationTask(ClassyTask):
 
         # Update the optimizer schedule
         if self.train and self.train_phase_idx >= 0:
-            self.optimizer.update_schedule_on_epoch(self.where)
+            self.optimizer.on_epoch(where=self.where)
 
     def done_training(self):
         """Stop condition for training

--- a/test/generic/optim_test_util.py
+++ b/test/generic/optim_test_util.py
@@ -11,7 +11,8 @@ import torch
 import torch.nn as nn
 from classy_vision.generic.util import split_batchnorm_params
 from classy_vision.models import ClassyModel
-from classy_vision.optim import build_optimizer
+from classy_vision.optim import build_optimizer, build_optimizer_schedulers
+from classy_vision.optim.param_scheduler import LinearParamScheduler
 
 
 class TestOptimizer(ABC):
@@ -61,18 +62,20 @@ class TestOptimizer(ABC):
         config = self._get_config()
 
         opt1 = build_optimizer(config)
-        opt1.set_param_groups(self._parameters())
+        opt1.set_param_groups(self._parameters(), lr=1, momentum=0.9)
+        self.assertTrue(isinstance(opt1, self._instance_to_test()))
 
         self._set_gradient(self._parameters(), grad_values)
-        opt1.step()
+        opt1.step(where=0)
         state = opt1.get_classy_state()
 
-        config["lr"] += 0.1
         opt2 = build_optimizer(config)
-        opt2.set_param_groups(self._parameters())
-        self.assertTrue(isinstance(opt1, self._instance_to_test()))
+        opt2.set_param_groups(self._parameters(), lr=2)
+
+        self.assertNotEqual(opt1.options_view.lr, opt2.options_view.lr)
         opt2.set_classy_state(state)
-        self.assertEqual(opt1.parameters, opt2.parameters)
+        self.assertEqual(opt1.options_view.lr, opt2.options_view.lr)
+
         for i in range(len(opt1.optimizer.param_groups[0]["params"])):
             self.assertTrue(
                 torch.allclose(
@@ -80,9 +83,7 @@ class TestOptimizer(ABC):
                     opt2.optimizer.param_groups[0]["params"][i],
                 )
             )
-        self._compare_momentum_values(
-            opt1.get_classy_state()["optim"], opt2.get_classy_state()["optim"]
-        )
+        self._compare_momentum_values(opt1.get_classy_state(), opt2.get_classy_state())
 
         # check if the optimizers behave the same on params update
         mock_classy_vision_model1 = self._parameters()
@@ -93,8 +94,8 @@ class TestOptimizer(ABC):
         opt1.set_param_groups(mock_classy_vision_model1)
         opt2 = build_optimizer(config)
         opt2.set_param_groups(mock_classy_vision_model2)
-        opt1.step()
-        opt2.step()
+        opt1.step(where=0)
+        opt2.step(where=0)
         for i in range(len(opt1.optimizer.param_groups[0]["params"])):
             print(opt1.optimizer.param_groups[0]["params"][i])
             self.assertTrue(
@@ -103,9 +104,7 @@ class TestOptimizer(ABC):
                     opt2.optimizer.param_groups[0]["params"][i],
                 )
             )
-        self._compare_momentum_values(
-            opt1.get_classy_state()["optim"], opt2.get_classy_state()["optim"]
-        )
+        self._compare_momentum_values(opt1.get_classy_state(), opt2.get_classy_state())
 
     def test_build_sgd(self):
         config = self._get_config()
@@ -130,7 +129,8 @@ class TestOptimizer(ABC):
         config = self._get_config()
 
         opt = build_optimizer(config)
-        opt.set_param_groups(self._parameters())
+        param_schedulers = build_optimizer_schedulers(config)
+        opt.set_param_groups({"params": self._parameters(), **param_schedulers})
 
         # Test initial learning rate
         for group in opt.optimizer.param_groups:
@@ -141,7 +141,7 @@ class TestOptimizer(ABC):
                 epoch = epochs[i]
                 target = targets[i]
                 param_groups = optimizer.optimizer.param_groups.copy()
-                optimizer.update_schedule_on_epoch(epoch / num_epochs)
+                optimizer.on_epoch(epoch / num_epochs)
                 for idx, group in enumerate(optimizer.optimizer.param_groups):
                     self.assertEqual(group["lr"], target)
                     # Make sure all but LR is same
@@ -159,7 +159,9 @@ class TestOptimizer(ABC):
             "lr": {"name": "step", "values": [0.1, 0.01, 0.001]}
         }
         opt = build_optimizer(config)
-        opt.set_param_groups(self._parameters())
+        param_schedulers = build_optimizer_schedulers(config)
+        opt.set_param_groups({"params": self._parameters(), **param_schedulers})
+
         targets = [0.1] * 8 + [0.01] * 3 + [0.001] * 4
         _test_lr_schedule(opt, num_epochs, epochs, targets)
 
@@ -180,37 +182,44 @@ class TestOptimizer(ABC):
         }
 
         opt = build_optimizer(config)
-        opt.set_param_groups(self._parameters())
+        param_schedulers = build_optimizer_schedulers(config)
+        opt.set_param_groups({"params": self._parameters(), **param_schedulers})
+
         targets = [0.01, 0.0325, 0.055] + [0.1] * 5 + [0.01] * 3 + [0.001] * 4
         _test_lr_schedule(opt, num_epochs, epochs, targets)
 
-    def test_frozen_param_groups(self):
-        a = torch.tensor([[1.0, 2.0]], requires_grad=True)
-        b = torch.tensor([[1.0, 2.0]], requires_grad=True)
-
-        a.grad = torch.ones_like(a)
-        b.grad = torch.ones_like(b)
-
+    def test_set_param_groups(self):
         opt = build_optimizer(self._get_config())
-        opt.set_param_groups(
-            param_groups=[a],
-            frozen_param_groups=[{"params": [b], "lr": 0, "weight_decay": 0}],
-        )
+        # This must crash since we're missing the .set_param_groups call
+        with self.assertRaises(RuntimeError):
+            opt.step(where=0)
 
-        opt.step()
+    def test_step_args(self):
+        opt = build_optimizer(self._get_config())
+        opt.set_param_groups([torch.tensor([1.0], requires_grad=True)])
 
-        # "b" should not change because lr and wd are set to zero
-        self.assertFalse(torch.allclose(a, torch.tensor([[1.0, 2.0]])))
-        self.assertTrue(torch.allclose(b, torch.tensor([[1.0, 2.0]])))
+        # where argument must be named explicitly
+        with self.assertRaises(RuntimeError):
+            opt.step(0)
 
-        # this mutates the param groups according to the schedulers, but frozen
-        # params should stay the same
-        opt.update_schedule_on_step(0.5)
+        # this shouldn't crash
+        opt.step(where=0)
 
-        opt.step()
+    def test_get_lr(self):
+        opt = build_optimizer(self._get_config())
+        param = torch.tensor([1.0], requires_grad=True)
+        opt.set_param_groups([{"params": [param], "lr": 1}])
 
-        self.assertFalse(torch.allclose(a, torch.tensor([[1.0, 2.0]])))
-        self.assertTrue(torch.allclose(b, torch.tensor([[1.0, 2.0]])))
+        self.assertEqual(opt.options_view.lr, 1)
+
+        # Case two: verify LR changes
+        opt = build_optimizer(self._get_config())
+        param = torch.tensor([1.0], requires_grad=True)
+        opt.set_param_groups([{"params": [param], "lr": LinearParamScheduler(1, 2)}])
+
+        self.assertEqual(opt.options_view.lr, 1)
+        opt.step(where=0.5)
+        self.assertEqual(opt.options_view.lr, 1.5)
 
     def test_batchnorm_weight_decay(self):
         class MyModel(nn.Module):
@@ -238,18 +247,23 @@ class TestOptimizer(ABC):
             out.backward()
 
         opt.set_param_groups(
-            param_groups=lin_params,
-            frozen_param_groups=[{"params": bn_params, "lr": 0, "weight_decay": 0}],
+            [
+                {
+                    "params": lin_params,
+                    "lr": LinearParamScheduler(1, 2),
+                    "weight_decay": 0.5,
+                },
+                {"params": bn_params, "lr": 0, "weight_decay": 0},
+            ]
         )
 
-        opt.step()
+        opt.step(where=0.5)
 
         # Make sure the linear parameters are trained but not the batch norm
         self.assertFalse(torch.allclose(model.lin.weight, lin_param_before))
         self.assertTrue(torch.allclose(model.bn.weight, bn_param_before))
 
-        opt.update_schedule_on_step(0.5)
-        opt.step()
+        opt.step(where=0.5)
 
         # Same, but after another step and triggering the lr scheduler
         self.assertFalse(torch.allclose(model.lin.weight, lin_param_before))

--- a/test/hooks_loss_lr_meter_logging_hook_test.py
+++ b/test/hooks_loss_lr_meter_logging_hook_test.py
@@ -98,7 +98,7 @@ class TestLossLrMeterLoggingHook(HookTestBase):
         config["dataset"]["train"]["batchsize_per_replica"] = 10
         config["dataset"]["test"]["batchsize_per_replica"] = 5
         task = build_task(config)
-        task.optimizer.param_schedulers["lr"] = mock_lr_scheduler
+        task.set_optimizer_schedulers({"lr": mock_lr_scheduler})
         trainer = LocalTrainer()
 
         # 2 LR updates per epoch = 6
@@ -113,7 +113,7 @@ class TestLossLrMeterLoggingHook(HookTestBase):
 
             def on_step(self, task):
                 if task.train:
-                    lr_list.append(task.optimizer.parameters.lr)
+                    lr_list.append(task.optimizer.options_view.lr)
 
         hook = LRLoggingHook()
         task.set_hooks([hook])

--- a/test/manual/hooks_tensorboard_plot_hook_test.py
+++ b/test/manual/hooks_tensorboard_plot_hook_test.py
@@ -161,7 +161,7 @@ class TestTensorboardPlotHook(HookTestBase):
         hook = TensorboardPlotHook(writer)
         hook.log_period = 1
         task.set_hooks([hook])
-        task.optimizer.param_schedulers["lr"] = mock_lr_scheduler
+        task.set_optimizer_schedulers({"lr": mock_lr_scheduler})
 
         trainer = LocalTrainer()
         trainer.train(task)

--- a/test/manual/hooks_visdom_hook_test.py
+++ b/test/manual/hooks_visdom_hook_test.py
@@ -123,7 +123,7 @@ class TestVisdomHook(HookTestBase):
                 )
                 self.assertAlmostEqual(
                     visdom_hook.metrics[lr_key][-1],
-                    task.optimizer.parameters.lr,
+                    task.optimizer.options_view.lr,
                     places=4,
                 )
 

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -11,7 +11,7 @@ from classy_vision.dataset import build_dataset
 from classy_vision.hooks import ClassyHook
 from classy_vision.losses import build_loss
 from classy_vision.models import build_model
-from classy_vision.optim import build_optimizer
+from classy_vision.optim import build_optimizer, build_optimizer_schedulers
 from classy_vision.optim.param_scheduler import (
     ClassyParamScheduler,
     UpdateInterval,
@@ -132,6 +132,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
             .set_loss(build_loss(config["loss"]))
             .set_model(build_model(config["model"]))
             .set_optimizer(build_optimizer(config["optimizer"]))
+            .set_optimizer_schedulers(build_optimizer_schedulers(config["optimizer"]))
         )
         for phase_type in ["train", "test"]:
             dataset = build_dataset(config["dataset"][phase_type])
@@ -151,12 +152,13 @@ class TestParamSchedulerIntegration(unittest.TestCase):
 
         mock = Mock(side_effect=scheduler_mock)
         mock.update_interval = UpdateInterval.EPOCH
-        task.optimizer.param_schedulers["lr"] = mock
+        task.set_optimizer_schedulers({"lr": mock})
 
         trainer = LocalTrainer()
         trainer.train(task)
 
-        self.assertEqual(where_list, [0, 1 / 3, 2 / 3])
+        # The first call is the initialization
+        self.assertEqual(where_list, [0, 0, 1 / 3, 2 / 3])
 
     def test_param_scheduler_step(self):
         task = self._build_task(num_epochs=3)
@@ -169,19 +171,20 @@ class TestParamSchedulerIntegration(unittest.TestCase):
 
         mock = Mock(side_effect=scheduler_mock)
         mock.update_interval = UpdateInterval.STEP
-        task.optimizer.param_schedulers["lr"] = mock
+        task.set_optimizer_schedulers({"lr": mock})
 
         trainer = LocalTrainer()
         trainer.train(task)
 
         # We have 10 samples, batch size is 5. Each epoch is done in two steps.
-        self.assertEqual(where_list, [0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6])
+        # The first call is the initialization
+        self.assertEqual(where_list, [0, 0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6])
 
     def test_no_param_schedulers(self):
         task = self._build_task(num_epochs=3, skip_param_schedulers=True)
 
         # there should be no param schedulers
-        self.assertEqual(task.optimizer.param_schedulers, {})
+        self.assertEqual(task.optimizer_schedulers, {})
 
         # we should still be able to train the task
         trainer = LocalTrainer()
@@ -207,33 +210,12 @@ class TestParamSchedulerIntegration(unittest.TestCase):
                     return
 
                 # make sure we have non-zero param groups
-                test_instance.assertGreater(
-                    len(task.optimizer.optimizer.param_groups), 0
-                )
-                # test that our overrides work on the underlying PyTorch optimizer
-                for param_group in task.optimizer.optimizer.param_groups:
-                    test_instance.assertEqual(
-                        param_group["lr"], task.optimizer.parameters.lr
-                    )
-                    test_instance.assertEqual(
-                        param_group["weight_decay"],
-                        task.optimizer.parameters.weight_decay,
-                    )
-                    test_instance.assertEqual(
-                        param_group["momentum"], task.optimizer.parameters.momentum
-                    )
-                lr_list.append(param_group["lr"])
-                weight_decay_list.append(param_group["weight_decay"])
-                momentum_list.append(param_group["momentum"])
+                test_instance.assertGreater(len(task.optimizer.param_groups), 0)
+                lr_list.append(task.optimizer.options_view.lr)
+                weight_decay_list.append(task.optimizer.options_view.weight_decay)
+                momentum_list.append(task.optimizer.options_view.momentum)
 
         task.set_hooks([TestHook()])
-
-        def scheduler_mock(where):
-            return where
-
-        mock = Mock(side_effect=scheduler_mock)
-        mock.update_interval = UpdateInterval.STEP
-        task.optimizer.param_schedulers["lr"] = mock
 
         trainer = LocalTrainer()
         trainer.train(task)

--- a/test/optim_sgd_test.py
+++ b/test/optim_sgd_test.py
@@ -7,6 +7,8 @@
 import unittest
 from test.generic.optim_test_util import TestOptimizer
 
+import torch
+from classy_vision.optim.param_scheduler import LinearParamScheduler
 from classy_vision.optim.sgd import SGD
 
 
@@ -23,3 +25,29 @@ class TestSGDOptimizer(TestOptimizer, unittest.TestCase):
 
     def _instance_to_test(self):
         return SGD
+
+    # This test relies on the SGD update equations, which is why it's not in
+    # the base class TestOptimizer
+    def test_lr_step(self):
+        opt = SGD()
+
+        param = torch.tensor([0.0], requires_grad=True)
+        opt.set_param_groups([param], lr=LinearParamScheduler(1, 2))
+
+        param.grad = torch.tensor([1.0])
+
+        self.assertAlmostEqual(opt.options_view.lr, 1.0)
+
+        # lr=1, param should go from 0 to -1
+        opt.step(where=0)
+        self.assertAlmostEqual(opt.options_view.lr, 1.0)
+
+        self.assertAlmostEqual(param.item(), -1.0, delta=1e-5)
+
+        # lr=1.5, param should go from -1 to -1-1.5 = -2.5
+        opt.step(where=0.5)
+        self.assertAlmostEqual(param.item(), -2.5, delta=1e-5)
+
+        # lr=1.9, param should go from -2.5 to -1.9-2.5 = -4.4
+        opt.step(where=0.9)
+        self.assertAlmostEqual(param.item(), -4.4, delta=1e-5)

--- a/test/tasks_classification_task_test.py
+++ b/test/tasks_classification_task_test.py
@@ -165,10 +165,7 @@ class TestClassificationTask(unittest.TestCase):
         trainer = LocalTrainer()
         trainer.train(task)
 
-        # make sure fetching the where raises an exception, which means that
-        # where is >= 1.0
-        with self.assertRaises(Exception):
-            task.where
+        self.assertAlmostEqual(task.where, 1.0, delta=1e-3)
 
         # set task_2's state as task's final train checkpoint
         task_2.set_checkpoint(self.base_dir)

--- a/test/trainer_local_trainer_test.py
+++ b/test/trainer_local_trainer_test.py
@@ -12,7 +12,7 @@ from classy_vision.hooks import LossLrMeterLoggingHook
 from classy_vision.losses import build_loss
 from classy_vision.meters import AccuracyMeter
 from classy_vision.models import build_model
-from classy_vision.optim import build_optimizer
+from classy_vision.optim import build_optimizer, build_optimizer_schedulers
 from classy_vision.tasks import ClassificationTask
 from classy_vision.trainer import LocalTrainer
 
@@ -27,6 +27,7 @@ class TestLocalTrainer(unittest.TestCase):
             .set_loss(build_loss(config["loss"]))
             .set_model(build_model(config["model"]))
             .set_optimizer(build_optimizer(config["optimizer"]))
+            .set_optimizer_schedulers(build_optimizer_schedulers(config["optimizer"]))
             .set_meters([AccuracyMeter(topk=[1])])
             .set_hooks([LossLrMeterLoggingHook()])
         )


### PR DESCRIPTION
Summary:
This refactors ClassyOptimizer to make its API (roughly) match n293833. Major changes:
 * ClassyOptimizer no longer instantiates ParamSchedulers in its config. This gives us more flexibility to combine them however we want and change the config format;
 * ClassyOptimizer.set_param_groups() no longer has a frozen_param_groups argument. Each option in the param group can be a ParamScheduler instead. This allows implementing discriminative learning rates and disabling wd.bn in a cleaner way;
 * ClassyOptimizer no longer keeps a copy of the optimizer options, so we can no longer have inconsistency bugs; Added an `options_view` argument to allow getting the current LR in a convenient way (used in hooks);
 * ClassyOptimizer is now completely stateless! Trivial get/set_classy_state implementations;

Differential Revision: D22466936

