### PR TITLE
use the cuda to represent the gpu device

### DIFF
--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -162,4 +162,4 @@ class ExponentialMovingAverageModelHook(ClassyHook):
 
     def use_optimization(self, task):
         # we can only use the optimization if we are on PyTorch >= 1.7 and the EMA state is on the same device as the model
-        return get_torch_version() >= "1.7" and task.use_gpu == (self.device == "gpu")
+        return get_torch_version() >= "1.7" and task.use_gpu == (self.device == "cuda")


### PR DESCRIPTION
Summary: self.device is set as "cuda" when the device is gpu.

Differential Revision: D24645064

