### PR TITLE
Report unknown classy head name when failing

### DIFF
--- a/classy_vision/heads/__init__.py
+++ b/classy_vision/heads/__init__.py
@@ -66,7 +66,7 @@ def build_head(config):
 
     assert "name" in config, "Expect name in config"
     assert "unique_id" in config, "Expect a global unique id in config"
-    assert config["name"] in HEAD_REGISTRY, "unknown head"
+    assert config["name"] in HEAD_REGISTRY, "unknown head {}".format(config["name"])
     name = config["name"]
     head_config = copy.deepcopy(config)
     del head_config["name"]


### PR DESCRIPTION
Summary: I have found it useful when the "unknown head" error actually reports the head name

Differential Revision: D22900439

