### PR TITLE
support non-strict checkpoint loading in FineTuningTask

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -117,7 +117,7 @@ def main(args, config):
 
 
 def configure_hooks(args, config):
-    hooks = [LossLrMeterLoggingHook(args.log_freq), ModelComplexityHook()]
+    hooks = [LossLrMeterLoggingHook(args.log_freq), ModelComplexityHook(verbose=True)]
 
     # Make a folder to store checkpoints and tensorboard logging outputs
     suffix = datetime.now().isoformat()

--- a/classy_vision/dataset/dataloader_limit_wrapper.py
+++ b/classy_vision/dataset/dataloader_limit_wrapper.py
@@ -58,7 +58,7 @@ class DataloaderLimitWrapper(DataloaderWrapper):
             if self.wrap_around:
                 # create a new iterator to load data from the beginning
                 logging.info(
-                    f"Wrapping around after {self._count} calls. Limit: {self.limit}"
+                    f"Wrapping around after {self._count - 1} calls. Limit: {self.limit}"
                 )
                 try:
                     self._iter = iter(self.dataloader)

--- a/classy_vision/generic/distributed_util.py
+++ b/classy_vision/generic/distributed_util.py
@@ -219,6 +219,7 @@ def init_distributed_data_parallel_model(
     model: torch.nn.Module,
     broadcast_buffers: bool = False,
     find_unused_parameters: bool = True,
+    gradient_as_bucket_view: bool = False,
 ) -> torch.nn.parallel.DistributedDataParallel:
     global _cuda_device_index
 
@@ -228,6 +229,7 @@ def init_distributed_data_parallel_model(
             model,
             broadcast_buffers=broadcast_buffers,
             find_unused_parameters=find_unused_parameters,
+            gradient_as_bucket_view=gradient_as_bucket_view,
         )
     else:
         # GPU model
@@ -237,6 +239,7 @@ def init_distributed_data_parallel_model(
             output_device=_cuda_device_index,
             broadcast_buffers=broadcast_buffers,
             find_unused_parameters=find_unused_parameters,
+            gradient_as_bucket_view=gradient_as_bucket_view,
         )
 
 

--- a/classy_vision/generic/profiler.py
+++ b/classy_vision/generic/profiler.py
@@ -86,7 +86,24 @@ def get_shape(x: Union[Tuple, List, Dict]) -> Union[Tuple, List, Dict]:
         return x.size()
 
 
