### PR TITLE
Support freezing model anywhere in fine tuning

### DIFF
--- a/classy_vision/tasks/fine_tuning_task.py
+++ b/classy_vision/tasks/fine_tuning_task.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Any, Dict
+import warnings
+from enum import Enum
+from typing import Any, Callable, Dict, Union
 
 from classy_vision.generic.util import (
     load_and_broadcast_checkpoint,
@@ -13,15 +15,42 @@ from classy_vision.generic.util import (
 from classy_vision.tasks import ClassificationTask, register_task
 
 
+class FreezeUntil(Enum):
+    """
+    Enum for a pre-specified point to freeze the classy model unitl.
+
+    Attributes:
+        HEAD (str): Freeze the model unitl the classy head
+    """
+
+    HEAD = "head"
+
+    def __eq__(self, other: str):
+        return other.lower() == self.value
+
+
 @register_task("fine_tuning")
 class FineTuningTask(ClassificationTask):
+    """Finetuning training task.
+
+    This task encapsultates all of the components and steps needed to
+    fine-tune a classifier using a :class:`classy_vision.trainer.ClassyTrainer`.
+
+    :var pretrained_checkpoint_path: String path to pretrained model
+    :var reset_heads: bool. Whether or not to reset the model heads during finetuning.
+    :var freeze_until: optional string. If specified, must be a string name of a module within
+        the model. Finetuning will freeze the model up to this module. Model weights will
+        only be trainable from this modeule onwards, always including the head. To freeze the
+        trunk model, specify 'head' as the un-freeze point.
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.pretrained_checkpoint_dict = None
         self.pretrained_checkpoint_path = None
         self.pretrained_checkpoint_load_strict = True
         self.reset_heads = False
-        self.freeze_trunk = False
+        self.freeze_until = None
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "FineTuningTask":
@@ -44,7 +73,13 @@ class FineTuningTask(ClassificationTask):
             )
 
         task.set_reset_heads(config.get("reset_heads", False))
-        task.set_freeze_trunk(config.get("freeze_trunk", False))
+        assert (
+            "freeze_trunk" not in config or "freeze_until" not in config
+        ), "Config options 'freeze_trunk' and 'freeze_until' cannot both be specified"
+        if "freeze_trunk" in config:
+            task.set_freeze_trunk(config.get("freeze_trunk", False))
+        else:
+            task.set_freeze_until(config.get("freeze_until", None))
         return task
 
     def set_pretrained_checkpoint(self, checkpoint_path: str) -> "FineTuningTask":
@@ -68,21 +103,45 @@ class FineTuningTask(ClassificationTask):
         return self
 
     def set_freeze_trunk(self, freeze_trunk: bool) -> "FineTuningTask":
-        self.freeze_trunk = freeze_trunk
+        if freeze_trunk:
+            self.freeze_until = FreezeUntil.HEAD.value
+            warnings.warn(
+                "Congig option freeze_trunk has been deprecated. "
+                "Use \"freeze_until:'head'\" instead",
+                DeprecationWarning,
+            )
+
+        return self
+
+    def set_freeze_until(self, freeze_until: Union[str, None]) -> "FineTuningTask":
+        self.freeze_until = freeze_until
         return self
 
     def _set_model_train_mode(self):
         phase = self.phases[self.phase_idx]
         self.loss.train(phase["train"])
 
-        if self.freeze_trunk:
+        if self.freeze_until is not None:
             # convert all the sub-modules to the eval mode, except the heads
             self.base_model.eval()
-            for heads in self.base_model.get_heads().values():
-                for h in heads:
-                    h.train(phase["train"])
+            self._apply_to_nonfrozen(lambda x: x.train(phase["train"]))
         else:
             self.base_model.train(phase["train"])
+
+    def _apply_to_nonfrozen(self, callable: Callable[..., Any]) -> None:
+        for heads in self.base_model.get_heads().values():
+            for h in heads:
+                callable(h)
+        if not self.freeze_until == FreezeUntil.HEAD:
+            unfrozen_module = False
+            for name, module in self.base_model.named_modules():
+                if name == self.freeze_until:
+                    unfrozen_module = True
+                if unfrozen_module:
+                    callable(module)
+            assert (
+                unfrozen_module
+            ), f"Freeze until point {self.freeze_until} not found in model"
 
     def prepare(self) -> None:
         super().prepare()
@@ -109,15 +168,17 @@ class FineTuningTask(ClassificationTask):
                 state_load_success
             ), "Update classy state from pretrained checkpoint was unsuccessful."
 
-        if self.freeze_trunk:
+        if self.freeze_until is not None:
             # do not track gradients for all the parameters in the model except
             # for the parameters in the heads
             for param in self.base_model.parameters():
                 param.requires_grad = False
-            for heads in self.base_model.get_heads().values():
-                for h in heads:
-                    for param in h.parameters():
-                        param.requires_grad = True
+
+            def _set_requires_grad_true(x):
+                for param in x.parameters():
+                    param.requires_grad = True
+
+            self._apply_to_nonfrozen(_set_requires_grad_true)
             # re-create ddp model
             self.distributed_model = None
             self.init_distributed_data_parallel_model()

--- a/test/generic/utils.py
+++ b/test/generic/utils.py
@@ -215,8 +215,15 @@ def recursive_unpack(batch):
     raise TypeError("Unexpected type %s passed to unpack" % type(batch))
 
 
-def compare_model_state(test_fixture, state, state2, check_heads=True):
+def compare_model_state(
+    test_fixture, state, state2, check_heads=True, state_changed_params=()
+):
     for k in state["model"]["trunk"].keys():
+        if k in state_changed_params:
+            test_fixture.assertFalse(
+                torch.allclose(state["model"]["trunk"][k], state2["model"]["trunk"][k])
+            )
+            continue
         if not torch.allclose(state["model"]["trunk"][k], state2["model"]["trunk"][k]):
             print(k, state["model"]["trunk"][k], state2["model"]["trunk"][k])
         test_fixture.assertTrue(


### PR DESCRIPTION
Summary:
Add support for freezing the model anywhere in the fine tuning task. Users can specify a specific module to freeze the model until in finetuning. Functionality is useful for situations, like the FixRes paper, where both the head and the last batch norm layer are trained during fine tuning.

Example fblearner run using freeze_until to freeze the trunk model: f259575699
Example fblearner run using freeze_until to unfreeze the last batchnorm and head:
f259575306

- Adds new config option `freeze_until` to specify what point to freeze the model to. Options are `head` or the name of a module in the model. The model will be frozen until but not including that module and unfrozen at that point onwards. `freeze_until: 'head'` has the same functionality as `freeze_trunk: true`.
- Adds documentation for fine tuning task

Differential Revision: D27199092

