### PR TITLE
Fix cutmix augmentation when minmax is specified

### DIFF
--- a/classy_vision/dataset/transforms/mixup.py
+++ b/classy_vision/dataset/transforms/mixup.py
@@ -8,6 +8,7 @@ import math
 from collections import abc
 from typing import Any, Dict, Optional, Tuple
 
+import numpy as np
 import torch
 from torch.distributions.beta import Beta
 
@@ -85,13 +86,18 @@ def rand_bbox_minmax(img_shape, minmax, count=1):
     """
     assert len(minmax) == 2
     img_h, img_w = img_shape[-2:]
-    cut_h = torch.randint(int(img_h * minmax[0]), int(img_h * minmax[1]), (count,))
-    cut_w = torch.randint(int(img_w * minmax[0]), int(img_w * minmax[1]), (count,))
-    yl = torch.randint(0, img_h - cut_h, (count,))
-    xl = torch.randint(0, img_w - cut_w, (count,))
+    cut_h = np.random.randint(
+        int(img_h * minmax[0]), int(img_h * minmax[1]), size=count
+    )
+    cut_w = np.random.randint(
+        int(img_w * minmax[0]), int(img_w * minmax[1]), size=count
+    )
+    # torch's randint does not accept a vector of max values
+    yl = np.random.randint(0, img_h - cut_h, size=count)
+    xl = np.random.randint(0, img_w - cut_w, size=count)
     yu = yl + cut_h
     xu = xl + cut_w
-    return yl, yu, xl, xu
+    return [torch.from_numpy(a) for a in [yl, yu, xl, xu]]
 
 
 def cutmix_bbox_and_lam(img_shape, lam, ratio_minmax=None, correct_lam=True, count=1):

--- a/test/dataset_transforms_mixup_test.py
+++ b/test/dataset_transforms_mixup_test.py
@@ -33,20 +33,22 @@ class DatasetTransformsMixupTest(unittest.TestCase):
         num_classes = 3
 
         for mode in ["batch", "pair", "elem"]:
-            cutmix_transform = MixupTransform(
-                mixup_alpha,
-                num_classes,
-                cutmix_alpha=cutmix_alpha,
-                mode=mode,
-            )
-            sample = {
-                "input": torch.rand(4, 3, 224, 224, dtype=torch.float32),
-                "target": torch.as_tensor([0, 1, 2, 2], dtype=torch.int32),
-            }
-            sample_cutmix = cutmix_transform(sample)
-            self.assertTrue(sample["input"].shape == sample_cutmix["input"].shape)
-            self.assertTrue(sample_cutmix["target"].shape[0] == 4)
-            self.assertTrue(sample_cutmix["target"].shape[1] == 3)
+            for minmax in [None, (0.3, 0.7)]:
+                cutmix_transform = MixupTransform(
+                    mixup_alpha,
+                    num_classes,
+                    cutmix_alpha=cutmix_alpha,
+                    mode=mode,
+                    cutmix_minmax=minmax,
+                )
+                sample = {
+                    "input": torch.rand(4, 3, 224, 224, dtype=torch.float32),
+                    "target": torch.as_tensor([0, 1, 2, 2], dtype=torch.int32),
+                }
+                sample_cutmix = cutmix_transform(sample)
+                self.assertTrue(sample["input"].shape == sample_cutmix["input"].shape)
+                self.assertTrue(sample_cutmix["target"].shape[0] == 4)
+                self.assertTrue(sample_cutmix["target"].shape[1] == 3)
 
     def test_mixup_cutmix_transform_single_label_image_batch(self):
         mixup_alpha = 0.3


### PR DESCRIPTION
Summary: The issue is that the code provides max as a tensor to `torch.randint`, which expects only scalars, unlike the numpy equivalent.

Differential Revision: D30761197