-def _layer_flops(layer: nn.Module, x: Any, y: Any) -> int:
+def _get_batchsize_per_replica(x: Union[Tuple, List, Dict]) -> int:
+    """
+    Some layer may take tuple/list/dict/list[dict] as input in forward function. We
+    recursively dive into the tuple/list until we meet a tensor and infer the batch size
+    """
+    while isinstance(x, (list, tuple)):
+        assert len(x) > 0, "input x of tuple/list type must have at least one element"
+        x = x[0]
+
+    if isinstance(x, (dict,)):
+        # index zero is always equal to batch size. select an arbitrary key.
+        key_list = list(x.keys())
+        x = x[key_list[0]]
+
+    return x.size()[0]
+
+
+def _layer_flops(layer: nn.Module, x: Any, y: Any, verbose: bool = False) -> int:
     """
     Computes the number of FLOPs required for a single layer.
 
@@ -146,86 +163,6 @@ def _layer_flops(layer: nn.Module, x: Any, y: Any) -> int:
             / layer.groups
         )
 
-    # learned group convolution:
-    elif layer_type in ["LearnedGroupConv"]:
-        conv = layer.conv
-        out_h = int(
-            (x.size()[2] + 2 * conv.padding[0] - conv.kernel_size[0]) / conv.stride[0]
-            + 1
-        )
-        out_w = int(
-            (x.size()[3] + 2 * conv.padding[1] - conv.kernel_size[1]) / conv.stride[1]
-            + 1
-        )
-        count1 = _layer_flops(layer.relu, x) + _layer_flops(layer.norm, x)
-        count2 = (
-            batchsize_per_replica
-            * conv.in_channels
-            * conv.out_channels
-            * conv.kernel_size[0]
-            * conv.kernel_size[1]
-            * out_h
-            * out_w
-            / layer.condense_factor
-        )
-        flops = count1 + count2
-
-    # non-linearities:
-    elif layer_type in ["ReLU", "ReLU6", "Tanh", "Sigmoid", "Softmax"]:
-        flops = x.numel()
-
-    # 2D pooling layers:
-    elif layer_type in ["AvgPool2d", "MaxPool2d"]:
-        in_h = x.size()[2]
-        in_w = x.size()[3]
-        if isinstance(layer.kernel_size, int):
-            layer.kernel_size = (layer.kernel_size, layer.kernel_size)
-        kernel_ops = layer.kernel_size[0] * layer.kernel_size[1]
-        out_h = 1 + int(
-            (in_h + 2 * layer.padding - layer.kernel_size[0]) / layer.stride
-        )
-        out_w = 1 + int(
-            (in_w + 2 * layer.padding - layer.kernel_size[1]) / layer.stride
-        )
-        flops = x.size()[0] * x.size()[1] * out_w * out_h * kernel_ops
-
-    # adaptive avg pool2d
-    # This is approximate and works only for downsampling without padding
-    # based on aten/src/ATen/native/AdaptiveAveragePooling.cpp
-    elif layer_type in ["AdaptiveAvgPool2d"]:
-        in_h = x.size()[2]
-        in_w = x.size()[3]
-        if isinstance(layer.output_size, int):
-            out_h, out_w = layer.output_size, layer.output_size
-        elif len(layer.output_size) == 1:
-            out_h, out_w = layer.output_size[0], layer.output_size[0]
-        else:
-            out_h, out_w = layer.output_size
-        if out_h > in_h or out_w > in_w:
-            raise ClassyProfilerNotImplementedError(layer)
-        batchsize_per_replica = x.size()[0]
-        num_channels = x.size()[1]
-        kh = in_h - out_h + 1
-        kw = in_w - out_w + 1
-        kernel_ops = kh * kw
-        flops = batchsize_per_replica * num_channels * out_h * out_w * kernel_ops
-
-    # linear layer:
-    elif layer_type in ["Linear"]:
-        weight_ops = layer.weight.numel()
-        bias_ops = layer.bias.numel() if layer.bias is not None else 0
-        flops = x.size()[0] * (weight_ops + bias_ops)
-
-    # batch normalization / layer normalization:
-    elif layer_type in [
-        "BatchNorm1d",
-        "BatchNorm2d",
-        "BatchNorm3d",
-        "SyncBatchNorm",
-        "LayerNorm",
-    ]:
-        flops = 2 * x.numel()
-
     # 3D convolution
     elif layer_type in ["Conv3d"]:
         out_t = int(
@@ -256,62 +193,75 @@ def _layer_flops(layer: nn.Module, x: Any, y: Any) -> int:
             / layer.groups
         )
 
-    # 3D pooling layers
-    elif layer_type in ["AvgPool3d", "MaxPool3d"]:
-        in_t = x.size()[2]
-        in_h = x.size()[3]
-        in_w = x.size()[4]
-        if isinstance(layer.kernel_size, int):
-            layer.kernel_size = (
-                layer.kernel_size,
-                layer.kernel_size,
-                layer.kernel_size,
-            )
-        if isinstance(layer.padding, int):
-            layer.padding = (layer.padding, layer.padding, layer.padding)
-        if isinstance(layer.stride, int):
-            layer.stride = (layer.stride, layer.stride, layer.stride)
-        kernel_ops = layer.kernel_size[0] * layer.kernel_size[1] * layer.kernel_size[2]
-        out_t = 1 + int(
-            (in_t + 2 * layer.padding[0] - layer.kernel_size[0]) / layer.stride[0]
+    # learned group convolution:
+    elif layer_type in ["LearnedGroupConv"]:
+        conv = layer.conv
+        out_h = int(
+            (x.size()[2] + 2 * conv.padding[0] - conv.kernel_size[0]) / conv.stride[0]
+            + 1
         )
-        out_h = 1 + int(
-            (in_h + 2 * layer.padding[1] - layer.kernel_size[1]) / layer.stride[1]
+        out_w = int(
+            (x.size()[3] + 2 * conv.padding[1] - conv.kernel_size[1]) / conv.stride[1]
+            + 1
         )
-        out_w = 1 + int(
-            (in_w + 2 * layer.padding[2] - layer.kernel_size[2]) / layer.stride[2]
+        count1 = _layer_flops(layer.relu, x) + _layer_flops(layer.norm, x)
+        count2 = (
+            batchsize_per_replica
+            * conv.in_channels
+            * conv.out_channels
+            * conv.kernel_size[0]
+            * conv.kernel_size[1]
+            * out_h
+            * out_w
+            / layer.condense_factor
         )
-        flops = batchsize_per_replica * x.size()[1] * out_t * out_h * out_w * kernel_ops
+        flops = count1 + count2
 
-    # adaptive avg pool3d
-    # This is approximate and works only for downsampling without padding
-    # based on aten/src/ATen/native/AdaptiveAveragePooling3d.cpp
-    elif layer_type in ["AdaptiveAvgPool3d"]:
-        in_t = x.size()[2]
-        in_h = x.size()[3]
-        in_w = x.size()[4]
-        out_t = layer.output_size[0]
-        out_h = layer.output_size[1]
-        out_w = layer.output_size[2]
-        if out_t > in_t or out_h > in_h or out_w > in_w:
-            raise ClassyProfilerNotImplementedError(layer)
-        batchsize_per_replica = x.size()[0]
-        num_channels = x.size()[1]
-        kt = in_t - out_t + 1
-        kh = in_h - out_h + 1
-        kw = in_w - out_w + 1
-        kernel_ops = kt * kh * kw
-        flops = (
-            batchsize_per_replica * num_channels * out_t * out_w * out_h * kernel_ops
+    # non-linearities are not considered in MAC counting
+    elif layer_type in ["ReLU", "ReLU6", "Tanh", "Sigmoid", "Softmax"]:
+        flops = 0
+
+    elif layer_type in [
+        "MaxPool1d",
+        "MaxPool2d",
+        "MaxPool3d",
+        "AdaptiveMaxPool1d",
+        "AdaptiveMaxPool2d",
+        "AdaptiveMaxPool3d",
+    ]:
+        flops = 0
+
+    elif layer_type in ["AvgPool1d", "AvgPool2d", "AvgPool3d"]:
+        kernel_ops = 1
+        flops = kernel_ops * y.numel()
+
+    elif layer_type in ["AdaptiveAvgPool1d", "AdaptiveAvgPool2d", "AdaptiveAvgPool3d"]:
+        assert isinstance(layer.output_size, (list, tuple))
+        kernel = torch.Tensor(list(x.shape[2:])) // torch.Tensor(
+            [list(layer.output_size)]
         )
+        kernel_ops = torch.prod(kernel)
+        flops = kernel_ops * y.numel()
+
+    # linear layer:
+    elif layer_type in ["Linear"]:
+        weight_ops = layer.weight.numel()
+        flops = x.size()[0] * weight_ops
+
+    # batch normalization / layer normalization:
+    elif layer_type in [
+        "BatchNorm1d",
+        "BatchNorm2d",
+        "BatchNorm3d",
+        "SyncBatchNorm",
+        "LayerNorm",
+    ]:
+        # batchnorm can be merged into conv op. Thus, count 0 FLOPS
+        flops = 0
 
     # dropout layer
     elif layer_type in ["Dropout"]:
-        # At test time, we do not drop values but scale the feature map by the
-        # dropout ratio
-        flops = 1
-        for dim_size in x.size():
-            flops *= dim_size
+        flops = 0
 
     elif layer_type == "Identity":
         flops = 0
@@ -335,11 +285,14 @@ def _layer_flops(layer: nn.Module, x: Any, y: Any) -> int:
         f"params(M): {count_params(layer) / 1e6}",
         f"flops(M): {int(flops) / 1e6}",
     ]
-    logging.debug("\t".join(message))
+    if verbose:
+        logging.info("\t".join(message))
     return flops
 
 
-def _layer_activations(layer: nn.Module, x: Any, out: Any) -> int:
+def _layer_activations(
+    layer: nn.Module, x: Any, out: Any, verbose: bool = False
+) -> int:
     """
     Computes the number of activations produced by a single layer.
 
