### PR TITLE
Initialize INFO level logging in tutorials

### DIFF
--- a/tutorials/fine_tuning.ipynb
+++ b/tutorials/fine_tuning.ipynb
@@ -15,6 +15,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Before we get started, let us enable INFO level logging so that we can monitor the progress of our runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Training a model\n",
     "Let us begin by pre-training a model using a head with 1000 classes"
    ]
@@ -722,9 +741,9 @@
    "bento/extensions/theme/main.css": true
   },
   "kernelspec": {
-   "display_name": "Classy Vision (local)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "classy_vision_local"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -736,7 +755,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5+"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,

--- a/tutorials/video_classification.ipynb
+++ b/tutorials/video_classification.ipynb
@@ -20,6 +20,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Before we get started, let us enable INFO level logging so that we can monitor the progress of our runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Prepare the dataset\n",
     "\n",
     "All right! Let's start with the dataset. [UCF-101](https://www.crcv.ucf.edu/data/UCF101.php) is a canonical action recognition dataset. It has 101 action classes, and has 3 folds with different training/testing splitting . We use fold 1 in this tutorial. Classy Vision has implemented the dataset `ucf101`, which can be used to load the training and testing splits. "


### PR DESCRIPTION
Classy's tutorials didn't log anything by default, which was very confusing. Fix that by also logging INFO level messages.