### PR TITLE
Add better support for testing torch.allclose

### DIFF
--- a/test/generic/utils.py
+++ b/test/generic/utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
+import unittest
 from functools import wraps
 
 import torch
@@ -298,3 +299,18 @@ class LimitedPhaseTrainer(ClassyTrainer):
             super().train(task)
         except LimitedPhaseException:
             pass
+
+
+class ClassyTestCase(unittest.TestCase):
+    def assertTorchAllClose(
+        self, tensor_1, tensor_2, rtol=1e-5, atol=1e-8, equal_nan=False
+    ):
+        for tensor in [tensor_1, tensor_2]:
+            if not isinstance(tensor, torch.Tensor):
+                raise AssertionError(
+                    f"Expected tensor, not {tensor} of type {type(tensor)}"
+                )
+        if not torch.allclose(
+            tensor_1, tensor_2, rtol=rtol, atol=atol, equal_nan=equal_nan
+        ):
+            raise AssertionError(f"{tensor_1} is not close to {tensor_2}")

--- a/test/losses_soft_target_cross_entropy_loss_test.py
+++ b/test/losses_soft_target_cross_entropy_loss_test.py
@@ -59,7 +59,7 @@ class TestSoftTargetCrossEntropyLoss(unittest.TestCase):
             "name": "soft_target_cross_entropy",
             "ignore_index": -1,
             "reduction": "mean",
-            "normalize_targets": None,
+            "normalize_targets": False,
         }
         crit = SoftTargetCrossEntropyLoss.from_config(config)
         outputs = self._get_outputs()

--- a/test/test_generic_utils_test.py
+++ b/test/test_generic_utils_test.py
@@ -1,0 +1,37 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from test.generic.utils import ClassyTestCase
+
+import torch
+
+
+class TestClassyTestCase(unittest.TestCase):
+    def test_assert_torch_all_close(self):
+        test_fixture = ClassyTestCase()
+
+        data = [1.1, 2.2]
+        tensor_1 = torch.Tensor(data)
+
+        # shouldn't raise an exception
+        tensor_2 = tensor_1
+        test_fixture.assertTorchAllClose(tensor_1, tensor_2)
+
+        # should fail because tensors are not close
+        tensor_2 = tensor_1 / 2
+        with self.assertRaises(AssertionError):
+            test_fixture.assertTorchAllClose(tensor_1, tensor_2)
+
+        # should fail because tensor_2 is not a tensor
+        tensor_2 = data
+        with self.assertRaises(AssertionError):
+            test_fixture.assertTorchAllClose(tensor_1, tensor_2)
+
+        # should fail because tensor_1 is not a tensor
+        tensor_1 = data
+        tensor_2 = torch.Tensor(data)
+        with self.assertRaises(AssertionError):
+            test_fixture.assertTorchAllClose(tensor_1, tensor_2)


### PR DESCRIPTION
Summary: Implemented a new `ClassyTestCase` with support for `assertTorchAllClose`. This prints in the assertion what the failure inputs are which makes writing tests easier.

Differential Revision: D24911128

