### PR TITLE
Fix breakage in torch quanitization import

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,8 @@ gpu: &gpu
     CUDA_VERSION: "10.2"
     TERM: xterm
   machine:
-    image: default
-  resource_class: gpu.medium  # Tesla M60
+    image: ubuntu-1604:202104-01
+  resource_class: gpu.nvidia.small.multi  # NVIDIA Tesla T4 2 GPU 4 vCPUs 15 GB RAM (2 GPUs)
 
 # -------------------------------------------------------------------------------------
 # Re-usable commands

--- a/test/models_densenet_test.py
+++ b/test/models_densenet_test.py
@@ -90,7 +90,7 @@ class TestDensenet(unittest.TestCase):
         compare_model_state(self, state, new_state, check_heads=True)
 
     def _test_quantize_model(self, model_config):
-        if get_torch_version() >= [1, 10]:
+        if get_torch_version() >= [1, 11]:
             import torch.ao.quantization as tq
             from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
         else:

--- a/test/models_mlp_test.py
+++ b/test/models_mlp_test.py
@@ -30,7 +30,7 @@ class TestMLPModel(unittest.TestCase):
         "FX Graph Modee Quantization is only availablee from 1.8",
     )
     def test_quantize_model(self):
-        if get_torch_version() >= [1, 10]:
+        if get_torch_version() >= [1, 11]:
             import torch.ao.quantization as tq
             from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
         else:

--- a/test/models_regnet_test.py
+++ b/test/models_regnet_test.py
@@ -171,7 +171,7 @@ class TestRegNetModelBuild(unittest.TestCase):
         """
         if get_torch_version() < [1, 8]:
             self.skipTest("FX Graph Modee Quantization is only availablee from 1.8")
-        if get_torch_version() >= [1, 10]:
+        if get_torch_version() >= [1, 11]:
             import torch.ao.quantization as tq
             from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
         else:

--- a/test/models_resnext_test.py
+++ b/test/models_resnext_test.py
@@ -88,7 +88,7 @@ def _find_block_full_path(model, block_name):
 
 
 def _post_training_quantize(model, input):
-    if get_torch_version() >= [1, 10]:
+    if get_torch_version() >= [1, 11]:
         import torch.ao.quantization as tq
         from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
     else:


### PR DESCRIPTION
Summary: D31260088 (https://github.com/facebookresearch/ClassyVision/commit/4785d5ee19d3bcedd5b28c1eb51ea1f59188b54d) moved quantization imports to `torch.ao.quantization`, but in pytorch 1.10 `torch.ao.quantization.quantize_fx` does not exist. Changing the check to pytorch 1.11 so this starts getting used from the next release.

Differential Revision: D32809959

