### PR TITLE
Do not multiply loss by target's batch size

### DIFF
--- a/classy_vision/hooks/loss_lr_meter_logging_hook.py
+++ b/classy_vision/hooks/loss_lr_meter_logging_hook.py
@@ -69,7 +69,7 @@ class LossLrMeterLoggingHook(ClassyHook):
         batches = len(task.losses)
 
         # Loss for the phase
-        loss = sum(task.losses) / (batches * task.get_batchsize_per_replica())
+        loss = sum(task.losses) / batches
         phase_pct = batches / task.num_batches_per_phase
         msg = (
             f"{prefix}[{get_rank()}] {phase_type} phase {phase_type_idx} "

--- a/classy_vision/hooks/tensorboard_plot_hook.py
+++ b/classy_vision/hooks/tensorboard_plot_hook.py
@@ -171,7 +171,7 @@ class TensorboardPlotHook(ClassyHook):
                 global_step=phase_type_idx,
             )
 
-        loss_avg = sum(task.losses) / (batches * task.get_batchsize_per_replica())
+        loss_avg = sum(task.losses) / batches
 
         loss_key = "Losses/{phase_type}".format(phase_type=task.phase_type)
         self.tb_writer.add_scalar(loss_key, loss_avg, global_step=phase_type_idx)

--- a/classy_vision/hooks/visdom_hook.py
+++ b/classy_vision/hooks/visdom_hook.py
@@ -71,7 +71,7 @@ class VisdomHook(ClassyHook):
             return
 
         # Loss for the phase
-        loss = sum(task.losses) / (batches * task.get_batchsize_per_replica())
+        loss = sum(task.losses) / batches
         loss_key = phase_type + "_loss"
         if loss_key not in metrics:
             metrics[loss_key] = []

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -1039,7 +1039,7 @@ class ClassificationTask(ClassyTask):
 
             self.check_inf_nan(loss)
 
-            self.losses.append(loss.data.cpu().item() * target.size(0))
+            self.losses.append(loss.data.cpu().item())
 
             self.update_meters(output, sample)
 
@@ -1116,7 +1116,7 @@ class ClassificationTask(ClassyTask):
 
                 local_loss = self.compute_loss(output, sample)
                 loss = local_loss.detach().clone()
-                self.losses.append(loss.data.cpu().item() * target.size(0))
+                self.losses.append(loss.data.cpu().item())
 
                 self.update_meters(output, sample)
 

--- a/test/manual/hooks_visdom_hook_test.py
+++ b/test/manual/hooks_visdom_hook_test.py
@@ -50,7 +50,7 @@ class TestVisdomHook(HookTestBase):
         task.prepare()
 
         losses = [1.2, 2.3, 1.23, 2.33]
-        loss_vals = {"train": 0.8825, "test": 0.353}
+        loss_val = sum(losses) / len(losses)
 
         task.losses = losses
 
@@ -110,7 +110,7 @@ class TestVisdomHook(HookTestBase):
                 )
                 self.assertAlmostEqual(
                     visdom_hook.metrics[loss_key][-1],
-                    loss_vals[phase_type] * count,
+                    loss_val * count,
                     places=4,
                 )
 


### PR DESCRIPTION
Summary: This is unnecessary and we unscale these values in our hooks later on. More importantly, this adds the assumption that the target is a tensor which this diff gets rid of - https://github.com/facebookresearch/ClassyVision/issues/719

Differential Revision: D27212190

