### PR TITLE
Dataloader refactor and simplification

### DIFF
--- a/classy_vision/hooks/profiler_hook.py
+++ b/classy_vision/hooks/profiler_hook.py
@@ -27,9 +27,7 @@ class ProfilerHook(ClassyHook):
     def on_start(self, task) -> None:
         """Profile the forward pass."""
         logging.info("Profiling forward pass...")
-        batchsize_per_replica = getattr(
-            task.dataloaders[task.phase_type].dataset, "batchsize_per_replica", 1
-        )
+        batchsize_per_replica = task.get_batchsize_per_replica()
         input_shape = task.base_model.input_shape
         p = profile(
             task.model,

--- a/test/dataset_dataloader_limit_wrapper_test.py
+++ b/test/dataset_dataloader_limit_wrapper_test.py
@@ -43,11 +43,11 @@ class TestDataloaderLimitWrapper(unittest.TestCase):
         self.assertEqual(task.num_batches_per_phase, expected_batches)
 
         # test that the data iterator returns the expected number of batches
-        data_iterator = task.get_data_iterator()
+        data_iterator = task.data_iterator
         self._test_number_of_batches(data_iterator, expected_batches)
 
-        # test that the dataloader can be rebuilt from the dataset inside it
-        task._recreate_data_loader_from_dataset()
-        task.create_data_iterator()
-        data_iterator = task.get_data_iterator()
+        # test that the dataloader can be rebuilt
+        task.build_dataloaders_for_current_phase()
+        task.create_data_iterators()
+        data_iterator = task.data_iterator
         self._test_number_of_batches(data_iterator, expected_batches)

--- a/test/manual/hooks_tensorboard_plot_hook_test.py
+++ b/test/manual/hooks_tensorboard_plot_hook_test.py
@@ -61,6 +61,7 @@ class TestTensorboardPlotHook(HookTestBase):
             config["dataset"]["test"]["batchsize_per_replica"] = 5
             task = build_task(config)
             task.prepare()
+            task.advance_phase()
             task.phase_idx = phase_idx
             task.train = train
 


### PR DESCRIPTION
Summary:
This diff is meant to simplify Classy's handling of dataloaders.
- Dataloaders are not created until they are needed and only live while they are being used
  - Earlier, we used to create all dataloaders during initialization and while loading from a checkpoint (which were destroyed and re-created before training even began), and we used to keep them alive throughout training
- We do not use dataloaders to re-create dataloaders for a new phase - all this can is done directly through the datasets
  - This gets rid of the requirement of dataloaders to have within them information to create a dataloader for a new phase, or a reference to the dataset
- Converted `self.dataloaders: Dict` to `self.dataloader: Iterable`
- Got rid of `_recreate_data_loader_from_dataset()` - this was an unnecessary function and was especially cumbersome to implement and maintain for downstream users
- A `dataloader` doesn't have to have a `dataloader.dataset` attribute anymore
- Replaced `build_dataloader()` and `build_dataloaders()` which took `torch.util.DataLoader` args such as `pin_memory` with simpler functions - `build_dataloader_from_dataset()` and `build_dataloaders_for_current_phase()` which take no extra args
  - `build_dataloader_from_dataset()` takes `**kwargs` to support re-use in derived classes
  - The functions impose no restrictions on how many dataloaders should be created for a phase, allowing more general use cases
  - `create_data_iterator()` has been renamed to `create_data_iterators()` for the same reason
- Removed `get_data_iterator()` - this didn't really do anything

Reviewed By: vreis

Differential Revision: D23720332

