### PR TITLE
Move log task usage in init function (classy_vision/tasks/classy_task.py)

### DIFF
--- a/classy_vision/tasks/__init__.py
+++ b/classy_vision/tasks/__init__.py
@@ -7,7 +7,6 @@
 from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
-from classy_vision.generic.util import log_class_usage
 
 from .classy_task import ClassyTask
 
@@ -28,7 +27,6 @@ def build_task(config):
     (see :func:`register_task`) and call .from_config on it."""
 
     task = TASK_REGISTRY[config["name"]].from_config(config)
-    log_class_usage("Task", task.__class__)
 
     return task
 

--- a/classy_vision/tasks/classy_task.py
+++ b/classy_vision/tasks/classy_task.py
@@ -8,6 +8,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
+from classy_vision.generic.util import log_class_usage
+
 
 class ClassyTask(ABC):
     """
@@ -22,6 +24,7 @@ class ClassyTask(ABC):
         Constructs a ClassyTask.
         """
         self.hooks = []
+        log_class_usage("Task", self.__class__)
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Summary: Moved log_class_usage from `classy_vision/tasks/__init__.py` to `classy_vision/tasks/classy_task.py`

Reviewed By: kazhang

Differential Revision: D25618822

