### PR TITLE
Do not pass the mp context if num_workers is zero

### DIFF
--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -165,6 +165,9 @@ class ClassyDataset:
         epoch = kwargs.get("current_phase_id", 0)
         assert isinstance(epoch, int), "Epoch must be an int"
         num_workers_override = kwargs.get("num_workers", self.num_workers)
+        if num_workers_override == 0:
+            # set the mp context to None to placate the PyTorch dataloader
+            kwargs["multiprocessing_context"] = None
 
         offset_epoch = shuffle_seed + epoch
 

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -231,10 +231,10 @@ class ClassificationTask(ClassyTask):
             self._train_only = False
         return self
 
-    def set_dataloader_mp_context(self, dataloader_mp_context: str):
+    def set_dataloader_mp_context(self, dataloader_mp_context: Optional[str]):
         """Set the multiprocessing context used by the dataloader.
 
-        The context can be either 'spawn', 'fork' or 'forkserver'. See
+        The context can be either 'spawn', 'fork', 'forkserver' or None. See
         https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_context
         for more details."""
 

--- a/test/dataset_classy_dataset_test.py
+++ b/test/dataset_classy_dataset_test.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import multiprocessing as mp
 import unittest
 import unittest.mock as mock
 from test.generic.utils import compare_batches, compare_samples
@@ -142,6 +143,15 @@ class TestClassyDataset(unittest.TestCase):
     def test_get_iterator(self):
         # Verifies that we can retrieve samples with iterators
         dl = self.dataset1.iterator(num_workers=0)
+        assert isinstance(
+            dl, DataLoader
+        ), "Classy Iterator should return instance of PyTorch Dataloader"
+        next(iter(dl))
+
+        # We should be able to set num_workers to zero while also passing a mp context
+        dl = self.dataset1.iterator(
+            num_workers=0, multiprocessing_context=mp.get_context()
+        )
         assert isinstance(
             dl, DataLoader
         ), "Classy Iterator should return instance of PyTorch Dataloader"


### PR DESCRIPTION
Summary:
Classy's default dataloader currently doesn't work when `num_workers` is set to 0. This is extremely useful for debugging dataloader issues like in https://github.com/facebookresearch/ClassyVision/issues/597 and https://github.com/facebookresearch/ClassyVision/issues/607.

Note that calling `set_dataloader_mp_context(None)` doesn't work since that just sets the mp context to the default value for the environment.

If `num_workers` is set to 0, the default call to `Dataloader` now sets `multiprocessing_context` to `None` so that PyTorch doesn't raise an exception.

Differential Revision: D23310512

