### PR TITLE
Update mixup transform to be compatible with latest pytorch (#97)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v7-cpu-dependencies-{{ checksum "requirements.txt" }}
+            - v9-cpu-dependencies-{{ checksum "requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v7-cpu-dependencies-
+            - v9-cpu-dependencies-
 
       - <<: *install_dev_dep
 
@@ -143,7 +143,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: v7-cpu-dependencies-{{ checksum "requirements.txt" }}
+          key: v9-cpu-dependencies-{{ checksum "requirements.txt" }}
 
       - <<: *run_tests
 
@@ -183,9 +183,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v4-gpu-dependencies-{{ checksum "requirements.txt" }}
+            - v6-gpu-dependencies-{{ checksum "requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v4-gpu-dependencies-
+            - v6-gpu-dependencies-
 
       - <<: *install_dev_dep
 
@@ -198,7 +198,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: v4-gpu-dependencies-{{ checksum "requirements.txt" }}
+          key: v6-gpu-dependencies-{{ checksum "requirements.txt" }}
 
       - <<: *run_tests
 
@@ -222,9 +222,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v2-gpu-bc-dependencies-{{ checksum "requirements_test_bc.txt" }}
+            - v3-gpu-bc-dependencies-{{ checksum "requirements_test_bc.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v2-gpu-bc-dependencies-
+            - v3-gpu-bc-dependencies-
 
       - <<: *install_dev_dep
 
@@ -237,7 +237,7 @@ jobs:
       - save_cache:
           paths:
             - ~/venv
-          key: v2-gpu-bc-dependencies-{{ checksum "requirements_test_bc.txt" }}
+          key: v3-gpu-bc-dependencies-{{ checksum "requirements_test_bc.txt" }}
 
       - <<: *run_tests
 

--- a/classy_vision/dataset/transforms/mixup.py
+++ b/classy_vision/dataset/transforms/mixup.py
@@ -64,10 +64,10 @@ def rand_bbox(img_shape, lam, margin=0.0, count=1):
     margin_y, margin_x = int(margin * cut_h), int(margin * cut_w)
     cy = torch.randint(0 + margin_y, img_h - margin_y, (count,))
     cx = torch.randint(0 + margin_x, img_w - margin_x, (count,))
-    yl = torch.clip(cy - cut_h // 2, 0, img_h)
-    yh = torch.clip(cy + cut_h // 2, 0, img_h)
-    xl = torch.clip(cx - cut_w // 2, 0, img_w)
-    xh = torch.clip(cx + cut_w // 2, 0, img_w)
+    yl = torch.clamp(cy - cut_h // 2, 0, img_h)
+    yh = torch.clamp(cy + cut_h // 2, 0, img_h)
+    xl = torch.clamp(cx - cut_w // 2, 0, img_w)
+    xh = torch.clamp(cx + cut_w // 2, 0, img_w)
     return yl, yh, xl, xh
 
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
                 "nbconvert==6.0.7",
                 "pre-commit",
                 "parameterized",
-                "fairscale==0.1.6",
+                "fairscale==0.3.7",
             ]
         },
         package_data={"classy_vision": ["configs/*.json", "templates"]},


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/fairinternal/ClassyVision/pull/97

`torch.clip` is an alias for `torch.clamp`, see https://pytorch.org/docs/stable/generated/torch.clip.html?highlight=clip#torch.clip

and `torch.clip` is no longer in the latest pytorch version

Differential Revision: D29520476

