### PR TITLE
change logging.warn to logging.warning

### DIFF
--- a/classy_vision/dataset/classy_video_dataset.py
+++ b/classy_vision/dataset/classy_video_dataset.py
@@ -223,13 +223,13 @@ class ClassyVideoDataset(ClassyDataset):
                 os.makedirs(filedir, exist_ok=True)
                 logging.info(f"Save metadata to file: {filedir}")
             except Exception as err:
-                logging.warn(f"Fail to create folder: {filedir}")
+                logging.warning(f"Fail to create folder: {filedir}")
                 raise err
 
         try:
             torch.save(metadata, filepath)
         except ValueError:
-            logging.warn(f"Fail to save metadata to file: {filepath}")
+            logging.warning(f"Fail to save metadata to file: {filepath}")
 
     @property
     def video_clips(self):

--- a/classy_vision/hooks/model_tensorboard_hook.py
+++ b/classy_vision/hooks/model_tensorboard_hook.py
@@ -77,5 +77,5 @@ class ModelTensorboardHook(ClassyHook):
                     writer=self.tb_writer,
                 )
             except Exception:
-                logging.warn("Unable to plot model to tensorboard")
+                logging.warning("Unable to plot model to tensorboard")
                 logging.debug("Exception encountered:", exc_info=True)

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -187,7 +187,9 @@ class ResNeXt3DBase(ClassyModel):
         current_state = self.state_dict()
         for name, weight_src in state["model"]["trunk"].items():
             if name not in current_state:
-                logging.warn(f"weight {name} is not found in current ResNeXt3D state")
+                logging.warning(
+                    f"weight {name} is not found in current ResNeXt3D state"
+                )
                 continue
 
             weight_tgt = current_state[name]

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -921,7 +921,7 @@ class ClassificationTask(ClassyTask):
             if hook.name() in state["hooks"]:
                 hook.set_classy_state(state["hooks"][hook.name()])
             else:
-                logging.warn(f"No state found for hook: {hook.name()}")
+                logging.warning(f"No state found for hook: {hook.name()}")
 
         if "train" in self.datasets and self._is_checkpointable_dataset(
             self.datasets["train"]


### PR DESCRIPTION
Summary: logging.warn() is deprecated since Python 3.3 in favor of logging.warning()

Reviewed By: ahornby

Differential Revision: D25870738

