### PR TITLE
Remove unused args from classy_train.py's documentation

### DIFF
--- a/classy_train.py
+++ b/classy_train.py
@@ -27,9 +27,7 @@ Example:
                  --master_port=29500 \
                  --use_env \
                  classy_train.py \
-                 --device=gpu \
                  --config=configs/resnet50_synthetic_image_classy_config.json \
-                 --num_workers=1 \
                  --log_freq=100
 
     For other use cases, try


### PR DESCRIPTION
Pointed out in https://github.com/facebookresearch/ClassyVision/issues/740