### PR TITLE
Add required example_args argument to prepare_fx and prepare_qat_fx

### DIFF
--- a/test/models_mlp_test.py
+++ b/test/models_mlp_test.py
@@ -26,23 +26,20 @@ class TestMLPModel(unittest.TestCase):
         self.assertEqual(output.shape, torch.Size([2, 1]))
 
     @unittest.skipIf(
-        get_torch_version() < [1, 8],
-        "FX Graph Modee Quantization is only availablee from 1.8",
+        get_torch_version() < [1, 13],
+        "This test is using a new api of FX Graph Mode Quantization which is only available after 1.13",
     )
     def test_quantize_model(self):
-        if get_torch_version() >= [1, 11]:
-            import torch.ao.quantization as tq
-            from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
-        else:
-            import torch.quantization as tq
-            from torch.quantization.quantize_fx import convert_fx, prepare_fx
+        import torch.ao.quantization as tq
+        from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
 
         config = {"name": "mlp", "input_dim": 3, "output_dim": 1, "hidden_dims": [2]}
         model = build_model(config)
         self.assertTrue(isinstance(model, ClassyModel))
 
         model.eval()
-        model.mlp = prepare_fx(model.mlp, {"": tq.default_qconfig})
+        example_inputs = (torch.rand(1, 3),)
+        model.mlp = prepare_fx(model.mlp, {"": tq.default_qconfig}, example_inputs)
         model.mlp = convert_fx(model.mlp)
 
         tensor = torch.tensor([[1, 2, 3]], dtype=torch.float)

--- a/test/models_regnet_test.py
+++ b/test/models_regnet_test.py
@@ -169,19 +169,18 @@ class TestRegNetModelBuild(unittest.TestCase):
         Test that the model builds using a config using either model_params or
         model_name and calls fx graph mode quantization apis
         """
-        if get_torch_version() < [1, 8]:
-            self.skipTest("FX Graph Modee Quantization is only availablee from 1.8")
-        if get_torch_version() >= [1, 11]:
-            import torch.ao.quantization as tq
-            from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
-        else:
-            import torch.quantization as tq
-            from torch.quantization.quantize_fx import convert_fx, prepare_fx
+        if get_torch_version() < [1, 13]:
+            self.skipTest(
+                "This test is using a new api of FX Graph Mode Quantization which is only available after 1.13"
+            )
+        import torch.ao.quantization as tq
+        from torch.ao.quantization.quantize_fx import convert_fx, prepare_fx
 
         model = build_model(config)
         assert isinstance(model, RegNet)
         model.eval()
-        model.stem = prepare_fx(model.stem, {"": tq.default_qconfig})
+        example_inputs = (torch.rand(1, 3, 3, 3),)
+        model.stem = prepare_fx(model.stem, {"": tq.default_qconfig}, example_inputs)
         model.stem = convert_fx(model.stem)
 
 


### PR DESCRIPTION
Summary:
FX Graph Mode Quantization needs to know whether an fx node is a floating point Tensor before it can decide whether to
insert observer/fake_quantize module or not, since we only insert observer/fake_quantize module for floating point Tensors.
Currently we have some hacks to support this by defining some rules like NON_OBSERVABLE_ARG_DICT (https://github.com/pytorch/pytorch/blob/master/torch/ao/quantization/fx/utils.py#L496), but this approach is fragile and we do not plan to maintain it long term in the pytorch code base.

As we discussed in the design review, we'd need to ask users to provide sample args and sample keyword args
so that we can infer the type in a more robust way. This PR starts with changing the prepare_fx and prepare_qat_fx api to require user to either provide
example arguments thrugh example_inputs, Note this api doesn't support kwargs, kwargs can make https://github.com/pytorch/pytorch/pull/76496#discussion_r861230047 (comment) simpler, but
it will be rare, and even then we can still workaround with positional arguments, also torch.jit.trace(https://pytorch.org/docs/stable/generated/torch.jit.trace.html) and ShapeProp: https://github.com/pytorch/pytorch/blob/master/torch/fx/passes/shape_prop.py#L140 just have single positional args, we'll just use a single example_inputs argument for now.

If needed, we can extend the api with an optional example_kwargs. e.g. in case when there are a lot of arguments for forward and it makes more sense to
pass the arguments by keyword

BC-breaking Note:
Before:
m = resnet18(...)
m = prepare_fx(m, qconfig_dict)

After:
m = resnet18(...)
m = prepare_fx(m, qconfig_dict, example_inputs=(torch.randn(1, 3, 224, 224),))

Reviewed By: vkuzo, andrewor14

Differential Revision: D35984526

