### PR TITLE
Fix BibTex citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ Classy Vision is MIT licensed, as found in the LICENSE file.
 ## Citing Classy Vision
 If you use Classy Vision in your work, please use the following BibTeX entry:
 
-```
-@article{adcock2019classy,
+```BibTeX
+@misc{adcock2019classy,
   title={Classy Vision},
-  author={{Adcock}, A. and {Reis}, V. and {Singh}, M. and {Yan}, Z. and {van der Maaten} L., and {Zhang}, K. and {Motwani}, S. and {Guerin}, J. and {Goyal}, N. and {Misra}, I. and {Gustafson}, L. and {Changhan}, C. and {Goyal}, P.},
+  author={{Adcock}, A. and {Reis}, V. and {Singh}, M. and {Yan}, Z. and {van der Maaten}, L. and {Zhang}, K. and {Motwani}, S. and {Guerin}, J. and {Goyal}, N. and {Misra}, I. and {Gustafson}, L. and {Changhan}, C. and {Goyal}, P.},
   howpublished = {\url{https://github.com/facebookresearch/ClassyVision}},
   year={2019}
 }


### PR DESCRIPTION
There was a typo in our citation entry - `{van der Maaten} L.,` instead of `{van der Maaten}, L.`. 

Also, changed the type from `article` (which requires a journal) to `misc`. 

Because of this citations for Classy Vision weren't getting picked up by Google Scholar