### PR TITLE
Fix usage logging bug

### DIFF
--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -81,7 +81,7 @@ def build_model(config):
             heads[fork_block].append(head)
         model.set_heads(heads)
 
-    log_class_usage("Model", model)
+    log_class_usage("Model", model.__class__)
 
     return model
 

--- a/classy_vision/tasks/__init__.py
+++ b/classy_vision/tasks/__init__.py
@@ -28,7 +28,7 @@ def build_task(config):
     (see :func:`register_task`) and call .from_config on it."""
 
     task = TASK_REGISTRY[config["name"]].from_config(config)
-    log_class_usage("Task", task)
+    log_class_usage("Task", task.__class__)
 
     return task
 


### PR DESCRIPTION
Summary:
Previously we added uage logging for tasks/model components in classy vision, however we didn't get the identifier work successfully.

Lessons learned:
In python, if we have an instance of a class, we'll need to use its `__class__` member before accessing its `__name__` member.

Differential Revision: D23978967

