### PR TITLE
Fix classy_vision test on heads_fully_connected_head_test

### DIFF
--- a/test/heads_fully_connected_head_test.py
+++ b/test/heads_fully_connected_head_test.py
@@ -57,7 +57,7 @@ class TestFullyConnectedHead(ClassyTestCase):
             if get_torch_version() >= [1, 7]
             else partial(torch.norm, p=2)
         )
-        norms = norm_func(input, dim=[1, 2, 3])
+        norms = norm_func(input.view(batch_size, -1), dim=1)
         normalized_input = torch.clone(input)
         for i in range(batch_size):
             normalized_input[i] /= norms[i]


### PR DESCRIPTION
Summary:
The heads_fully_connected_head_test on classy_vision seems to failed, see: https://www.internalfb.com/intern/test/562949985032390/

And this can be reproduced in on-demand server by running the buck command provided on the above url.

The error message:
```
RuntimeError: linalg.norm: If dim is specified, it must be of length 1 or 2. Got [1, 2, 3]
```
indicate that the test has wrong value of `dim` input.

This diffs try to solve this issue

Differential Revision: D36702425

