### PR TITLE
Async copy dataloader

### DIFF
--- a/classy_vision/dataset/__init__.py
+++ b/classy_vision/dataset/__init__.py
@@ -81,6 +81,7 @@ from .classy_synthetic_image_streaming import (  # isort:skip
 from .classy_synthetic_video import SyntheticVideoDataset  # isort:skip
 from .classy_ucf101 import UCF101Dataset  # isort:skip
 from .classy_video_dataset import ClassyVideoDataset  # isort:skip
+from .dataloader_async_gpu_wrapper import DataloaderAsyncGPUWrapper  # isort:skip
 from .dataloader_limit_wrapper import DataloaderLimitWrapper  # isort:skip
 from .dataloader_skip_none_wrapper import DataloaderSkipNoneWrapper  # isort:skip
 from .dataloader_wrapper import DataloaderWrapper  # isort:skip
@@ -93,6 +94,7 @@ __all__ = [
     "DataloaderLimitWrapper",
     "DataloaderSkipNoneWrapper",
     "DataloaderWrapper",
+    "DataloaderAsyncGPUWrapper",
     "HMDB51Dataset",
     "ImagePathDataset",
     "Kinetics400Dataset",

--- a/classy_vision/dataset/dataloader_async_gpu_wrapper.py
+++ b/classy_vision/dataset/dataloader_async_gpu_wrapper.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Iterable, Iterator
+
+import torch
+from classy_vision.generic.util import recursive_copy_to_gpu
+
+from .dataloader_wrapper import DataloaderWrapper
+
+
+class DataloaderAsyncGPUWrapper(DataloaderWrapper):
+    """
+    Dataloader which wraps another dataloader, and moves the data to GPU asynchronously.
+    At most one batch is pre-emptively copied.
+
+    credits: @vini
+    """
+
+    def __init__(self, dataloader: Iterable) -> None:
+        super().__init__(dataloader)
+        self.cache = None
+        self.stream = torch.cuda.Stream()
+        assert torch.cuda.is_available(), "This Dataloader wrapper needs a CUDA setup"
+
+    def __iter__(self) -> Iterator[Any]:
+        self._iter = iter(self.dataloader)
+        return self
+
+    def __next__(self) -> Any:
+        result = None
+
+        with torch.cuda.stream(self.stream):
+            if self.cache is not None:
+                # Make sure that an ongoing transfer is done
+                torch.cuda.current_stream().wait_stream(self.stream)
+                result = self.cache
+            else:
+                result = recursive_copy_to_gpu(next(self._iter))
+
+            # Lookahead and start upload
+            try:
+                self.cache = recursive_copy_to_gpu(next(self._iter))
+            except StopIteration:
+                self.cache = None
+        assert result is not None
+
+        return result
+
+    def __len__(self) -> int:
+        return len(self.dataloader)

--- a/test/dataset_dataloader_gpu_async_wrapper_test.py
+++ b/test/dataset_dataloader_gpu_async_wrapper_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from test.generic.config_utils import get_test_task_config
+
+import torch
+from classy_vision.tasks import build_task
+
+
+class TestDataloaderAsyncGPUWrapper(unittest.TestCase):
+    def _test_number_of_batches(self, data_iterator, expected_batches):
+        num_batches = 0
+        for _ in data_iterator:
+            num_batches += 1
+        self.assertEqual(num_batches, expected_batches)
+
+    def test_streaming_dataset_async(self):
+        """
+        Test that streaming datasets return the correct number of batches, and that
+        the length is also calculated correctly.
+        """
+
+        if not torch.cuda.is_available():
+            return True
+
+        config = get_test_task_config()
+        dataset_config = {
+            "name": "synthetic_image_streaming",
+            "split": "train",
+            "crop_size": 224,
+            "class_ratio": 0.5,
+            "num_samples": 2000,
+            "length": 4000,
+            "seed": 0,
+            "batchsize_per_replica": 32,
+            "use_shuffle": True,
+            "async_gpu_copy": True,
+        }
+        expected_batches = 62
+        config["dataset"]["train"] = dataset_config
+        task = build_task(config)
+        task.prepare()
+        task.advance_phase()
+
+        # test that the number of batches expected is correct
+        self.assertEqual(task.num_batches_per_phase, expected_batches)
+
+        # test that the data iterator returns the expected number of batches
+        data_iterator = task.get_data_iterator()
+        self._test_number_of_batches(data_iterator, expected_batches)
+
+        # test that the dataloader can be rebuilt from the dataset inside it
+        task._recreate_data_loader_from_dataset()
+        task.create_data_iterator()
+        data_iterator = task.get_data_iterator()
+        self._test_number_of_batches(data_iterator, expected_batches)


### PR DESCRIPTION
Summary: Add a dataloader wrapper which starts the GPU copy of the next sample ahead of time. Credits to vreis / D20586997

Differential Revision: D23089284

