### PR TITLE
Optimizer inf/nan loss, remove unused optimizer backward

### DIFF
--- a/classy_vision/optim/classy_optimizer.py
+++ b/classy_vision/optim/classy_optimizer.py
@@ -208,19 +208,6 @@ class ClassyOptimizer(ABC):
         """
         self.optimizer.load_state_dict(state["optim"])
 
-    def backward(self, loss: torch.Tensor) -> None:
-        """
-        Computer gradients with respect to the loss.
-
-        Calls :func:`zero_grad` and then computes the gradient using
-        `torch.Tensor.backward <https://pytorch.org/docs/stable/
-        tensors.html#torch.Tensor.backward>`_. See :mod:`torch.autograd` for
-        more information.
-        """
-        # TODO (aadcock): Add gradient accumulation logic
-        self.zero_grad()
-        loss.backward()
-
     def on_epoch(self, where: float) -> None:
         """
         Called at the end of a phase.

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -27,10 +27,10 @@ from classy_vision.generic.util import (
     Timer,
     copy_model_to_gpu,
     load_and_broadcast_checkpoint,
+    master_params,
     recursive_copy_to_gpu,
     split_batchnorm_params,
     update_classy_state,
-    master_params,
 )
 from classy_vision.hooks import CheckpointHook, ClassyHook, build_hooks
 from classy_vision.losses import ClassyLoss, build_loss
@@ -985,6 +985,8 @@ class ClassificationTask(ClassyTask):
         if (update_idx % self.optimizer_period) == 0:
             self.optimizer.zero_grad()
 
+        self.check_inf_nan(loss)
+
         if self.amp_args is not None:
             with apex.amp.scale_loss(loss, self.optimizer.optimizer) as scaled_loss:
                 scaled_loss.backward()
@@ -1000,8 +1002,6 @@ class ClassificationTask(ClassyTask):
                 self._clip_gradients(self.clip_grad_norm)
 
             self.optimizer.step(where=self.where)
-
-        self.check_inf_nan(loss)
 
     def _rescale_gradients(self, scale):
         for param in master_params(self.optimizer):


### PR DESCRIPTION
Summary:
* Check for loss sanity before calling backward and step, D24740329 (https://github.com/facebookresearch/ClassyVision/commit/1ba6b0354e87c41b5eb26934888d66a55e198b37) modified the order of check.
* Remove unused optimizer backward, previously this was re-introduced in D21080585 (https://github.com/facebookresearch/ClassyVision/commit/4a627a1e97d72d02eeeefac52d3d71b13822e835) and rendered useless in D24740329 (https://github.com/facebookresearch/ClassyVision/commit/1ba6b0354e87c41b5eb26934888d66a55e198b37).

Differential Revision: D24955125

