### PR TITLE
Add stateless output option for classy block (#101)

### DIFF
--- a/classy_vision/models/classy_block.py
+++ b/classy_vision/models/classy_block.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
+
 import torch
 import torch.nn as nn
 
@@ -19,11 +21,15 @@ class ClassyBlock(nn.Module):
         self.name = name
         self.output = torch.zeros(0)
         self._module = module
+        self._is_output_stateless = "STATELESS_CLASSY_OUTPUT" in os.environ
 
     def wrapped_module(self):
         return self._module
 
     def forward(self, input):
-        output = self._module(input)
-        self.output = output
-        return output
+        if self._is_output_stateless:
+            return self._module(input)
+        else:
+            output = self._module(input)
+            self.output = output
+            return output

--- a/test/models_classy_block_stateless_test.py
+++ b/test/models_classy_block_stateless_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import unittest
+
+import torch
+from classy_vision.models import ClassyBlock
+
+
+class TestClassyStatelessBlock(unittest.TestCase):
+    def setUp(self):
+        """
+        This test checks on output stateful (default) and stateless variants of ClassyBlock
+        by enabling and propagating the environmental variable STATELESS_CLASSY_OUTPUT
+        """
+        # initialize stateful model
+        self._model_stateful = ClassyBlock(name="stateful", module=torch.nn.Identity())
+        # initialize stateless model
+        os.environ["STATELESS_CLASSY_OUTPUT"] = "True"
+        self._model_stateless = ClassyBlock(
+            name="stateless", module=torch.nn.Identity()
+        )
+        # note: use low=1 since default of ClassyBlock output variable is torch.zeros
+        self._data = torch.randint(low=1, high=5, size=(3, 5, 5))
+
+    def tearDown(self):
+        # environmental variables do not propagate outside the scope of this test
+        # but we'll clean it up anyway
+        del os.environ["STATELESS_CLASSY_OUTPUT"]
+
+    def test_classy_output_stateless(self):
+        # confirm model.output is (stateless) i.e. default of torch.zeros(0) and that output == data
+        output = self._model_stateless.forward(self._data)
+        self.assertTrue(torch.equal(self._model_stateless.output, torch.zeros(0)))
+        self.assertTrue(torch.equal(output, self._data))
+
+    def test_classy_output_stateful(self):
+        # confirm model.output keeps input data and that output == data
+        output = self._model_stateful.forward(self._data)
+        self.assertTrue(torch.equal(self._model_stateful.output, output))
+        self.assertTrue(torch.equal(output, self._data))


### PR DESCRIPTION
Summary:
X-link: https://github.com/fairinternal/ClassyVision/pull/101

This diff adds a stateless output option within `ClassyBlock.py` when if the environmental variable `STATELESS_CLASSY_OUTPUT` is enabled, `self.output` within `ClassyBlock` never hold the value of the last output (and thus is stateless).  This is useful to prevent certain race conditions, while the default condition will still be maintained if the flag is not enabled to maintain original behavior.

Differential Revision: D35662345

