### PR TITLE
Delete duplicate ImagenetAugmentTransform import

### DIFF
--- a/classy_vision/dataset/transforms/__init__.py
+++ b/classy_vision/dataset/transforms/__init__.py
@@ -137,7 +137,6 @@ import_all_modules(FILE_ROOT, "classy_vision.dataset.transforms")
 from .lighting_transform import LightingTransform  # isort:skip
 from .util import ApplyTransformToKey  # isort:skip
 from .util import ImagenetAugmentTransform  # isort:skip
-from .util import ImagenetAugmentTransform  # isort:skip
 from .util import ImagenetNoAugmentTransform  # isort:skip
 from .util import GenericImageTransform  # isort:skip
 from .util import TupleToMapTransform  # isort:skip


### PR DESCRIPTION
Summary:
Remove the deprecated TorchVision video transforms import.
For backward compatibility, user should still be able to use the deprecated video transform name in the config, but there should be a warning about the deprecation.

Reviewed By: kazhang

Differential Revision: D34588248

