### PR TITLE
Use generic types in type checking

### DIFF
--- a/classy_vision/meters/accuracy_meter.py
+++ b/classy_vision/meters/accuracy_meter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import torch
 from classy_vision.generic.distributed_util import all_reduce_sum
@@ -27,7 +27,7 @@ class AccuracyMeter(ClassyMeter):
         """
         super().__init__()
 
-        assert isinstance(topk, list), "topk must be a list"
+        assert isinstance(topk, Sequence), "topk must be a sequence"
         assert len(topk) > 0, "topk list should have at least one element"
         assert [is_pos_int(x) for x in topk], "each value in topk must be >= 1"
 

--- a/classy_vision/meters/precision_meter.py
+++ b/classy_vision/meters/precision_meter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import torch
 from classy_vision.generic.distributed_util import all_reduce_sum
@@ -28,7 +28,7 @@ class PrecisionAtKMeter(ClassyMeter):
         """
         super().__init__()
 
-        assert isinstance(topk, list), "topk must be a list"
+        assert isinstance(topk, Sequence), "topk must be a sequence"
         assert len(topk) > 0, "topk list should have at least one element"
         assert [is_pos_int(x) for x in topk], "each value in topk must be >= 1"
 

--- a/classy_vision/meters/recall_meter.py
+++ b/classy_vision/meters/recall_meter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import torch
 from classy_vision.generic.distributed_util import all_reduce_sum
@@ -27,7 +27,7 @@ class RecallAtKMeter(ClassyMeter):
         """
         super().__init__()
 
-        assert isinstance(topk, list), "topk must be a list"
+        assert isinstance(topk, Sequence), "topk must be a sequence"
         assert len(topk) > 0, "topk list should have at least one element"
         assert [is_pos_int(x) for x in topk], "each value in topk must be >= 1"
 

--- a/classy_vision/meters/video_accuracy_meter.py
+++ b/classy_vision/meters/video_accuracy_meter.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 from classy_vision.generic.util import is_pos_int
 from classy_vision.meters.accuracy_meter import AccuracyMeter
@@ -30,7 +30,7 @@ class VideoAccuracyMeter(VideoMeter):
             clips_per_video_test: No. of clips sampled per video at test time
         """
         super().__init__(clips_per_video_train, clips_per_video_test)
-        assert isinstance(topk, list), "topk must be a list"
+        assert isinstance(topk, Sequence), "topk must be a sequence"
         assert len(topk) > 0, "topk list should have at least one element"
         assert [is_pos_int(x) for x in topk], "each value in topk must be >= 1"
 

--- a/classy_vision/models/densenet.py
+++ b/classy_vision/models/densenet.py
@@ -9,7 +9,7 @@
 # dependencies:
 import math
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import torch
 import torch.nn as nn
@@ -136,7 +136,7 @@ class DenseNet(ClassyModel):
         super().__init__()
 
         # assertions:
-        assert type(num_blocks) == list
+        assert isinstance(num_blocks, Sequence)
         assert all(is_pos_int(b) for b in num_blocks)
         assert num_classes is None or is_pos_int(num_classes)
         assert is_pos_int(init_planes)

--- a/classy_vision/models/resnext.py
+++ b/classy_vision/models/resnext.py
@@ -13,7 +13,7 @@ import math
 import re
 import warnings
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Sequence
 
 import torch.nn as nn
 from classy_vision.generic.util import is_pos_int, is_pos_int_tuple
@@ -267,7 +267,7 @@ class ResNeXt(ClassyModel):
         reduction: int = 4,
         small_input: bool = False,
         zero_init_bn_residuals: bool = False,
-        base_width_and_cardinality: Optional[Union[Tuple, List]] = None,
+        base_width_and_cardinality: Optional[Sequence] = None,
         basic_layer: bool = False,
         final_bn_relu: bool = True,
         use_se: bool = False,
@@ -288,7 +288,7 @@ class ResNeXt(ClassyModel):
         super().__init__()
 
         # assertions on inputs:
-        assert type(num_blocks) == list
+        assert isinstance(num_blocks, Sequence)
         assert all(is_pos_int(n) for n in num_blocks)
         assert is_pos_int(init_planes) and is_pos_int(reduction)
         assert type(small_input) == bool
@@ -297,7 +297,7 @@ class ResNeXt(ClassyModel):
         ), "zero_init_bn_residuals must be a boolean, set to true if gamma of last\
              BN of residual block should be initialized to 0.0, false for 1.0"
         assert base_width_and_cardinality is None or (
-            isinstance(base_width_and_cardinality, (tuple, list))
+            isinstance(base_width_and_cardinality, Sequence)
             and len(base_width_and_cardinality) == 2
             and is_pos_int(base_width_and_cardinality[0])
             and is_pos_int(base_width_and_cardinality[1])

--- a/classy_vision/models/resnext3d.py
+++ b/classy_vision/models/resnext3d.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 import torch
 import torch.nn as nn
@@ -134,11 +134,11 @@ class ResNeXt3DBase(ClassyModel):
         assert is_pos_int(ret_config["stem_spatial_kernel"])
         assert type(ret_config["stem_maxpool"]) == bool
         assert is_pos_int(ret_config["stage_planes"])
-        assert type(ret_config["stage_temporal_kernel_basis"]) == list
+        assert isinstance(ret_config["stage_temporal_kernel_basis"], Sequence)
         assert all(
             is_pos_int_list(l) for l in ret_config["stage_temporal_kernel_basis"]
         )
-        assert type(ret_config["temporal_conv_1x1"]) == list
+        assert isinstance(ret_config["temporal_conv_1x1"], Sequence)
         assert is_pos_int_list(ret_config["stage_temporal_stride"])
         assert is_pos_int_list(ret_config["stage_spatial_stride"])
         assert is_pos_int(ret_config["num_groups"])

--- a/classy_vision/models/resnext3d_stem.py
+++ b/classy_vision/models/resnext3d_stem.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import Sequence
+
 import torch.nn as nn
 
 from .r2plus1_util import r2plus1_unit
@@ -232,9 +234,9 @@ class ResNeXt3DStemMultiPathway(nn.Module):
         self._construct_stem(dim_in, dim_out)
 
     def _construct_stem(self, dim_in, dim_out):
-        assert type(dim_in) == list
+        assert isinstance(dim_in, Sequence)
         assert all(dim > 0 for dim in dim_in)
-        assert type(dim_out) == list
+        assert isinstance(dim_out, Sequence)
         assert all(dim > 0 for dim in dim_out)
 
         self.blocks = {}
@@ -325,9 +327,9 @@ class R2Plus1DStemMultiPathway(ResNeXt3DStemMultiPathway):
         )
 
     def _construct_stem(self, dim_in, dim_out):
-        assert type(dim_in) == list
+        assert isinstance(dim_in, Sequence)
         assert all(dim > 0 for dim in dim_in)
-        assert type(dim_out) == list
+        assert isinstance(dim_out, Sequence)
         assert all(dim > 0 for dim in dim_out)
 
         self.blocks = {}


### PR DESCRIPTION
Summary:
Background:
https://fb.workplace.com/groups/349226332644221/permalink/776593166574200/

According to the suggestion, we make the following changes in the classy vision codebase (only for the type checking part):
1. `type(x) == list or tuple` -> `isinstance(x, Typing.Sequence)`
2. `type(x) == dict` -> `isinstance(x, Typing.Mapping)`

Differential Revision: D27170968

