### PR TITLE
Changes to ClassyVision to support regression task with List[float] labels

### DIFF
--- a/classy_vision/heads/fully_convolutional_linear_head.py
+++ b/classy_vision/heads/fully_convolutional_linear_head.py
@@ -24,6 +24,9 @@ class FullyConvolutionalLinear(nn.Module):
             self.act = nn.Softmax(dim=4)
         elif act_func == "sigmoid":
             self.act = nn.Sigmoid()
+        elif act_func == "identity":
+            # for some tasks eg. regression, we don't want an activation function
+            self.act = nn.Identity()
         else:
             raise NotImplementedError(
                 "{} is not supported as an activation" "function.".format(act_func)


### PR DESCRIPTION
Summary:
The v0 model of XRayRelevance project is a distillation model where we use the MViTv2 AV trunk to regress on IG's TTSN engagement embeddings. More details on project: https://docs.google.com/document/d/1SJaPU2xckTwUSE3Z8tONBj3jz1BvPQbifEHorH8Oe08/edit

This diff makes following changes to classyvision:
- support List[float] label type for regression
- support "none" activation_func in ClassyHead

Differential Revision: D38049210

