### PR TITLE
Support delete for classy wrapper

### DIFF
--- a/classy_vision/models/classy_model.py
+++ b/classy_vision/models/classy_model.py
@@ -90,6 +90,12 @@ class ClassyModelWrapper:
         else:
             super().__setattr__(name, value)
 
+    def __delattr__(self, name):
+        if name != "classy_model" and hasattr(self, "classy_model"):
+            delattr(self.classy_model, name)
+        else:
+            return super().__delattr__(name)
+
     def forward(self, *args, **kwargs):
         return self.classy_model(*args, **kwargs)
 

--- a/test/models_classy_model_test.py
+++ b/test/models_classy_model_test.py
@@ -163,6 +163,18 @@ class TestClassyModel(unittest.TestCase):
             self.assertTrue(torch.allclose(expected_output, model(input)))
             self.assertTrue(torch.allclose(expected_output, jitted_model(input)))
 
+    def test_classy_model_wrapper_attr(self):
+        model = MyTestModel2()
+        model.test_attr = 123
+        model_wrapper = ClassyModelWrapper(model)
+        self.assertTrue(hasattr(model_wrapper, "test_attr"))
+        self.assertEqual(model_wrapper.test_attr, 123)
+
+        # delete the attr
+        delattr(model_wrapper, "test_attr")
+        self.assertFalse(hasattr(model_wrapper, "test_attr"))
+        self.assertFalse(hasattr(model, "test_attr"))
+
     def test_classy_model_set_state_strict(self):
         model_1 = build_model(self.get_model_config(use_head=True))
         model_state_1 = model_1.get_classy_state(deep_copy=True)


### PR DESCRIPTION
Summary:
Support delete for classy wrapper
* Otherwise `hasattr(model, attr)` will return True but `delattr model.attr` will fail.

Differential Revision: D36916133