@@ -360,7 +313,8 @@ def _layer_activations(layer: nn.Module, x: Any, out: Any) -> int:
         return 0
 
     message = [f"module: {typestr}", f"activations: {activations}"]
-    logging.debug("\t".join(message))
+    if verbose:
+        logging.info("\t".join(message))
     return activations
 
 
@@ -386,17 +340,19 @@ def summarize_profiler_info(prof: torch.autograd.profiler.profile) -> str:
 
 
 class ComplexityComputer:
-    def __init__(self, compute_fn: Callable, count_unique: bool):
+    def __init__(self, compute_fn: Callable, count_unique: bool, verbose: bool = False):
         self.compute_fn = compute_fn
         self.count_unique = count_unique
         self.count = 0
+        self.verbose = verbose
         self.seen_modules = set()
 
     def compute(self, layer: nn.Module, x: Any, out: Any, module_name: str):
         if self.count_unique and module_name in self.seen_modules:
             return
-        logging.debug(f"module name: {module_name}")
-        self.count += self.compute_fn(layer, x, out)
+        if self.verbose:
+            logging.info(f"module name: {module_name}")
+        self.count += self.compute_fn(layer, x, out, self.verbose)
         self.seen_modules.add(module_name)
 
     def reset(self):
@@ -482,6 +438,7 @@ def compute_complexity(
     input_key: Optional[Union[str, List[str]]] = None,
     patch_attr: str = None,
     compute_unique: bool = False,
+    verbose: bool = False,
 ) -> int:
     """
     Compute the complexity of a forward pass.
@@ -501,7 +458,7 @@ def compute_complexity(
     else:
         input = get_model_dummy_input(model, input_shape, input_key)
 
-    complexity_computer = ComplexityComputer(compute_fn, compute_unique)
+    complexity_computer = ComplexityComputer(compute_fn, compute_unique, verbose)
 
     # measure FLOPs:
     modify_forward(model, complexity_computer, patch_attr=patch_attr)
@@ -519,12 +476,13 @@ def compute_flops(
     model: nn.Module,
     input_shape: Tuple[int] = (3, 224, 224),
     input_key: Optional[Union[str, List[str]]] = None,
+    verbose: bool = False,
 ) -> int:
     """
     Compute the number of FLOPs needed for a forward pass.
     """
     return compute_complexity(
-        model, _layer_flops, input_shape, input_key, patch_attr="flops"
+        model, _layer_flops, input_shape, input_key, patch_attr="flops", verbose=verbose
     )
 
 
@@ -532,12 +490,18 @@ def compute_activations(
     model: nn.Module,
     input_shape: Tuple[int] = (3, 224, 224),
     input_key: Optional[Union[str, List[str]]] = None,
+    verbose: bool = False,
 ) -> int:
     """
     Compute the number of activations created in a forward pass.
     """
     return compute_complexity(
-        model, _layer_activations, input_shape, input_key, patch_attr="activations"
+        model,
+        _layer_activations,
+        input_shape,
+        input_key,
+        patch_attr="activations",
+        verbose=verbose,
     )
 
 

--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -274,7 +274,9 @@ def load_checkpoint(
     return checkpoint
 
 
-def update_classy_model(model, model_state_dict: Dict, reset_heads: bool) -> bool:
+def update_classy_model(
+    model, model_state_dict: Dict, reset_heads: bool, strict: bool = True
+) -> bool:
     """
     Updates the model with the provided model state dictionary.
 
