### PR TITLE
Fix version of nbconvert, and update ipynb to html script

### DIFF
--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -68,8 +68,7 @@ def gen_tutorials(repo_dir: str) -> None:
 
         # pull out html div for notebook
         soup = BeautifulSoup(html, "html.parser")
-        nb_meat = soup.find("div", {"id": "notebook-container"})
-        del nb_meat.attrs["id"]
+        nb_meat = soup.find("body", {"class": "jp-Notebook"})
         nb_meat.attrs["class"] = ["notebook"]
         html_out = JS_SCRIPTS + str(nb_meat)
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
                 "sphinx",
                 "isort==5.2.2",
                 "bs4",
-                "nbconvert",
+                "nbconvert==6.0.7",
                 "pre-commit",
                 "parameterized",
             ]


### PR DESCRIPTION
Summary: Script to parse to ipynb into html for ClassyVision website was broken, as there was no longer a `div` with `id` `notebook-container`. Likely culprit is `nbconvert`, so fixed version in `setup.py` to hopefully prevent breakage in the future.

Reviewed By: vreis

Differential Revision: D25128504

