### PR TITLE
trace duplicate registrations

### DIFF
--- a/classy_vision/dataset/transforms/__init__.py
+++ b/classy_vision/dataset/transforms/__init__.py
@@ -6,6 +6,7 @@
 
 
 import copy
+import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 
@@ -21,6 +22,7 @@ FILE_ROOT = Path(__file__).parent
 
 
 TRANSFORM_REGISTRY = {}
+TRANSFORM_REGISTRY_TB = {}
 
 
 def build_transform(transform_config: Dict[str, Any]) -> Callable:
@@ -96,7 +98,10 @@ def register_transform(name: str):
 
     def register_transform_cls(cls: Callable[..., Callable]):
         if name in TRANSFORM_REGISTRY:
-            raise ValueError("Cannot register duplicate transform ({})".format(name))
+            msg = (
+                "Cannot register duplicate transform ({}). Already registered at \n{}\n"
+            )
+            raise ValueError(msg.format(name, TRANSFORM_REGISTRY_TB[name]))
         if hasattr(transforms, name) or hasattr(transforms_video, name):
             raise ValueError(
                 "{} has existed in torchvision.transforms, Please change the name!".format(
@@ -104,6 +109,8 @@ def register_transform(name: str):
                 )
             )
         TRANSFORM_REGISTRY[name] = cls
+        tb = "".join(traceback.format_stack())
+        TRANSFORM_REGISTRY_TB[name] = tb
         return cls
 
     return register_transform_cls

--- a/classy_vision/heads/__init__.py
+++ b/classy_vision/heads/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import traceback
 from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
@@ -17,6 +18,8 @@ FILE_ROOT = Path(__file__).parent
 
 HEAD_REGISTRY = {}
 HEAD_CLASS_NAMES = set()
+HEAD_REGISTRY_TB = {}
+HEAD_CLASS_NAMES_TB = {}
 
 
 def register_head(name):
@@ -38,19 +41,25 @@ def register_head(name):
 
     def register_head_cls(cls):
         if name in HEAD_REGISTRY:
-            raise ValueError("Cannot register duplicate head ({})".format(name))
+            msg = "Cannot register duplicate head ({}). Already registered at \n{}\n"
+            raise ValueError(msg.format(name, HEAD_REGISTRY_TB[name]))
         if not issubclass(cls, ClassyHead):
             raise ValueError(
                 "Head ({}: {}) must extend ClassyHead".format(name, cls.__name__)
             )
         if cls.__name__ in HEAD_CLASS_NAMES:
-            raise ValueError(
-                "Cannot register head with duplicate class name ({})".format(
-                    cls.__name__
-                )
+            msg = (
+                "Cannot register head with duplicate class name({})."
+                + "Previously registered at \n{}\n"
             )
+            raise ValueError(
+                msg.format(cls.__name__, HEAD_CLASS_NAMES_TB[cls.__name__])
+            )
+        tb = "".join(traceback.format_stack())
         HEAD_REGISTRY[name] = cls
         HEAD_CLASS_NAMES.add(cls.__name__)
+        HEAD_REGISTRY_TB[name] = tb
+        HEAD_CLASS_NAMES_TB[cls.__name__] = tb
         return cls
 
     return register_head_cls

--- a/classy_vision/losses/__init__.py
+++ b/classy_vision/losses/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import traceback
 from pathlib import Path
 
 import torch
@@ -19,7 +20,9 @@ FILE_ROOT = Path(__file__).parent
 
 
 LOSS_REGISTRY = {}
+LOSS_REGISTRY_TB = {}
 LOSS_CLASS_NAMES = set()
+LOSS_CLASS_NAMES_TB = {}
 
 
 def build_loss(config):
@@ -83,13 +86,17 @@ def register_loss(name):
 
     def register_loss_cls(cls):
         if name in LOSS_REGISTRY:
-            raise ValueError("Cannot register duplicate optimizer ({})".format(name))
+            msg = "Cannot register duplicate loss ({}). Already registered at \n{}\n"
+            raise ValueError(msg.format(name, LOSS_REGISTRY_TB[name]))
         if not issubclass(cls, ClassyLoss):
             raise ValueError(
                 "Loss ({}: {}) must extend ClassyLoss".format(name, cls.__name__)
             )
+        tb = "".join(traceback.format_stack())
         LOSS_REGISTRY[name] = cls
         LOSS_CLASS_NAMES.add(cls.__name__)
+        LOSS_REGISTRY_TB[name] = tb
+        LOSS_CLASS_NAMES_TB[cls.__name__] = tb
         return cls
 
     return register_loss_cls

--- a/classy_vision/meters/__init__.py
+++ b/classy_vision/meters/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import traceback
 from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
@@ -15,6 +16,7 @@ FILE_ROOT = Path(__file__).parent
 
 
 METER_REGISTRY = {}
+METER_REGISTRY_TB = {}
 
 
 def build_meter(config):
@@ -51,7 +53,8 @@ def register_meter(name):
 
     def register_meter_cls(cls):
         if name in METER_REGISTRY:
-            raise ValueError("Cannot register duplicate meter ({})".format(name))
+            msg = "Cannot register duplicate meter ({}). Already registered at \n{}\n"
+            raise ValueError(msg.format(name, METER_REGISTRY_TB[name]))
         if not issubclass(cls, ClassyMeter):
             raise ValueError(
                 "Meter ({}: {}) must extend \
@@ -59,7 +62,9 @@ def register_meter(name):
                     name, cls.__name__
                 )
             )
