### PR TITLE
update flops compute for linear module

### DIFF
--- a/classy_vision/dataset/dataloader_limit_wrapper.py
+++ b/classy_vision/dataset/dataloader_limit_wrapper.py
@@ -58,7 +58,7 @@ class DataloaderLimitWrapper(DataloaderWrapper):
             if self.wrap_around:
                 # create a new iterator to load data from the beginning
                 logging.info(
-                    f"Wrapping around after {self._count} calls. Limit: {self.limit}"
+                    f"Wrapping around after {self._count - 1} calls. Limit: {self.limit}"
                 )
                 try:
                     self._iter = iter(self.dataloader)

--- a/classy_vision/generic/profiler.py
+++ b/classy_vision/generic/profiler.py
@@ -215,7 +215,7 @@ def _layer_flops(layer: nn.Module, layer_args: List[Any], y: Any) -> int:
     elif layer_type in ["Linear"]:
         weight_ops = layer.weight.numel()
         bias_ops = layer.bias.numel() if layer.bias is not None else 0
-        flops = x.size()[0] * (weight_ops + bias_ops)
+        flops = (x.numel() / x.size(-1)) * (weight_ops + bias_ops)
 
     # batch normalization / layer normalization:
     elif layer_type in [


### PR DESCRIPTION
Summary:
Major changes
- In tranformer-type model, we often use linear layer to perform matrix-matrix multiplication A * B where A has shape (B, L, C1) and B is the weight matrix with shape (C1, C2). The current profiler will ignore the size L. Fix it.
- A minor logging fix to `dataloader_limit_wrapper.py`.

Differential Revision: D28172235