@@ -283,6 +285,8 @@ def update_classy_model(model, model_state_dict: Dict, reset_heads: bool) -> boo
         model_state_dict: State dict, should be the output of a call to
             ClassyVisionModel.get_classy_state().
         reset_heads: if False, uses the heads' state from model_state_dict.
+        strict: if True, strictly match the module/buffer keys in current model and
+            pass-in model_state_dict
     """
     try:
         if reset_heads:
@@ -291,7 +295,7 @@ def update_classy_model(model, model_state_dict: Dict, reset_heads: bool) -> boo
             model_state_dict["model"]["heads"] = current_model_state_dict["model"][
                 "heads"
             ]
-        model.set_classy_state(model_state_dict)
+        model.set_classy_state(model_state_dict, strict=strict)
         logging.info("Model state load successful")
         return True
     except Exception:

--- a/classy_vision/hooks/model_complexity_hook.py
+++ b/classy_vision/hooks/model_complexity_hook.py
@@ -27,11 +27,12 @@ class ModelComplexityHook(ClassyHook):
     on_phase_end = ClassyHook._noop
     on_end = ClassyHook._noop
 
-    def __init__(self) -> None:
+    def __init__(self, verbose=False) -> None:
         super().__init__()
         self.num_flops = None
         self.num_activations = None
         self.num_parameters = None
+        self.verbose = verbose
 
     def on_start(self, task) -> None:
         """Measure number of parameters, FLOPs and activations."""
@@ -48,15 +49,13 @@ class ModelComplexityHook(ClassyHook):
                     input_key=task.base_model.input_key
                     if hasattr(task.base_model, "input_key")
                     else None,
+                    verbose=self.verbose,
                 )
                 if self.num_flops is None:
                     logging.info("FLOPs for forward pass: skipped.")
                     self.num_flops = 0
                 else:
-                    logging.info(
-                        "FLOPs for forward pass: %d MFLOPs"
-                        % (float(self.num_flops) / 1e6)
-                    )
+                    logging.info(f"FLOPs for forward pass: {self.num_flops} FLOPs")
             except ClassyProfilerNotImplementedError as e:
                 logging.warning(f"Could not compute FLOPs for model forward pass: {e}")
             try:
@@ -66,6 +65,7 @@ class ModelComplexityHook(ClassyHook):
                     input_key=task.base_model.input_key
                     if hasattr(task.base_model, "input_key")
                     else None,
+                    verbose=self.verbose,
                 )
                 logging.info(f"Number of activations in model: {self.num_activations}")
             except ClassyProfilerNotImplementedError as e:

--- a/classy_vision/hooks/precise_batch_norm_hook.py
+++ b/classy_vision/hooks/precise_batch_norm_hook.py
@@ -4,21 +4,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
-from classy_vision.generic.util import (
-    get_batchsize_per_replica,
-    recursive_copy_to_device,
-    recursive_copy_to_gpu,
-)
+import logging
+
+from classy_vision.generic.util import get_batchsize_per_replica, recursive_copy_to_gpu
 from classy_vision.hooks import ClassyHook, register_hook
 from fvcore.nn.precise_bn import update_bn_stats
 
 
-def _get_iterator(cache, use_gpu):
-    for elem in cache:
+def _get_iterator(data_iter, use_gpu):
+    for elem in data_iter:
         if use_gpu:
             elem = recursive_copy_to_gpu(elem, non_blocking=True)
-        yield elem
+        yield elem["input"]
 
 
 @register_hook("precise_bn")
@@ -32,9 +29,7 @@ class PreciseBatchNormHook(ClassyHook):
     fvcore/nn/precise_bn.py>`_ for more information.
     """
 
