### PR TITLE
Do not check for inf / nan loss in eval phase

### DIFF
--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -1040,8 +1040,6 @@ class ClassificationTask(ClassyTask):
 
             loss = local_loss.detach().clone()
 
-            self.check_inf_nan(loss)
-
             self.losses.append(loss.data.cpu().item())
 
             self.update_meters(output, sample)


### PR DESCRIPTION
Summary: The loss being NaN / inf during training is problematic since we cannot backprop using an invalid loss. This isn't the case during an eval phase and we don't need to crash.

Differential Revision: D28204666

