### PR TITLE
Customize model forward

### DIFF
--- a/classy_vision/dataset/classy_dataset.py
+++ b/classy_vision/dataset/classy_dataset.py
@@ -124,6 +124,9 @@ class ClassyDataset:
         return self.transform(sample)
 
     def __len__(self):
+        if self.dataset is None:
+            assert self.num_samples
+            return self.num_samples
         assert self.num_samples is None or self.num_samples <= len(
             self.dataset
         ), "Num samples mus be less than length of base dataset"

--- a/classy_vision/tasks/classification_task.py
+++ b/classy_vision/tasks/classification_task.py
@@ -1129,7 +1129,7 @@ class ClassificationTask(ClassyTask):
         with ctx_mgr_model, ctx_mgr_loss:
             # Forward pass
             with torch.enable_grad(), torch_amp_context:
-                output = self.model(sample["input"])
+                output = self.compute_model(sample)
 
                 local_loss = self.compute_loss(output, sample)
                 loss = local_loss.detach().clone()
@@ -1150,6 +1150,9 @@ class ClassificationTask(ClassyTask):
             sample=sample,
             step_data={"sample_fetch_time": timer.elapsed_time},
         )
+
+    def compute_model(self, sample):
+        return self.model(sample["input"])
 
     def compute_loss(self, model_output, sample):
         return self.loss(model_output, sample["target"])


### PR DESCRIPTION
Summary: Minor refactor to introduce a `compute_model` method, similar to the `compute_loss` method. This allows customizing the model forward pass in subclasses.

Differential Revision: D30647461

