### PR TITLE
Add support to normalize inputs in the heads

### DIFF
--- a/classy_vision/heads/vision_transformer_head.py
+++ b/classy_vision/heads/vision_transformer_head.py
@@ -14,6 +14,7 @@ https://github.com/rwightman/pytorch-image-models/blob/master/timm/models/vision
 
 import copy
 from collections import OrderedDict
+from typing import Optional
 
 import torch.nn as nn
 from classy_vision.heads import ClassyHead, register_head
@@ -21,16 +22,38 @@ from classy_vision.heads import ClassyHead, register_head
 from ..models.lecun_normal_init import lecun_normal_init
 
 
+NORMALIZE_L2 = "l2"
+
+
 @register_head("vision_transformer_head")
 class VisionTransformerHead(ClassyHead):
     def __init__(
         self,
-        in_plane,
-        num_classes,
-        hidden_dim=None,
+        unique_id: str,
+        in_plane: int,
+        num_classes: Optional[int] = None,
+        hidden_dim: Optional[int] = None,
+        normalize_inputs: Optional[str] = None,
     ):
-        super().__init__()
-        if hidden_dim is None:
+        """
+        Args:
+            unique_id: A unique identifier for the head
+            in_plane: Input size for the fully connected layer
+            num_classes: Number of output classes for the head
+            hidden_dim: If not None, a hidden layer with the specific dimension is added
+            normalize_inputs: If specified, normalize the inputs using the specified
+                method. Supports "l2" normalization.
+        """
+        super().__init__(unique_id, num_classes)
+
+        if normalize_inputs is not None and normalize_inputs != NORMALIZE_L2:
+            raise ValueError(
+                f"Unsupported value for normalize_inputs: {normalize_inputs}"
+            )
+
+        if num_classes is None:
+            layers = []
+        elif hidden_dim is None:
             layers = [("head", nn.Linear(in_plane, num_classes))]
         else:
             layers = [
@@ -39,6 +62,7 @@ class VisionTransformerHead(ClassyHead):
                 ("head", nn.Linear(hidden_dim, num_classes)),
             ]
         self.layers = nn.Sequential(OrderedDict(layers))
+        self.normalize_inputs = normalize_inputs
         self.init_weights()
 
     def init_weights(self):
@@ -47,14 +71,17 @@ class VisionTransformerHead(ClassyHead):
                 self.layers.pre_logits.weight, fan_in=self.layers.pre_logits.in_features
             )
             nn.init.zeros_(self.layers.pre_logits.bias)
-        nn.init.zeros_(self.layers.head.weight)
-        nn.init.zeros_(self.layers.head.bias)
+        if hasattr(self.layers, "head"):
+            nn.init.zeros_(self.layers.head.weight)
+            nn.init.zeros_(self.layers.head.bias)
 
     @classmethod
     def from_config(cls, config):
         config = copy.deepcopy(config)
-        config.pop("unique_id")
         return cls(**config)
 
     def forward(self, x):
+        if self.normalize_inputs is not None:
+            if self.normalize_inputs == NORMALIZE_L2:
+                x = nn.functional.normalize(x, p=2.0, dim=1)
         return self.layers(x)

--- a/test/heads_fully_connected_head_test.py
+++ b/test/heads_fully_connected_head_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import copy
+from functools import partial
+from test.generic.utils import ClassyTestCase
+
+import torch
+from classy_vision.generic.util import get_torch_version
+from classy_vision.heads.fully_connected_head import FullyConnectedHead
+
+
+class TestFullyConnectedHead(ClassyTestCase):
+    def test_fully_connected_head(self):
+        batch_size = 2
+        in_plane = 3
+        image_size = 4
+        num_classes = 5
+        head = FullyConnectedHead(
+            "default_head",
+            num_classes=num_classes,
+            in_plane=in_plane,
+        )
+        input = torch.rand([batch_size, in_plane, image_size, image_size])
+        output = head(input)
+        self.assertEqual(output.shape, torch.Size([batch_size, num_classes]))
+
+    def test_fully_connected_head_normalize_inputs(self):
+        batch_size = 2
+        in_plane = 3
+        image_size = 4
+        head = FullyConnectedHead(
+            "default_head",
+            in_plane=in_plane,
+            normalize_inputs="l2",
+            num_classes=None,
+        )
+        input = torch.rand([batch_size, in_plane, image_size, image_size])
+        output = head(input)
+        self.assertEqual(output.shape, torch.Size([batch_size, in_plane]))
+        for i in range(batch_size):
+            output_i = output[i]
+            self.assertAlmostEqual(output_i.norm().item(), 1, delta=1e-5)
+
+        # test that the grads will be the same when using normalization as when
+        # normalizing an input and passing it to the head without normalize_inputs.
+        # use input with a norm > 1 and make image_size = 1 so that average
+        # pooling is a no op
+        image_size = 1
+        input = 2 + torch.rand([batch_size, in_plane, image_size, image_size])
+        norm_func = (
+            torch.linalg.norm
+            if get_torch_version() >= [1, 7]
+            else partial(torch.norm, p=2)
+        )
+        norms = norm_func(input, dim=[1, 2, 3])
+        normalized_input = torch.clone(input)
+        for i in range(batch_size):
+            normalized_input[i] /= norms[i]
+        num_classes = 10
+        head_norm = FullyConnectedHead(
+            "default_head",
+            in_plane=in_plane,
+            normalize_inputs="l2",
+            num_classes=num_classes,
+        )
+        head_no_norm = FullyConnectedHead(
+            "default_head",
+            in_plane=in_plane,
+            num_classes=num_classes,
+        )
+        # share the weights between the heads
+        head_norm.load_state_dict(copy.deepcopy(head_no_norm.state_dict()))
+
+        # use the sum of the output as the loss and perform a backward
+        head_no_norm(normalized_input).sum().backward()
+        head_norm(input).sum().backward()
+
+        for param_1, param_2 in zip(head_norm.parameters(), head_no_norm.parameters()):
+            self.assertTorchAllClose(param_1, param_2)
+            self.assertTorchAllClose(param_1.grad, param_2.grad)

--- a/test/heads_vision_transformer_head_test.py
+++ b/test/heads_vision_transformer_head_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+
+import torch
+from classy_vision.heads.vision_transformer_head import VisionTransformerHead
+
+
+class TestVisionTransformerHead(unittest.TestCase):
+    def test_vision_transformer_head(self):
+        batch_size = 2
+        in_plane = 3
+        num_classes = 5
+        head = VisionTransformerHead(
+            "default_head",
+            num_classes=num_classes,
+            in_plane=in_plane,
+        )
+        input = torch.rand([batch_size, in_plane])
+        output = head(input)
+        self.assertEqual(output.shape, torch.Size([batch_size, num_classes]))
+
+    def test_vision_transformer_head_normalize_inputs(self):
+        batch_size = 2
+        in_plane = 3
+        head = VisionTransformerHead(
+            "default_head",
+            num_classes=None,
+            in_plane=in_plane,
+            normalize_inputs="l2",
+        )
+        input = torch.rand([batch_size, in_plane])
+        output = head(input)
+        self.assertEqual(output.shape, torch.Size([batch_size, in_plane]))
+        for i in range(batch_size):
+            output_i = output[i]
+            self.assertAlmostEqual(output_i.norm().item(), 1, places=3)


### PR DESCRIPTION
Summary:
Added a `normalize_inputs` argument to `FullyConnectedHead` and `VisionTransformerHead`.

Added simple test cases for both heads

Differential Revision: D25213285