+        tb = "".join(traceback.format_stack())
         METER_REGISTRY[name] = cls
+        METER_REGISTRY_TB[name] = tb
         return cls
 
     return register_meter_cls

--- a/classy_vision/models/__init__.py
+++ b/classy_vision/models/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import copy
+import traceback
 from collections import defaultdict
 from pathlib import Path
 
@@ -19,6 +20,8 @@ FILE_ROOT = Path(__file__).parent
 
 MODEL_REGISTRY = {}
 MODEL_CLASS_NAMES = set()
+MODEL_REGISTRY_TB = {}
+MODEL_CLASS_NAMES_TB = {}
 
 
 def register_model(name):
@@ -40,19 +43,25 @@ def register_model(name):
 
     def register_model_cls(cls):
         if name in MODEL_REGISTRY:
-            raise ValueError("Cannot register duplicate model ({})".format(name))
+            msg = "Cannot register duplicate model ({}). Already registered at \n{}\n"
+            raise ValueError(msg.format(name, MODEL_REGISTRY_TB[name]))
         if not issubclass(cls, ClassyModel):
             raise ValueError(
                 "Model ({}: {}) must extend ClassyModel".format(name, cls.__name__)
             )
         if cls.__name__ in MODEL_CLASS_NAMES:
-            raise ValueError(
-                "Cannot register model with duplicate class name ({})".format(
-                    cls.__name__
-                )
+            msg = (
+                "Cannot register model with duplicate class name({})."
+                + "Previously registered at \n{}\n"
             )
+            raise ValueError(
+                msg.format(cls.__name__, MODEL_CLASS_NAMES_TB[cls.__name__])
+            )
+        tb = "".join(traceback.format_stack())
         MODEL_REGISTRY[name] = cls
         MODEL_CLASS_NAMES.add(cls.__name__)
+        MODEL_REGISTRY_TB[name] = tb
+        MODEL_CLASS_NAMES_TB[cls.__name__] = tb
         return cls
 
     return register_model_cls

--- a/classy_vision/optim/param_scheduler/__init__.py
+++ b/classy_vision/optim/param_scheduler/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import traceback
 from pathlib import Path
 from typing import Any, Dict
 
@@ -20,6 +21,7 @@ FILE_ROOT = Path(__file__).parent
 
 
 PARAM_SCHEDULER_REGISTRY = {}
+PARAM_SCHEDULER_REGISTRY_TB = {}
 
 
 def build_param_scheduler(config: Dict[str, Any]) -> ParamScheduler:
@@ -53,16 +55,17 @@ def register_param_scheduler(name):
 
     def register_param_scheduler_cls(cls):
         if name in PARAM_SCHEDULER_REGISTRY:
-            raise ValueError(
-                "Cannot register duplicate param scheduler ({})".format(name)
-            )
+            msg = "Cannot register duplicate param scheduler ({}). Already registered at \n{}\n"
+            raise ValueError(msg.format(name, PARAM_SCHEDULER_REGISTRY_TB[name]))
         if not issubclass(cls, ParamScheduler):
             raise ValueError(
                 "Param Scheduler ({}: {}) must extend ParamScheduler".format(
                     name, cls.__name__
                 )
             )
+        tb = "".join(traceback.format_stack())
         PARAM_SCHEDULER_REGISTRY[name] = cls
+        PARAM_SCHEDULER_REGISTRY_TB[name] = tb
         return cls
 
     return register_param_scheduler_cls

--- a/classy_vision/tasks/__init__.py
+++ b/classy_vision/tasks/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import traceback
 from pathlib import Path
 
 from classy_vision.generic.registry_utils import import_all_modules
@@ -16,6 +17,8 @@ FILE_ROOT = Path(__file__).parent
 
 TASK_REGISTRY = {}
 TASK_CLASS_NAMES = set()
+TASK_REGISTRY_TB = {}
+TASK_CLASS_NAMES_TB = {}
 
 
 def build_task(config):
@@ -49,19 +52,25 @@ def register_task(name):
 
     def register_task_cls(cls):
         if name in TASK_REGISTRY:
-            raise ValueError("Cannot register duplicate task ({})".format(name))
+            msg = "Cannot register duplicate task ({}). Already registered at \n{}\n"
+            raise ValueError(msg.format(name, TASK_REGISTRY_TB[name]))
         if not issubclass(cls, ClassyTask):
             raise ValueError(
                 "Task ({}: {}) must extend ClassyTask".format(name, cls.__name__)
             )
         if cls.__name__ in TASK_CLASS_NAMES:
-            raise ValueError(
-                "Cannot register task with duplicate class name ({})".format(
-                    cls.__name__
-                )
+            msg = (
+                "Cannot register task with duplicate class name({})."
+                + "Previously registered at \n{}\n"
             )
+            raise ValueError(
+                msg.format(cls.__name__, TASK_CLASS_NAMES_TB[cls.__name__])
+            )
+        tb = "".join(traceback.format_stack())
         TASK_REGISTRY[name] = cls
         TASK_CLASS_NAMES.add(cls.__name__)
+        TASK_REGISTRY_TB[name] = tb
+        TASK_CLASS_NAMES_TB[cls.__name__] = tb
         return cls
 
     return register_task_cls


### PR DESCRIPTION
While using ClassyVision, I was getting a bit confused as to how duplicate registrations were occurring. It turned out to be a consequence of the way a test harness of a downstream project did imports. I have a sense others may struggle with understanding such error messages about duplicates, too. In this change, I add full tracebacks of the original registration to the errors, which is very verbose but potentially useful.