### PR TITLE
Add support for more generic inputs to "Recursive copy to"

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -153,16 +153,15 @@ def recursive_copy_to_device(
     value: Any, non_blocking: bool, device: torch.device
 ) -> Any:
     """
-    Recursively searches lists, tuples, dicts and copies tensors to device if
-    possible. Non-tensor values are passed as-is in the result.
+    Recursively searches lists, tuples, dicts and copies any object which
+    supports an object.to API (e.g. tensors) to device if possible.
+    Other values are passed as-is in the result.
 
     Note:  These are all copies, so if there are two objects that reference
     the same object, then after this call, there will be two different objects
     referenced on the device.
     """
-    if isinstance(value, torch.Tensor):
-        return value.to(device, non_blocking=non_blocking)
-    elif isinstance(value, list) or isinstance(value, tuple):
+    if isinstance(value, list) or isinstance(value, tuple):
         device_val = []
         for val in value:
             device_val.append(
@@ -178,6 +177,8 @@ def recursive_copy_to_device(
             )
 
         return device_val
+    elif callable(getattr(value, "to", None)):
+        return value.to(device=device, non_blocking=non_blocking)
 
     return value
 

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -46,9 +46,23 @@ def get_mock_tensor(mock_class):
 
 
 class TestUtilMethods(unittest.TestCase):
+    class StructuredInput:
+        def __init__(self, tensor_a, tensor_b):
+            self.tensor_a = tensor_a
+            self.tensor_b = tensor_b
+
+        def to(self, device, non_blocking):
+            return TestUtilMethods.StructuredInput(
+                tensor_a=self.tensor_a.to(device=device, non_blocking=non_blocking),
+                tensor_b=self.tensor_b.to(device=device, non_blocking=non_blocking),
+            )
+
     def test_recursive_copy_to_gpu(self):
         tensor_a = get_mock_tensor()
         tensor_b = get_mock_tensor()
+        tensor_structured = TestUtilMethods.StructuredInput(
+            tensor_a=get_mock_tensor(), tensor_b=get_mock_tensor()
+        )
 
         valid_gpu_copy_value = tensor_a
         gpu_value = util.recursive_copy_to_gpu(valid_gpu_copy_value)
@@ -75,6 +89,11 @@ class TestUtilMethods(unittest.TestCase):
 
         value = {"a": "b"}
         self.assertEqual(value, util.recursive_copy_to_gpu(value))
+
+        valid_gpu_copy_structured = tensor_structured
+        gpu_value = util.recursive_copy_to_gpu(valid_gpu_copy_structured)
+        self.assertTrue(gpu_value.tensor_a.is_cuda)
+        self.assertTrue(gpu_value.tensor_b.is_cuda)
 
     _json_config_file = ROOT / "generic_util_json_blob_test.json"
 


### PR DESCRIPTION
Summary:
Add support to other types to recursive_copy_to_device.
In particular, as long as the input has a "to" method, recursive_copy_to_device will be able to handle it. This opens support to more complex inputs, e.g. classes.

Differential Revision: D24910581