-    on_start = ClassyHook._noop
     on_phase_start = ClassyHook._noop
-    on_step = ClassyHook._noop
     on_end = ClassyHook._noop
 
     def __init__(self, num_samples: int) -> None:
@@ -49,31 +44,32 @@ class PreciseBatchNormHook(ClassyHook):
         if num_samples <= 0:
             raise ValueError("num_samples has to be a positive integer")
         self.num_samples = num_samples
-        self.cache = []
-        self.current_samples = 0
+        self.batch_size = None
 
     @classmethod
     def from_config(cls, config):
         return cls(config["num_samples"])
 
-    def on_phase_start(self, task) -> None:
-        self.cache = []
-        self.current_samples = 0
+    def on_start(self, task) -> None:
+        logging.info("Use precise BatchNorm hook")
 
     def on_step(self, task) -> None:
-        if not task.train or self.current_samples >= self.num_samples:
+        if not task.train or self.batch_size is not None:
             return
-        input = recursive_copy_to_device(
-            task.last_batch.sample["input"],
-            non_blocking=True,
-            device=torch.device("cpu"),
-        )
-        self.cache.append(input)
-        self.current_samples += get_batchsize_per_replica(input)
+
+        self.batch_size = get_batchsize_per_replica(task.last_batch.sample["input"])
 
     def on_phase_end(self, task) -> None:
         if not task.train:
             return
-        iterator = _get_iterator(self.cache, task.use_gpu)
-        num_batches = len(self.cache)
+
+        num_batches = (self.num_samples + self.batch_size - 1) // self.batch_size
+
+        task.build_dataloaders_for_current_phase()
+        task.create_data_iterators()
+        if num_batches > len(task.data_iterator):
+            num_batches = len(task.data_iterator)
+            logging.info(f"Reduce no. of samples to {num_batches * self.batch_size}")
+
+        iterator = _get_iterator(task.data_iterator, task.use_gpu)
         update_bn_stats(task.base_model, iterator, num_batches)

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -161,6 +161,7 @@ class ClassificationTask(ClassyTask):
         self.last_batch = None
         self.batch_norm_sync_mode = BatchNormSyncMode.DISABLED
         self.find_unused_parameters = True
