### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility

### DIFF
--- a/classy_vision/generic/util.py
+++ b/classy_vision/generic/util.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import collections
+import collections.abc
 import contextlib
 import json
 import logging
@@ -367,7 +367,7 @@ def flatten_dict(value_dict: Dict, prefix="", sep="_") -> Dict:
     items = []
     for k, v in value_dict.items():
         key = prefix + sep + k if prefix else k
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, collections.abc.MutableMapping):
             items.extend(flatten_dict(value_dict=v, prefix=key, sep=sep).items())
         else:
             items.append((key, v))

--- a/classy_vision/hooks/visdom_hook.py
+++ b/classy_vision/hooks/visdom_hook.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import collections
+import collections.abc
 import logging
 from typing import Any, Dict
 
@@ -86,7 +86,7 @@ class VisdomHook(ClassyHook):
 
         # Calculate meters
         for meter in task.meters:
-            if isinstance(meter.value, collections.MutableMapping):
+            if isinstance(meter.value, collections.abc.MutableMapping):
                 flattened_meters_dict = flatten_dict(meter.value, prefix=meter.name)
                 for k, v in flattened_meters_dict.items():
                     metric_key = phase_type + "_" + k


### PR DESCRIPTION
Import ABC from `collections` was deprecated and removed in Python 3.10. Use `collections.abc` .