### PR TITLE
Improve get_torch_version to not return strings

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -572,7 +572,12 @@ def log_class_usage(component_type, klass):
 
 
 def get_torch_version():
-    return torch.__version__[:3]
+    """Get the torch version as a [major, minor, revision].
+
+    All comparisons must be done with the three version values.
+    """
+    version_list = torch.__version__.split(".")
+    return [int(version_str) for version_str in version_list]
 
 
 train_model = partial(_train_mode, train_mode=True)

--- a/classy_vision/hooks/exponential_moving_average_model_hook.py
+++ b/classy_vision/hooks/exponential_moving_average_model_hook.py
@@ -162,4 +162,6 @@ class ExponentialMovingAverageModelHook(ClassyHook):
 
     def use_optimization(self, task):
         # we can only use the optimization if we are on PyTorch >= 1.7 and the EMA state is on the same device as the model
-        return get_torch_version() >= "1.7" and task.use_gpu == (self.device == "cuda")
+        return get_torch_version() >= [1, 7, 0] and task.use_gpu == (
+            self.device == "cuda"
+        )

--- a/classy_vision/models/lecun_normal_init.py
+++ b/classy_vision/models/lecun_normal_init.py
@@ -13,7 +13,7 @@ from torch import Tensor
 
 
 def lecun_normal_init(tensor, fan_in):
-    if get_torch_version() >= "1.7":
+    if get_torch_version() >= [1, 7, 0]:
         trunc_normal_ = nn.init.trunc_normal_
     else:
 

--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -24,6 +24,7 @@ from classy_vision.generic.util import (
     split_batchnorm_params,
     update_classy_model,
     update_classy_state,
+    get_torch_version,
 )
 from classy_vision.models import build_model
 from classy_vision.tasks import build_task
@@ -346,3 +347,11 @@ class TestCheckpointFunctions(unittest.TestCase):
         checkpoint_path = f"{self.base_dir}/{filename}"
         loaded_checkpoint = load_checkpoint(checkpoint_path)
         self.assertDictEqual(checkpoint_dict, loaded_checkpoint)
+
+    @mock.patch("classy_vision.generic.util.torch")
+    def test_get_torch_version(self, mock_torch: mock.MagicMock):
+        mock_torch.__version__ = "1.7.2"
+        self.assertEqual(get_torch_version(), [1, 7, 2])
+        self.assertLess(get_torch_version(), [1, 7, 3])
+        self.assertLess(get_torch_version(), [1, 8, 0])
+        self.assertGreater(get_torch_version(), [1, 6, 9])


### PR DESCRIPTION
Summary: String comparisons are risky

Differential Revision: D26654750