+        self.gradient_as_bucket_view = True
         self.use_gpu = torch.cuda.is_available()
         self.dataloader_mp_context = "spawn"
         self.bn_weight_decay = False
@@ -274,6 +275,7 @@ class ClassificationTask(ClassyTask):
         batch_norm_sync_mode: BatchNormSyncMode = BatchNormSyncMode.DISABLED,
         batch_norm_sync_group_size: int = 0,
         find_unused_parameters: bool = True,
+        gradient_as_bucket_view: bool = True,
     ):
         """Set distributed options.
 
@@ -287,6 +289,8 @@ class ClassificationTask(ClassyTask):
                 efficient synchronization, set it to the number of GPUs in a node (
                 usually 8).
             find_unused_parameters: See
+                :class:`torch.nn.parallel.DistributedDataParallel` for information.
+            gradient_as_bucket_view: See
                 :class:`torch.nn.parallel.DistributedDataParallel` for information.
 
         Raises:
@@ -317,6 +321,7 @@ class ClassificationTask(ClassyTask):
         self.batch_norm_sync_mode = batch_norm_sync_mode
 
         self.find_unused_parameters = find_unused_parameters
+        self.gradient_as_bucket_view = gradient_as_bucket_view
 
         return self
 
@@ -473,6 +478,9 @@ class ClassificationTask(ClassyTask):
             ),
             "find_unused_parameters": distributed_config.get(
                 "find_unused_parameters", True
+            ),
+            "gradient_as_bucket_view": distributed_config.get(
+                "gradient_as_bucket_view", True
             ),
         }
 
@@ -718,6 +726,7 @@ class ClassificationTask(ClassyTask):
             self.base_model,
             broadcast_buffers=broadcast_buffers,
             find_unused_parameters=self.find_unused_parameters,
+            gradient_as_bucket_view=self.gradient_as_bucket_view,
         )
         if (
             isinstance(self.base_loss, ClassyLoss)
@@ -728,6 +737,7 @@ class ClassificationTask(ClassyTask):
                 self.base_loss,
                 broadcast_buffers=broadcast_buffers,
                 find_unused_parameters=self.find_unused_parameters,
+                gradient_as_bucket_view=self.gradient_as_bucket_view,
             )
 
     @property

--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -19,6 +19,7 @@ class FineTuningTask(ClassificationTask):
         super().__init__(*args, **kwargs)
         self.pretrained_checkpoint_dict = None
         self.pretrained_checkpoint_path = None
+        self.pretrained_checkpoint_load_strict = True
         self.reset_heads = False
         self.freeze_trunk = False
 
@@ -38,6 +39,9 @@ class FineTuningTask(ClassificationTask):
         pretrained_checkpoint_path = config.get("pretrained_checkpoint")
         if pretrained_checkpoint_path:
             task.set_pretrained_checkpoint(pretrained_checkpoint_path)
+            task.set_pretrained_checkpoint_load_strict(
+                config.get("pretrained_checkpoint_load_strict", True)
+            )
 
         task.set_reset_heads(config.get("reset_heads", False))
         task.set_freeze_trunk(config.get("freeze_trunk", False))
@@ -45,6 +49,12 @@ class FineTuningTask(ClassificationTask):
 
     def set_pretrained_checkpoint(self, checkpoint_path: str) -> "FineTuningTask":
         self.pretrained_checkpoint_path = checkpoint_path
+        return self
+
+    def set_pretrained_checkpoint_load_strict(
+        self, pretrained_checkpoint_load_strict: bool
+    ):
+        self.pretrained_checkpoint_load_strict = pretrained_checkpoint_load_strict
         return self
 
     def _set_pretrained_checkpoint_dict(
@@ -93,6 +103,7 @@ class FineTuningTask(ClassificationTask):
                 self.base_model,
                 self.pretrained_checkpoint_dict["classy_state_dict"]["base_model"],
                 self.reset_heads,
+                self.pretrained_checkpoint_load_strict,
             )
             assert (
                 state_load_success


### PR DESCRIPTION
Summary: When we want to fine-tune a model which has extra modules that are not seen in pre-trained model, we need to load the pre-trained checkpoint in a non-strict manner. Thus, we allow users to provide `pretrained_checkpoint_load_strict` argument to enable this.

Differential Revision: D24375548

