### PR TITLE
strict parameter in model.set_classy_state

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -234,7 +234,7 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
             model_state_dict = copy.deepcopy(model_state_dict)
         return model_state_dict
 
-    def load_head_states(self, state):
+    def load_head_states(self, state, strict=True):
         """Load only the state (weights) of the heads.
 
         For a trunk-heads model, this function allows the user to
@@ -247,9 +247,9 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         """
         for block_name, head_states in state["model"]["heads"].items():
             for head_name, head_state in head_states.items():
-                self._heads[block_name][head_name].load_state_dict(head_state)
+                self._heads[block_name][head_name].load_state_dict(head_state, strict)
 
-    def set_classy_state(self, state):
+    def set_classy_state(self, state, strict=True):
         """Set the state of the ClassyModel.
 
         Args:
@@ -259,7 +259,7 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         This is used to load the state of the model from a checkpoint.
         """
         # load the state for heads
-        self.load_head_states(state)
+        self.load_head_states(state, strict)
 
         # clear the heads to set the trunk's state. This is done because when heads are
         # attached to modules, we wrap them by ClassyBlocks, thereby changing the
@@ -267,7 +267,7 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         # fetched / set when there are no blocks attached.
         attached_heads = self.get_heads()
         self.clear_heads()
-        self.load_state_dict(state["model"]["trunk"])
+        self.load_state_dict(state["model"]["trunk"], strict)
 
         # set the heads back again
         self.set_heads(attached_heads)

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -469,7 +469,7 @@ class ResNeXt(ClassyModel):
         state["version"] = VERSION
         return state
 
-    def set_classy_state(self, state):
+    def set_classy_state(self, state, strict=True):
         version = state.get("version")
         if version is None:
             # convert the weights from the previous implementation of ResNeXt to the
@@ -485,7 +485,7 @@ class ResNeXt(ClassyModel):
             raise ValueError(
                 f"Unsupported ResNeXt version: {version}. Expected: {VERSION}"
             )
-        super().set_classy_state(state)
+        super().set_classy_state(state, strict)
 
 
 class _ResNeXt(ResNeXt):


### PR DESCRIPTION
Summary: Allow to load partial head states from state_dict. This is useful when we have new parameters in a head and we want to load weights for the existing parameters.

Reviewed By: mannatsingh

Differential Revision: D22133179

