### PR TITLE
Move optimizer.on_epoch call to task.on_phase_end

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -1009,10 +1009,6 @@ class ClassificationTask(ClassyTask):
         # Set up pytorch module in train vs eval mode, update optimizer.
         self._set_model_train_mode()
 
-        # Update the optimizer schedule
-        if self.train and self.train_phase_idx >= 0:
-            self.optimizer.on_epoch(where=self.where)
-
     def done_training(self):
         """Stop condition for training
         """
@@ -1112,6 +1108,9 @@ class ClassificationTask(ClassyTask):
 
     def on_phase_end(self):
         self.log_phase_end("train")
+
+        if self.train:
+            self.optimizer.on_epoch(where=self.where)
 
         logging.debug("Syncing losses on phase end...")
         self.synchronize_losses()

--- a/test/optim_param_scheduler_test.py
+++ b/test/optim_param_scheduler_test.py
@@ -157,8 +157,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
         trainer = LocalTrainer()
         trainer.train(task)
 
-        # The first call is the initialization
-        self.assertEqual(where_list, [0, 0, 1 / 3, 2 / 3])
+        self.assertEqual(where_list, [0, 1 / 3, 2 / 3])
 
     def test_param_scheduler_step(self):
         task = self._build_task(num_epochs=3)
@@ -177,7 +176,7 @@ class TestParamSchedulerIntegration(unittest.TestCase):
         trainer.train(task)
 
         # We have 10 samples, batch size is 5. Each epoch is done in two steps.
-        # The first call is the initialization
+        # The first call is the initialization - only happens for step schedulers
         self.assertEqual(where_list, [0, 0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6])
 
     def test_no_param_schedulers(self):


### PR DESCRIPTION
Summary: According to `optimizer.on_epoch()`, it should be called at the end of a phase. Instead, it was being called in `task.advance_phase()`. Moved the to a more appropriate location inside `task.on_phase_end()`

Differential Revision: D23190096

