### PR TITLE
add reduction mode none in soft_target_cross_entropy_loss

### DIFF
--- a/classy_vision/dataset/dataloader_limit_wrapper.py
+++ b/classy_vision/dataset/dataloader_limit_wrapper.py
@@ -58,7 +58,7 @@ class DataloaderLimitWrapper(DataloaderWrapper):
             if self.wrap_around:
                 # create a new iterator to load data from the beginning
                 logging.info(
-                    f"Wrapping around after {self._count} calls. Limit: {self.limit}"
+                    f"Wrapping around after {self._count - 1} calls. Limit: {self.limit}"
                 )
                 try:
                     self._iter = iter(self.dataloader)

--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -7,6 +7,7 @@
 import logging
 from typing import Optional
 
+import torch
 from classy_vision.generic.distributed_util import get_rank
 from classy_vision.hooks import register_hook
 from classy_vision.hooks.classy_hook import ClassyHook
@@ -48,6 +49,13 @@ class LossLrMeterLoggingHook(ClassyHook):
             # trainer to implement an unsynced end of phase meter or
             # for meters to not provide a sync function.
             self._log_loss_lr_meters(task, prefix="Synced meters: ", log_batches=True)
+
+        logging.info(
+            f"max memory allocated(MB) {torch.cuda.max_memory_allocated() // 1e6}"
+        )
+        logging.info(
+            f"max memory reserved(MB) {torch.cuda.max_memory_reserved() // 1e6}"
+        )
 
     def on_step(self, task) -> None:
         """

--- a/classy_vision/meters/classy_meter.py
+++ b/classy_vision/meters/classy_meter.py
@@ -131,3 +131,19 @@ class ClassyMeter:
 
         values = ",".join([f"{key}={value:.6f}" for key, value in self.value.items()])
         return f"{self.name}_meter({values})"
+
+    def value_better_than(self, other) -> bool:
+        """Return whether current meter value is better than the other value.
+
+        The default implementation assumes meter value is a dict and larger meter value is better.
+        """
+        if isinstance(self.value, dict):
+            for k, v in self.value.items():
+                if isinstance(v, (float, int)):
+                    if v > other[k]:
+                        return True
+                    elif v < other[k]:
+                        return False
+            return False
+        else:
+            raise NotImplementedError


### PR DESCRIPTION
Summary: To support customized per-sampling weighting during loss computation, allow reduction mode to be `none` in soft_target_cross_entropy_loss.

Differential Revision: D27035879

