### PR TITLE
Support FP16 grad communication in DDP

### DIFF
--- a/test/generic_util_test.py
+++ b/test/generic_util_test.py
@@ -19,12 +19,12 @@ import torch.nn as nn
 from classy_vision.generic.util import (
     CHECKPOINT_FILE,
     Timer,
+    get_torch_version,
     load_checkpoint,
     save_checkpoint,
     split_batchnorm_params,
     update_classy_model,
     update_classy_state,
-    get_torch_version,
 )
 from classy_vision.models import build_model
 from classy_vision.tasks import build_task


### PR DESCRIPTION
Summary:
DDP supports an fp16_compress_hook which compresses the grads to FP16, which can result in a significant speed up. Added support for this using the following config setting -
```
      "distributed": {
        "fp16_grad_compress": true
      },
```

Differential Revision: D26655070

