### PR TITLE
Remove references to gluster

### DIFF
--- a/classy_vision/hooks/checkpoint_hook.py
+++ b/classy_vision/hooks/checkpoint_hook.py
@@ -14,15 +14,6 @@ from classy_vision.hooks.classy_hook import ClassyHook
 from fvcore.common.file_io import PathManager
 
 
-gfs_prefix_list = {
-    "/mnt/gfsdataswarm",
-    "/mnt/gfsdataswarm-global",
-    "/mnt/vol",
-    "/mnt/shared",
-    "/mnt/homedir",
-}
-
-
 @register_hook("checkpoint")
 class CheckpointHook(ClassyHook):
     """
@@ -86,13 +77,6 @@ class CheckpointHook(ClassyHook):
         assert PathManager.exists(
             self.checkpoint_folder
         ), "Checkpoint folder '{}' deleted unexpectedly".format(self.checkpoint_folder)
-
-        for prefix in gfs_prefix_list:
-            if self.checkpoint_folder.startswith(prefix):
-                logging.warning(
-                    "GFS is deprecating... please save checkpoint to manifold!"
-                )
-                break
 
         # save checkpoint:
         logging.info("Saving checkpoint to '{}'...".format(self.checkpoint_folder))


### PR DESCRIPTION
Summary: Gluster is scaling down, so we should remove references to gluster. As such, remove warning about gluster file paths in checkpoint hook.

Differential Revision: D26638806

