### PR TITLE
move model logging (#676)

### DIFF
--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -9,7 +9,6 @@ from collections import defaultdict
 from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
-from classy_vision.generic.util import log_class_usage
 from classy_vision.heads import build_head
 
 from .classy_model import ClassyModel
@@ -80,8 +79,6 @@ def build_model(config):
             head = build_head(updated_config)
             heads[fork_block].append(head)
         model.set_heads(heads)
-
-    log_class_usage("Model", model.__class__)
 
     return model
 

--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
+from classy_vision.generic.util import log_class_usage
 from classy_vision.heads.classy_head import ClassyHead
 
 from .classy_block import ClassyBlock
@@ -157,6 +158,8 @@ class ClassyModel(nn.Module, metaclass=_ClassyModelMeta):
         self._attachable_block_names = []
         self._heads = nn.ModuleDict()
         self._head_outputs = {}
+
+        log_class_usage("Model", self.__class__)
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "ClassyModel":


### PR DESCRIPTION
Summary:
As mentioned in the task, logging the model usage within the `build_model` function in `__init__.py` does not capture all use cases. This diff moves it to the init function of `ClassyModel` instead, where the logging would capture all use cases.

Pull Request resolved: https://github.com/facebookresearch/ClassyVision/pull/676

Reviewed By: kazhang

Differential Revision: D25728909

Pulled By: scottyshi

